### PR TITLE
Added canbus to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -129,6 +129,11 @@
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.cameras/master/admin/cameras.png",
     "type": "multimedia"
   },
+  "canbus": {
+    "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.canbus/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.canbus/master/admin/canbus.png",
+    "type": "hardware"
+  },
   "chromecast": {
     "meta": "https://raw.githubusercontent.com/angelnu/ioBroker.chromecast/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/angelnu/ioBroker.chromecast/master/admin/chromecast.png",


### PR DESCRIPTION
Add my new [ioBroker.canbus](https://github.com/crycode-de/ioBroker.canbus) adapter to the latest repo.

~Adapter checker complains about `tsconfig.json` files not in `.npmignore`, but they are there with wildcards.~

Adapter request: https://github.com/ioBroker/AdapterRequests/issues/441