### PR TITLE
Fix ZWave2 icon url

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1454,7 +1454,7 @@
   },
   "zwave2": {
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/admin/zwave2.svg",
+    "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/admin/zwave2.svg?sanitize=true",
     "type": "hardware"
   }
 }


### PR DESCRIPTION
When I added ZWave2 with #479 I started a little experiment. The adapter is the first one to use an SVG icon. While that mostly works, it breaks in the adapter list:
![grafik](https://user-images.githubusercontent.com/17641229/65769119-1f867d00-e133-11e9-855c-adc086c73dec.png)

The reason is that `https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/admin/zwave2.svg` shows the SVG source code while `https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/admin/zwave2.svg?sanitize=true` has the correct MIME type to display an image.

This PR fixes that (or rather starts another experiment to see **if the query string breaks any scripts**)

/cc @GermanBluefox @Apollon77 