### PR TITLE
bump email

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -225,7 +225,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.email/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.email/master/admin/email.png",
     "type": "messaging",
-    "version": "1.0.5"
+    "version": "1.0.6"
   },
   "emby": {
     "meta": "https://raw.githubusercontent.com/thewhobox/ioBroker.emby/master/io-package.json",


### PR DESCRIPTION
- 1.0.5 has getMessage warning on stable  with stable controller
- https://github.com/iobroker-community-adapters/ioBroker.email/issues/25