### PR TITLE
Update sources-dist.json with sprinklecontrol

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1780,5 +1780,10 @@
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/admin/zwave2.svg?sanitize=true",
     "type": "hardware"
+  },
+  "sprinklecontrol": {
+    "meta": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/admin/sprinklecontrol.png",
+    "type": "garden"
   }
 }

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1322,6 +1322,11 @@
     "icon": "https://raw.githubusercontent.com/twonky4/ioBroker.spotify-premium/master/admin/spotify-premium.png",
     "type": "multimedia"
   },
+  "sprinklecontrol": {
+    "meta": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/admin/sprinklecontrol.png",
+    "type": "garden"
+  },
   "sql": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.sql/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.sql/master/admin/sql.png",
@@ -1780,10 +1785,5 @@
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/admin/zwave2.svg?sanitize=true",
     "type": "hardware"
-  },
-  "sprinklecontrol": {
-    "meta": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/admin/sprinklecontrol.png",
-    "type": "garden"
   }
 }


### PR DESCRIPTION
sprinklecontrol, "type": garden
E801 und E802 waren erledigt, wurden von https://adapter-check.iobroker.in/ nicht erkannt
[E145] Keine Neuigkeiten für aktuelle Version 0.0.6 gefunden => kann ich nicht nachvollziehen (Beschreibung wurde vervollständigt und ein Fehler im calcPosTimer behoben.
Ich hoffe das jetzt alle Kriterien erfüllt sind.
Dirk Peter