### PR TITLE
Reworked npm adapter version check

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var semver = require('semver');
 require('events').EventEmitter.prototype._maxListeners = 100;
 var request;
 var extend;
@@ -464,57 +465,31 @@ function getInstalledInfo(hostRunningVersion) {
     return result;
 }
 
-function initNpm(prefix, callback) {
-    if (typeof prefix === 'function') {
-        callback = prefix;
-        prefix = undefined;
-    }
-
-    var settings = {
-        silent: true,
-        global: false,
-        production: true,
-        minTimeout: 500,
-        maxTimeout: 1500,
-        times: 1
-    };
-    if (prefix) settings.prefix = prefix;
-
-    var npm = require('npm');
-    npm.load(settings, function (er) {
-        // Disable debug outputs
-        npm.registry.log.silly   = function () {};
-        npm.registry.log.verbose = function () {};
-        npm.registry.log.info    = function () {};
-        npm.registry.log.http    = function () {};
-        if (callback) callback(er, npm);
-    });
-}
-
-// reads version of packet from npm
+/**
+ * Reads an adapter's npm version
+ * @param {string | null} adapter The adapter to read the npm version from. Null for the root ioBroker packet
+ * @param {(err: Error | null, version: string) => void} [callback]
+ */
 function getNpmVersion(adapter, callback) {
     adapter = adapter ? module.exports.appName + '.' + adapter : module.exports.appName;
-
     adapter = adapter.toLowerCase();
 
-    try {
-        initNpm(function (er, npm) {
-            setImmediate(function () {
-                npm.commands.view([adapter, 'dist-tags.latest'], true, function (error, response) {
-                    if (error) return callback ? callback(error) : 0;
+    const cliCommand = `npm view ${adapter}@latest version`;
 
-                    if (response) {
-                        if (callback) callback(null, Object.keys(response)[0]);
-                    } else {
-                        if (callback) callback();
-                    }
-                });
-            });
-        });
-    } catch (e) {
-        console.log('error by reading ' + adapter + ': ' + e);
-        if (callback) callback(e);
-    }
+    var exec = require('child_process').exec;
+    exec(cliCommand, {timeout: 2000}, (error, stdout, stderr) => {
+        let version;
+        if (error) {
+            // command failed
+            if (typeof callback === "function") {
+                callback(error);
+                return;
+            }
+        } else if (stdout) {
+            version = semver.valid(stdout.trim());
+        }
+        if (typeof callback === "function") callback(null, version);
+    });
 }
 
 function getIoPack(sources, name, callback) {
@@ -803,10 +778,7 @@ function getHostName() {
 function getSystemNpmVersion(callback) {
     var exec = require('child_process').exec;
     exec('npm -v', function (error, stdout) {//, stderr) {
-        if (stdout) {
-            var lines = stdout.split('\n');
-            stdout = lines[0].replace('\r', '').trim();
-        }
+        if (stdout) stdout = semver.valid(stdout.trim());
         if (callback) callback(error, stdout);
     });
 }
@@ -931,7 +903,6 @@ module.exports.sendDiagInfo =       sendDiagInfo;
 module.exports.getAdapterDir =      getAdapterDir;
 module.exports.getDefaultDataDir =  getDefaultDataDir;
 module.exports.getConfigFileName =  getConfigFileName;
-module.exports.initNpm =            initNpm;
 module.exports.getHostName =        getHostName;
 module.exports.appName =            getAppName();
 module.exports.createUuid =         createUuid;

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -777,7 +777,21 @@ function getHostName() {
  */
 function getSystemNpmVersion(callback) {
     var exec = require('child_process').exec;
-    exec('npm -v', function (error, stdout) {//, stderr) {
+
+    // remove local node_modules\.bin dir from path
+    // or we potentially get a wrong npm version
+    var newEnv = Object.assign({}, process.env);
+    newEnv.PATH = (newEnv.PATH || newEnv.Path || newEnv.path)
+        .split(path.delimiter)
+        .filter(dir => {
+            dir = dir.toLowerCase();
+            if (dir.indexOf("iobroker") > -1 && dir.indexOf(path.join("node_modules", ".bin")) > -1) return false;
+            return true;
+        })
+        .join(path.delimiter)
+        ;
+
+    exec('npm -v', { encoding: "utf8", env: newEnv }, function (error, stdout) {//, stderr) {
         if (stdout) stdout = semver.valid(stdout.trim());
         if (callback) callback(error, stdout);
     });

--- a/package.json
+++ b/package.json
@@ -33,11 +33,12 @@
     "bluefox <dogafox@gmail.com>"
   ],
   "devDependencies": {
-    "gulp": "^3.9.1",
-    "npm": "^2.15.12",
-    "mocha": "^4.1.0",
     "chai": "^4.1.2",
+    "gulp": "^3.9.1",
+    "mocha": "^4.1.0",
+    "node.extend": "^2.0.0",
+    "npm": "^2.15.12",
     "request": "^2.83.0",
-    "node.extend": "^2.0.0"
+    "semver": "^5.5.0"
   }
 }


### PR DESCRIPTION
to work without js-controller's outdated `npm` package

Followup to:
https://github.com/ioBroker/ioBroker.js-controller/pull/174