### PR TITLE
Updated latest innogy-smarthome lib to 0.3.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -579,7 +579,7 @@
     "meta": "https://raw.githubusercontent.com/PArns/ioBroker.innogy-smarthome/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/PArns/ioBroker.innogy-smarthome/master/admin/innogy-smarthome.png",
     "type": "iot-systems",
-    "version": "0.3.3"
+    "version": "0.3.5"
   },
   "iogo": {
     "meta": "https://raw.githubusercontent.com/nisiode/ioBroker.iogo/master/io-package.json",


### PR DESCRIPTION
Needed update in order to bring innogy adapter back functional with the new AUTH endpoint