### PR TITLE
Fix time-switch type

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1645,7 +1645,7 @@
   "time-switch": {
     "meta": "https://raw.githubusercontent.com/walli545/ioBroker.time-switch/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/walli545/ioBroker.time-switch/master/admin/time-switch.png",
-    "type": "time-and-date"
+    "type": "date-and-time"
   },
   "tinker": {
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.tinker/master/io-package.json",


### PR DESCRIPTION
Change type of time-switch from `time-and-date` to `date-and-time`. See https://github.com/walli545/ioBroker.time-switch/issues/134.