### PR TITLE
source-list-stable: update nibeuplink to 0.4.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1058,7 +1058,7 @@
     "meta": "https://raw.githubusercontent.com/sebilm/ioBroker.nibeuplink/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/sebilm/ioBroker.nibeuplink/master/admin/nibeuplink.png",
     "type": "climate-control",
-    "version": "0.3.0"
+    "version": "0.4.0"
   },
   "nina": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.nina/master/io-package.json",


### PR DESCRIPTION
It runs for 4 weeks on 2 of my machines (compact mode and normal mode).
2 users tested it: https://github.com/sebilm/ioBroker.nibeuplink/issues/12
No problems were reported in the forum: https://forum.iobroker.net/topic/40046/test-adapter-nibeuplink-v0-4-0-latest
I did not get any error messages.