### PR TITLE
Add vis-3dmodel widget

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1741,6 +1741,11 @@
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis/master/admin/vis.png",
     "type": "visualization"
   },
+  "vis-3dmodel": {
+    "meta": "https://raw.githubusercontent.com/Excodibur/ioBroker.vis-3dmodel/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Excodibur/ioBroker.vis-3dmodel/master/admin/vis-3dmodel.png",
+    "type": "visualization-widgets"
+  },
   "vis-bars": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-bars/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-bars/master/admin/bars.png",


### PR DESCRIPTION
Please add this widget to the latest repo. Official documentation can be found [here](https://excodibur.github.io/ioBroker.vis-3dmodel/latest/index.html).

Tests (& build) are done via Github Actions.

There seem to be false positives [E605] and [E701] from adapter-checker. Both are related to "no year found", although it is actually set.