### PR TITLE
added egigeozone adapter

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -93,7 +93,7 @@
   "egigeozone": {
     "meta": "https://raw.githubusercontent.com/BasGo/ioBroker.egigeozone/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/BasGo/ioBroker.egigeozone/master/admin/egigeozone.png",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "type": "geoposition"
   },
   "email": {

--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -90,6 +90,12 @@
     "version": "2.1.1",
     "type": "weather"
   },
+  "egigeozone": {
+    "meta": "https://raw.githubusercontent.com/BasGo/ioBroker.egigeozone/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/BasGo/ioBroker.egigeozone/master/admin/egigeozone.png",
+    "version": "0.0.1",
+    "type": "geoposition"
+  },
   "email": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.email/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.email/master/admin/email.png",

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -84,6 +84,11 @@
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.dwd/master/admin/dwd.png",
     "type": "weather"
   },
+  "egigeozone": {
+    "meta": "https://raw.githubusercontent.com/BasGo/ioBroker.egigeozone/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/BasGo/ioBroker.egigeozone/master/admin/egigeozone.png",
+    "type": "geoposition"
+  },
   "email": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.email/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.email/master/admin/email.png",


### PR DESCRIPTION
Hi Bluefox,

hier mal ein Adapter, so dass man EgiGeoFence (App) auf Android fürs Geofencing nutzen kann. Basis ist der Geofency-Adapter, Tests sind ebenfalls aktiviert und das Paket ist bei NPM gepublished.

VG

Bastian