### PR TITLE
bump ioBroker.fuelpricemonitor from 0.2.2 to 0.2.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -423,7 +423,7 @@
     "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.fuelpricemonitor/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/HGlab01/ioBroker.fuelpricemonitor/master/admin/fuelpricemonitor.png",
     "type": "vehicle",
-    "version": "0.2.2"
+    "version": "0.2.4"
   },
   "fullcalendar": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.fullcalendar/master/io-package.json",


### PR DESCRIPTION
Please blacklist 0.2.2 and 0.2.3 in Sentry. Thanks!