### PR TITLE
Update sources-dist-stable.json

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -9,7 +9,7 @@
     "meta": "https://raw.githubusercontent.com/misanorot/ioBroker.alarm/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/misanorot/ioBroker.alarm/master/admin/alarm.png",
     "type": "alarm",
-    "version": "0.3.0"
+    "version": "0.7.4"
   },
   "alexa2": {
     "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.alexa2/master/io-package.json",


### PR DESCRIPTION
Why was the alarm adapter automatically in the stable source?