### PR TITLE
Move Telegram Adapter 1.4.3 from latest to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1484,10 +1484,10 @@
   "telegram": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.telegram/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.telegram/master/admin/telegram.png",
-    "version": "1.2.4",
+    "version": "1.4.3",
     "type": "messaging",
     "published": "2016-02-14T13:00:28.242Z",
-    "versionDate": "2018-06-02T21:05:44.662Z"
+    "versionDate": "2019-02-21T21:05:44.662Z"
   },
   "terminal": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.terminal/master/io-package.json",


### PR DESCRIPTION
Changes between Version 1.2.4 and 1.4.3:

1.4.3 (2019-02-21)
(BuZZy1337) Bugfix for not yet completely implemented feature
1.4.2 (2019-02-18)
(BuZZy1337) fix for recipients containing withespaces
(BuZZy1337) change loglevel of "getMe" info-messages to debug
(bluefox) fix scroll in firefox
1.4.1 (2019-01-12)
(simatec) Support for Compact mode
1.4.0 (2019-01-06)
(bluefox) Custom settings for states were added
1.3.6 (2018-12-01)
(Apollon77) fix #78
1.3.5 (2018-11-04)
(BuZZy1337) Fix a small error caused by previous commit
1.3.4 (2018-11-04)
(BuZZy1337) Ask if saved users should be wiped when password is changed.
1.3.3 (2018-11-03)
(BuZZy1337) Show warning if no password is set.
1.3.2 (2018-10-28)
(BuZZy1337) Just minor cosmetic fixes/changes
1.3.1 (2018-10-08)
(bluefox) The ability of enable/disable of states controlling was added
1.3.0 (2018-09-19)
(BuZZy1337) Added possibility to delete authenticated users in the Adapter-Config screen (via Messages tab)
(BuZZy1337) fixed a problem "building" the Blockly sendto block when no adapter instance exists.
1.2.7 (2018-08-29)
(BuZZy1337) Added "disable notification" checkbox to blockly block.
(BuZZy1337) Added "parse_mode" selector to blockly block.
1.2.6 (2018-07-30)
(BuZZy1337) Added support for sending Messages to Group-Chats via Blockly.
1.2.5 (2018-07-11)
(BuZZy1337) Added possibility to specify more than one recipient. (separated by comma)