### PR TITLE
Add new adapter hass-mqtt

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -426,6 +426,13 @@
     "published": "2015-08-18T08:32:32.461Z",
     "versionDate": "2019-03-12T23:47:36.396Z"
   },
+  "hass-mqtt": {
+    "meta": "https://raw.githubusercontent.com/smarthomefans/ioBroker.hass-mqtt/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/smarthomefans/ioBroker.hass-mqtt/master/admin/hass-mqtt.png",
+    "type": "iot-systems",
+    "published": "2019-05-17T16:43:46.836Z",
+    "versionDate": "2019-05-17T16:43:46.836Z"
+  },
   "hid": {
     "meta": "https://raw.githubusercontent.com/soef/ioBroker.hid/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/soef/ioBroker.hid/master/admin/hid.png",


### PR DESCRIPTION
This adapter can discover and add devices which followed hass defined mqtt protocol.


Signed-off-by: SchumyHao <schumyhaojl@126.com>