### PR TITLE
Updated stable version of wiffi-wz to 2.2.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1532,7 +1532,7 @@
     "meta": "https://raw.githubusercontent.com/t4qjXH8N/ioBroker.wiffi-wz/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/t4qjXH8N/ioBroker.wiffi-wz/master/admin/wiffi-wz.png",
     "type": "hardware",
-    "version": "2.1.4"
+    "version": "2.2.0"
   },
   "wifilight": {
     "meta": "https://raw.githubusercontent.com/soef/ioBroker.wifilight/master/io-package.json",


### PR DESCRIPTION
Version 2.2.0 appears to be stable.