### PR TITLE
update iogo to 0.5.8

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -549,7 +549,7 @@
     "meta": "https://raw.githubusercontent.com/nisiode/ioBroker.iogo/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/nisiode/ioBroker.iogo/master/admin/iogo.png",
     "type": "visualization",
-    "version": "0.5.7"
+    "version": "0.5.8"
   },
   "iot": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.iot/master/io-package.json",


### PR DESCRIPTION
new version is ignoring the "ts" from objects for object-hash creation, as the value in object "ts" is triggered from some adapters without changing the object in a high frequency (like spamming).