### PR TITLE
Push tradfri 1.5.4 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1272,7 +1272,7 @@
   "tradfri": {
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.tradfri/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.tradfri/master/admin/tradfri.png",
-    "version": "1.4.1",
+    "version": "1.5.4",
     "type": "lighting",
     "published": "2017-08-23T11:33:34.827Z",
     "versionDate": "2018-05-14T14:24:24.327Z"


### PR DESCRIPTION
Hasn't been out long, but it contains only incremental bugfixes over 1.5.0 which has been out for 3 weeks now. Also it should finally solve the installation problems with node-aead-crypto.