### PR TITLE
Push version of fahrplan to 1.0.2 in stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -309,7 +309,7 @@
     "meta": "https://raw.githubusercontent.com/gaudes/ioBroker.fahrplan/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/gaudes/ioBroker.fahrplan/master/admin/fahrplan.png",
     "type": "date-and-time",
-    "version": "1.0.0"
+    "version": "1.0.2"
   },
   "fakeroku": {
     "meta": "https://raw.githubusercontent.com/Pmant/ioBroker.fakeroku/master/io-package.json",


### PR DESCRIPTION
Hi Apollon,

please push version of adapter fahrplan to 1.0.2 in stable.

Thanks and regards,

Ralf