### PR TITLE
Bump zwave2 stable version

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1970,6 +1970,6 @@
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/admin/zwave2.svg?sanitize=true",
     "type": "hardware",
-    "version": "1.8.5"
+    "version": "1.8.11"
   }
 }


### PR DESCRIPTION
1.8.11 is not that old, but it fixes a critical bug in 1.8.10 which has been out almost 3 weeks now.
Other than that - no known issues.