### PR TITLE
Add zwave2 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1749,5 +1749,11 @@
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.zwave/master/admin/zwave.png",
     "type": "hardware",
     "version": "2.0.1"
+  },
+  "zwave2": {
+    "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/admin/zwave2.svg?sanitize=true",
+    "type": "hardware",
+    "version": "0.14.6"
   }
 }

--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1754,6 +1754,6 @@
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/admin/zwave2.svg?sanitize=true",
     "type": "hardware",
-    "version": "0.14.6"
+    "version": "1.0.0"
   }
 }


### PR DESCRIPTION
I'm preparing the stable release for Z-Wave 2. v0.14.6 will probably be the final version before that is going to happen.

I'm raising this PR to find potential problems while the final tests are going on.