### PR TITLE
Pollenflug adapter

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -974,7 +974,7 @@
     "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.pollenflug/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/schmupu/ioBroker.pollenflug/master/admin/pollenflug.png",
     "type": "weather",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   "proxmox": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.proxmox/master/io-package.json",


### PR DESCRIPTION
Bugfix of pollen risk adapter. Without this bugfix the pollen risk adapter does not work anymore because of a DWD SSL change.  
see https://forum.iobroker.net/topic/20288/aufruf-neuer-dwd-pollenflug-adapter/129