### PR TITLE
logparser to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -724,6 +724,12 @@
     "type": "logic",
     "version": "1.1.4"
   },
+  "logparser": {
+    "meta": "https://raw.githubusercontent.com/Mic-M/ioBroker.logparser/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Mic-M/ioBroker.logparser/master/admin/logparser.png",
+    "type": "logic",
+    "version": "1.0.0"
+  },
   "lovelace": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.lovelace/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.lovelace/master/admin/lovelace.png",


### PR DESCRIPTION
Add logparser to stable. 
Adapter is very stable: used by many users and no issues for several weeks.

https://github.com/Mic-M/ioBroker.logparser