### PR TITLE
Updated latest innogy-smarthome lib to 0.3.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -495,7 +495,7 @@
     "meta": "https://raw.githubusercontent.com/PArns/ioBroker.innogy-smarthome/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/PArns/ioBroker.innogy-smarthome/master/admin/innogy-smarthome.png",
     "type": "iot-systems",
-    "version": "0.2.11"
+    "version": "0.3.3"
   },
   "iogo": {
     "meta": "https://raw.githubusercontent.com/nisiode/ioBroker.iogo/master/io-package.json",


### PR DESCRIPTION
Updated latest innogy-smarthome lib to 0.3.3

Version 0.2.x is outdated and will not be compatible with the next update