### PR TITLE
Stable: Lupusec, Shelly, Ring

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1094,7 +1094,7 @@
     "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.shelly/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/schmupu/ioBroker.shelly/master/admin/shelly.png",
     "type": "iot-systems",
-    "version": "3.1.0"
+    "version": "3.1.1"
   },
   "sia": {
     "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.sia/master/io-package.json",

--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -644,7 +644,7 @@
     "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.lupusec/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/schmupu/ioBroker.lupusec/master/admin/lupusec.png",
     "type": "alarm",
-    "version": "1.1.8"
+    "version": "1.2.0"
   },
   "luxtronik1": {
     "meta": "https://raw.githubusercontent.com/forelleblau/ioBroker.luxtronik1/master/io-package.json",
@@ -1040,7 +1040,7 @@
     "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.ring/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/schmupu/ioBroker.ring/master/admin/ring.png",
     "type": "hardware",
-    "version": "1.0.4"
+    "version": "1.0.5"
   },
   "roomba": {
     "meta": "https://raw.githubusercontent.com/Zefau/ioBroker.roomba/master/io-package.json",
@@ -1094,7 +1094,7 @@
     "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.shelly/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/schmupu/ioBroker.shelly/master/admin/shelly.png",
     "type": "iot-systems",
-    "version": "3.0.8"
+    "version": "3.1.0"
   },
   "sia": {
     "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.sia/master/io-package.json",


### PR DESCRIPTION
New stable versions for following adapters:

* Lupusec from 1.1.8 to 1.2.0 (new devices like Nuki door opener, bugfixing)
* Ring from 1.0.4 to 1.0.5 (bugfixing for js-controller >= 2)
* Shelly 3.0.8 to 3.1.0 (new devices like dimmer, bugfixing)

all adapters are js-controller 2 ready.