### PR TITLE
Update ioBroker.iogo version to 0.4.13

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -501,7 +501,7 @@
     "meta": "https://raw.githubusercontent.com/nisiode/ioBroker.iogo/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/nisiode/ioBroker.iogo/master/admin/iogo.png",
     "type": "visualization",
-    "version": "0.3.4"
+    "version": "0.4.13"
   },
   "iot": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.iot/master/io-package.json",


### PR DESCRIPTION
Version 0.4.13 is needed for new app version 2.0.0