### PR TITLE
Move BLE 0.3.4 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -37,7 +37,7 @@
   "ble": {
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.ble/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.ble/master/admin/ble.png",
-    "version": "0.3.2",
+    "version": "0.3.4",
     "type": "hardware",
     "published": "2017-09-05T15:57:13.123Z"
   },


### PR DESCRIPTION
v0.3.4 (from Github) has been in testing for a while now. I just published the package to npm.