### PR TITLE
Bump Z-Wave 2 to v1.7.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1844,6 +1844,6 @@
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/admin/zwave2.svg?sanitize=true",
     "type": "hardware",
-    "version": "1.5.0"
+    "version": "1.7.5"
   }
 }


### PR DESCRIPTION
Time to update, the current stable version is 3 months old.