### PR TITLE
Emergency fix: bump Tradfri to 0.5.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -763,7 +763,7 @@
   "tradfri": {
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.tradfri/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.tradfri/master/admin/tradfri.png",
-    "version": "0.4.5",
+    "version": "0.5.5",
     "type": "lighting"
   },
   "tvspielfilm": {


### PR DESCRIPTION
Yesterday's gateway update changed how the connection is initialized and broke all versions prior to 0.5.5.