### PR TITLE
nello: updating to v2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -940,12 +940,12 @@
     "versionDate": "2018-07-13T16:52:33.201Z"
   },
   "nello": {
-    "meta": "https://raw.githubusercontent.com/Zefau/ioBroker.nello/v1/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Zefau/ioBroker.nello/v1/admin/nello.png",
-    "version": "1.0.1",
+    "meta": "https://raw.githubusercontent.com/Zefau/ioBroker.nello/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Zefau/ioBroker.nello/master/admin/nello.png",
+    "version": "2.0.1",
     "type": "hardware",
     "published": "2018-12-09T12:08:00.000Z",
-    "versionDate": "2018-12-09T12:08:00.000Z"
+    "versionDate": "2018-02-03T21:29:00.000Z"
   },
   "netatmo": {
     "meta": "https://raw.githubusercontent.com/PArns/ioBroker.netatmo/master/io-package.json",

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -932,11 +932,11 @@
     "versionDate": "2018-10-15T16:47:50.402Z"
   },
   "nello": {
-    "meta": "https://raw.githubusercontent.com/Zefau/ioBroker.nello/v1/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Zefau/ioBroker.nello/v1/admin/nello.png",
+    "meta": "https://raw.githubusercontent.com/Zefau/ioBroker.nello/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Zefau/ioBroker.nello/master/admin/nello.png",
     "type": "hardware",
-    "published": "2018-11-05T20:38:00.000Z",
-    "versionDate": "2018-11-05T20:38:00.000Z"
+    "published": "2018-12-09T12:08:00.000Z",
+    "versionDate": "2018-02-03T21:29:00.000Z"
   },
   "netatmo": {
     "meta": "https://raw.githubusercontent.com/PArns/ioBroker.netatmo/master/io-package.json",


### PR DESCRIPTION
updating v2 in both repos has no effect since npm is already on 2.0.1 (see https://github.com/ioBroker/ioBroker.repositories/issues/302)