### PR TITLE
Bosch Smart Home Bridge Adapter stable 0.1.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -101,6 +101,12 @@
     "type": "iot-systems",
     "version": "1.8.0"
   },
+  "bshb": {
+    "meta": "https://raw.githubusercontent.com/holomekc/ioBroker.bshb/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/holomekc/ioBroker.bshb/master/admin/bshb-logo.jpg",
+    "type": "iot-systems",
+    "version": "0.1.4"
+  },
   "chromecast": {
     "meta": "https://raw.githubusercontent.com/angelnu/ioBroker.chromecast/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/angelnu/ioBroker.chromecast/master/admin/chromecast.png",


### PR DESCRIPTION
Hi. I would add the first stable version of the adapter. There was an issue in 0.1.3 which is fixed in 0.1.4 and I did not receive any other issues. 