### PR TITLE
Update sources-dist-stable.json

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1395,9 +1395,9 @@
   "snips": {
     "meta": "https://raw.githubusercontent.com/unltdnetworx/ioBroker.snips/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/unltdnetworx/ioBroker.snips/master/admin/snips.png",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "type": "iot-systems",
-    "published": "2019-01-16T14:15:00.000Z",
+    "published": "2019-05-28T17:09:00.000Z",
     "versionDate": "2019-05-06T18:40:00.000Z"
   },
   "snmp": {

--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1397,8 +1397,8 @@
     "icon": "https://raw.githubusercontent.com/unltdnetworx/ioBroker.snips/master/admin/snips.png",
     "version": "1.1.7",
     "type": "iot-systems",
-    "published": "2019-05-28T17:09:00.000Z",
-    "versionDate": "2019-05-06T18:40:00.000Z"
+    "published": "2019-01-16T14:15:00.000Z",
+    "versionDate": "2019-05-28T17:09:00.000Z"
   },
   "snmp": {
     "meta": "https://raw.githubusercontent.com/ctjaeger/ioBroker.snmp/master/io-package.json",


### PR DESCRIPTION
New stable version of snips. Security update, due to vulnerability in mqtt-packet, pulled by mqtt.