### PR TITLE
Stable update of smartcontrol from 1.0.0 to 1.2.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1370,7 +1370,7 @@
     "meta": "https://raw.githubusercontent.com/Mic-M/ioBroker.smartcontrol/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Mic-M/ioBroker.smartcontrol/master/admin/smartcontrol.png",
     "type": "logic",
-    "version": "1.0.0"
+    "version": "1.2.1"
   },
   "smartgarden": {
     "meta": "https://raw.githubusercontent.com/jpgorganizer/ioBroker.smartgarden/master/io-package.json",


### PR DESCRIPTION
This to update stable to address bug fixes. Many Latest installation users did not report any bugs, nor Sentry did.
I consider this version as stable.
Thanks.