### PR TITLE
Fixed wrong type for ds18b20 adapter in latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -167,7 +167,7 @@
   "ds18b20": {
     "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.ds18b20/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.ds18b20/master/admin/ds18b20.png",
-    "type": "protocols"
+    "type": "hardware"
   },
   "dwd": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.dwd/master/io-package.json",


### PR DESCRIPTION
I had accidentally specified a wrong type for the _ds18b20_ adapter in the latest repo. Sorry!