### PR TITLE
Integrating adapter fahrplan

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -284,6 +284,11 @@
     "icon": "https://raw.githubusercontent.com/instalator/ioBroker.exchangerates/master/admin/exchangerates.png",
     "type": "misc-data"
   },
+  "fahrplan": {
+    "meta": "https://raw.githubusercontent.com/gaudes/ioBroker.fahrplan/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/gaudes/ioBroker.fahrplan/master/admin/fahrplan.png",
+    "type": "date-and-time"
+  },
   "fakeroku": {
     "meta": "https://raw.githubusercontent.com/Pmant/ioBroker.fakeroku/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Pmant/ioBroker.fakeroku/master/admin/fakeroku.png",
@@ -1211,7 +1216,7 @@
     "meta": "https://raw.githubusercontent.com/nobl/ioBroker.senec/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/nobl/ioBroker.senec/master/admin/senec.png",
     "type": "energy"
-  }, 
+  },
   "shelly": {
     "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.shelly/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/schmupu/ioBroker.shelly/master/admin/shelly.png",


### PR DESCRIPTION
Hi,

please integrate my adapter "fahrplan" into latest branch.

Here are the informations about the new adapter:

https://github.com/gaudes/ioBroker.fahrplan

Adapter checker result has only one false-positive error:
_[E300] Not found on travis. Please setup travis_
But I'm using travis.com

I've done a alpha version test in forum already, see here:

https://forum.iobroker.net/topic/35169/test-adapter-fahrplan-v0-1-x-github-alpha-version

There is also an old adapter request here:

https://github.com/ioBroker/AdapterRequests/issues/257

Don't hesitate to contact me for further questions.

Thanks and regards,

Ralf