### PR TITLE
Add ioBroker.nuki2 to latest repository

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -966,6 +966,13 @@
     "published": "2018-10-05T09:37:04.501Z",
     "versionDate": "2019-01-21T13:37:47.916Z"
   },
+  "nuki2": {
+    "meta": "https://raw.githubusercontent.com/Zefau/ioBroker.nuki2/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Zefau/ioBroker.nuki2/master/admin/nuki-logo.png",
+    "type": "hardware",
+    "published": "2019-02-10T12:42:00.000Z",
+    "versionDate": "2019-02-10T12:42:00.000Z"
+  },
   "nut": {
     "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.nut/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.nut/master/admin/nut.png",


### PR DESCRIPTION
I have reworked the existing ioBroker.nuki adapter and optimized the code.
Furthermore, I have added the following features:
- using both Bridge API and Web API (current adapter only uses bridge API)
- support for multiple bridges
- support for discovery within admin panel
- additional states for bridges and better separation between software / hardware bridge
  - retrieve the basic and advanced configuration from the lock
  - retrieve all users having access to the lock
- added Web Interface to view logs