### PR TITLE
"emergency" fix: bump G-Homa version to 0.1.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -184,7 +184,7 @@
   "g-homa": {
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.g-homa/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.g-homa/master/admin/g-homa.png",
-    "version": "0.1.0",
+    "version": "0.1.2",
     "type": "iot-systems"
   },
   "geofency": {


### PR DESCRIPTION
Since the current stable version (0.1.0) the admin UI had a bug making it impossible to add new devices.
v0.1.2 fixes that.
I wanted to get the PR ready, but I'd wait for confirmation http://forum.iobroker.net/viewtopic.php?p=92505#p92505 before merging.