### PR TITLE
update fb-checkpresence to version 1.0.3 in stable repo

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -297,7 +297,7 @@
     "meta": "https://raw.githubusercontent.com/afuerhoff/ioBroker.fb-checkpresence/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/afuerhoff/ioBroker.fb-checkpresence/master/admin/fb-checkpresence.png",
     "type": "infrastructure",
-    "version": "0.3.0"
+    "version": "1.0.3"
   },
   "feiertage": {
     "meta": "https://raw.githubusercontent.com/Pix---/ioBroker.feiertage/master/io-package.json",


### PR DESCRIPTION
Here you can find the Forum thread [Test 1.0.x](https://forum.iobroker.net/topic/31787/test-adapter-fb-checkpresence-v1-0-x)