### PR TITLE
Update stable version of ecovacs-deebot to 1.2.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -303,7 +303,7 @@
     "meta": "https://raw.githubusercontent.com/mrbungle64/ioBroker.ecovacs-deebot/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/mrbungle64/ioBroker.ecovacs-deebot/master/admin/ecovacs-deebot.png",
     "type": "household",
-    "version": "1.1.1"
+    "version": "1.2.1"
   },
   "egigeozone": {
     "meta": "https://raw.githubusercontent.com/BasGo/ioBroker.egigeozone/master/io-package.json",


### PR DESCRIPTION
https://github.com/mrbungle64/ioBroker.ecovacs-deebot/issues/148
Version 1.2.1 was released 18 days ago.

Thanks :)