### PR TITLE
Update tradfri stable version to 1.0.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -899,7 +899,7 @@
   "tradfri": {
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.tradfri/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.tradfri/master/admin/tradfri.png",
-    "version": "1.0.0",
+    "version": "1.0.3",
     "type": "lighting",
     "published": "2017-08-23T11:33:34.827Z"
   },


### PR DESCRIPTION
1.0.3 has been tested for a while from Github. NPM was just published.

Adapter testing is red because one of my tests sometimes has a timing issue:
https://github.com/AlCalzone/ioBroker.tradfri/issues/34