### PR TITLE
Lupusec Adapter stable version 1.2.9

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -770,7 +770,7 @@
     "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.lupusec/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/schmupu/ioBroker.lupusec/master/admin/lupusec.png",
     "type": "alarm",
-    "version": "1.2.6"
+    "version": "1.2.9"
   },
   "luxtronik1": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.luxtronik1/master/io-package.json",


### PR DESCRIPTION
* Bugfixing
* Add sentry mode
* Now you can hold the reason for the alarm in alarm_status and alarm_status till the alarm ends