### PR TITLE
Add radiohead v1.0.2 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1018,6 +1018,12 @@
     "type": "network",
     "version": "1.0.3"
   },
+  "radiohead": {
+    "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.radiohead/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.radiohead/master/admin/radiohead.png",
+    "type": "protocols",
+    "version": "1.0.2"
+  },
   "rflink": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.rflink/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.rflink/master/admin/rflink.png",


### PR DESCRIPTION
The RadioHead adapter is already in the latest repository for about two month.

The [forum post](https://forum.iobroker.net/topic/24197/aufruf-neuer-adapter-iobroker-radiohead) has unfortunately no feedback, but I'm running the adapter since several weeks now and it seams to be stable.