### PR TITLE
Shelly 4.0.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1280,7 +1280,7 @@
     "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.shelly/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/schmupu/ioBroker.shelly/master/admin/shelly.png",
     "type": "iot-systems",
-    "version": "4.0.2"
+    "version": "4.0.3"
   },
   "shuttercontrol": {
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.shuttercontrol/master/io-package.json",


### PR DESCRIPTION
(Stübi) - Add a checkbox, to optionally enable updates of objects even if they have not changed (Issue #209)
(Stübi) - Calculate temperature fahrenheit for Shelly 1PM and Plug S in MQTT mode
(Stübi) - Fixed longpush time for MQTT (Shelly 1, 1PM, 2 and 2.5)
(Stübi) - Add State for changing temperature unit for Shelly HT and DW2
(Stübi) - Delete external temperature 4 and external humidity 4 states for Shelly 1 and 1PM because they do not exist
(Stübi) - Renamed state temperature to temperatureC for Shelly 1, 1PM, 2, 2.5, Plug S
(Stübi) - Add tmperature in Celsius and Fahrenheit for Shelly HT and DW2
(Stübi) - Bugfixing. Add missing states to MQTT, which exist for CoAP (Shelly 2, 2.5)
(Stübi) - Polltime for http optimized.
(Stübi) - removed min and max values for temperature states (Issue #236)
(Stübi) - Bugfixing. Add timer to Shelly 1, 1PM for CoAP and removed it for MQTT (Shelly 1, 1PM, 2, 2.5) because it is not supported by MQTT
(Stübi) - Add overpower value to Shelly 1, 1PM, 2, 2.5 and Plug, Plug S
(Stübi) - Removed channel name from Shelly 4 Pro (Issue #238)