### PR TITLE
change nuki2 Github branch and add nuki-extended to latest

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1119,9 +1119,9 @@
     "versionDate": "2018-10-12T16:52:47.916Z"
   },
   "nuki2": {
-    "meta": "https://raw.githubusercontent.com/Zefau/ioBroker.nuki2/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Zefau/ioBroker.nuki2/master/admin/nuki-logo.png",
-    "version": "1.0.4",
+    "meta": "https://raw.githubusercontent.com/Zefau/ioBroker.nuki-extended/nuki2/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Zefau/ioBroker.nuki-extended/nuki2/admin/nuki-logo.png",
+    "version": "1.0.5",
     "type": "hardware",
     "published": "2019-02-10T12:42:00.000Z",
     "versionDate": "2019-08-03T20:28:08.378Z"

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1121,11 +1121,18 @@
     "versionDate": "2019-08-31T08:39:39.803Z"
   },
   "nuki2": {
-    "meta": "https://raw.githubusercontent.com/Zefau/ioBroker.nuki2/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Zefau/ioBroker.nuki2/master/admin/nuki-logo.png",
+    "meta": "https://raw.githubusercontent.com/Zefau/ioBroker.nuki-extended/nuki2/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Zefau/ioBroker.nuki-extended/nuki2/admin/nuki-logo.png",
     "type": "hardware",
     "published": "2019-02-09T22:58:18.515Z",
     "versionDate": "2019-08-30T16:55:26.452Z"
+  },
+  "nuki-extended": {
+    "meta": "https://raw.githubusercontent.com/Zefau/ioBroker.nuki-extended/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Zefau/ioBroker.nuki-extended/master/admin/nuki-logo.png",
+    "type": "hardware",
+    "published": "2019-10-15T22:22:22.000Z",
+    "versionDate": "2019-10-15T22:22:22.000Z"
   },
   "nut": {
     "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.nut/master/io-package.json",


### PR DESCRIPTION
**nuki-extended shall replace nuki2 in near future.**
____
**FEATURES**
- Support for Nuki Smartlock and Nuki Opener
- Support for both Nuki Bridge API and Nuki Web API
- Support for hashed token on hardware bridges
- Fallback to Nuki Web API in case applied actions on Nuki Bridge API fail, e.g. due to bridge error 503
- Retry in case applied actions on Nuki Bridge API fail (when Nuki Web API is not used)
- Option to regularly synchronise instead of using Bridge API callback (which may be delayed due to Hardware Bridge)
- Refreshing all states of Nuki Web API when callback is received via Nuki Bridge API
- Retrieve authorised users for Nuki Smartlock and Nuki Opener
- Retrieve the configuration for Nuki Smartlock and Nuki Opener
- Retrieve setup Nuki Notifications
- Web Interface that shows the recent events from your Nuki Smartlock and Nuki Opener
