### PR TITLE
added google-sharedlocations adapter

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1297,5 +1297,11 @@
     "icon": "https://raw.githubusercontent.com/t4qjXH8N/ioBroker.wiffi-wz/master/admin/wiffi-wz.png",
     "published": "2018-08-14T19:15:00.000Z",
     "type": "hardware"
+  },
+  "google-sharedlocations": {
+    "meta": "https://raw.githubusercontent.com/t4qjXH8N/ioBroker.google-sharedlocations/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/t4qjXH8N/ioBroker.google-sharedlocations/master/admin/google-sharedlocations.png",
+    "published": "2018-02-13T14:17:46.370Z",
+    "type": "geoposition"
   }
 }


### PR DESCRIPTION
This is an adapter to poll the locations from users from Google Sharedlocations. Some users want this adapter to be in the repo.