### PR TITLE
added stable version 2.0.0 of the wiffi-wz adapter

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1379,6 +1379,6 @@
     "icon": "https://raw.githubusercontent.com/t4qjXH8N/ioBroker.wiffi-wz/master/admin/wiffi-wz.png",
     "version": "2.0.0",
     "type": "hardware",
-    "published": "2018-10-03T17:30:31.393Z"
+    "published": "2018-08-14T19:15:00.000Z"
   }
 }

--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1284,8 +1284,8 @@
   "wiffi-wz": {
     "meta": "https://raw.githubusercontent.com/t4qjXH8N/ioBroker.wiffi-wz/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/t4qjXH8N/ioBroker.wiffi-wz/master/admin/wiffi-wz.png",
-	"version": "1.3.1",
+	"version": "2.0.0",
     "type": "hardware",
-    "published": "2018-09-01T16:34:11.165Z"
+    "published": "2018-10-03T17:30:31.393Z"
   }
 }


### PR DESCRIPTION
This version of the adapter supports all products from stall.biz that support sending a datagram. This adapter was tested by me and at least one other user with a different setup. I suppose it is stable.