### PR TITLE
Bump Tradfri to 2.7.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1682,7 +1682,7 @@
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.tradfri/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.tradfri/master/admin/tradfri.png",
     "type": "lighting",
-    "version": "2.7.1"
+    "version": "2.7.2"
   },
   "trashschedule": {
     "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.trashschedule/master/io-package.json",


### PR DESCRIPTION
The version was just released, but it only makes sure that `setState` isn't called with `undefined`, avoiding warnings in JS-Controller 3.3