### PR TITLE
Update Stables: logparser and windows-control

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -728,7 +728,7 @@
     "meta": "https://raw.githubusercontent.com/Mic-M/ioBroker.logparser/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Mic-M/ioBroker.logparser/master/admin/logparser.png",
     "type": "logic",
-    "version": "1.0.0"
+    "version": "1.0.4"
   },
   "lovelace": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.lovelace/master/io-package.json",
@@ -1724,7 +1724,7 @@
     "meta": "https://raw.githubusercontent.com/Mic-M/ioBroker.windows-control/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Mic-M/ioBroker.windows-control/master/admin/windows-control.png",
     "type": "hardware",
-    "version": "0.1.3"
+    "version": "0.1.5"
   },
   "wled": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.wled/master/io-package.json",


### PR DESCRIPTION
Update stables:
* logparser 1.0.0 -> 1.0.4 -- https://github.com/Mic-M/ioBroker.logparser
* windows-control: 0.1.3 -> 0.1.5 -- https://github.com/Mic-M/ioBroker.windows-control

See: https://github.com/Mic-M/ioBroker.windows-control/issues/9