### PR TITLE
Push Nuki v 1.4.2 to stable (fixed invalid type push,pull)

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1016,7 +1016,7 @@
     "meta": "https://raw.githubusercontent.com/smaragdschlange/ioBroker.nuki/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/smaragdschlange/ioBroker.nuki/master/admin/nuki-logo.png",
     "type": "hardware",
-    "version": "1.4.1"
+    "version": "1.4.2"
   },
   "nuki-extended": {
     "meta": "https://raw.githubusercontent.com/Zefau/ioBroker.nuki-extended/master/io-package.json",


### PR DESCRIPTION
Hi,
sorry for my late reply. I've fixed the issue stated in version [1.4.1](https://github.com/ioBroker/ioBroker.repositories/pull/987) and created a new version.