### PR TITLE
Added go-e for Hardware go-eCharger

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -364,6 +364,11 @@
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.geofency/master/admin/geofency.png",
     "type": "geoposition"
   },
+  "go-e": {
+    "meta": "https://raw.githubusercontent.com/MK-2001/ioBroker.go-e/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/MK-2001/ioBroker.go-e/master/admin/go-echarger.png",
+    "type": "vehicle"
+  },
   "gruenbeck": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.gruenbeck/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.gruenbeck/master/admin/gruenbeck.png",


### PR DESCRIPTION
Added an adapter for go-e for the hardware go-eCharger.
Similar to #852 / #853.
But with no error in the checking tools of ioBroker.