### PR TITLE
Add tesla-motors to repositories

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1222,6 +1222,11 @@
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.terminal/master/admin/terminal.png",
     "type": "utility"
   },
+  "tesla-motors": {
+    "meta": "https://raw.githubusercontent.com/dbweb-ch/ioBroker.tesla-motors/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/dbweb-ch/ioBroker.tesla-motors/master/admin/tesla-motors.png",
+    "type": "hardware"
+  },
   "text2command": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.text2command/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.text2command/master/admin/text2command.png",


### PR DESCRIPTION
Test-Thread:
https://forum.iobroker.net/topic/26428/test-adapter-tesla-motors-v0-1-x
Released current version is v0.2.0, also on NPM.
I still get 2 errors on https://adapter-check.iobroker.in/, but I've added Bluefox on NPM and included travis testing, so this should be fine.