### PR TITLE
Added canbus v1.2.2 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -167,6 +167,12 @@
     "type": "energy",
     "version": "1.2.3"
   },
+  "canbus": {
+    "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.canbus/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.canbus/master/admin/canbus.png",
+    "type": "hardware",
+    "version": "1.2.2"
+  },
   "chromecast": {
     "meta": "https://raw.githubusercontent.com/angelnu/ioBroker.chromecast/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/angelnu/ioBroker.chromecast/master/admin/chromecast.png",


### PR DESCRIPTION
[ioBroker.canbus](https://github.com/crycode-de/ioBroker.canbus) seams to be stable and working nicely with the latest js-controller and admin 5.

Forum testing thread: https://forum.iobroker.net/topic/39033/test-adapter-canbus-v1-1-x-latest/