### PR TITLE
Update iqontrol to 1.9.10

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -753,7 +753,7 @@
     "meta": "https://raw.githubusercontent.com/sbormann/ioBroker.iqontrol/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/sbormann/ioBroker.iqontrol/master/admin/iqontrol.png",
     "type": "visualization",
-    "version": "1.8.2"
+    "version": "1.9.10"
   },
   "jarvis": {
     "meta": "https://raw.githubusercontent.com/Zefau/ioBroker.jarvis/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.iqontrol to version 1.9.10.

*This pull request was created by https://www.iobroker.dev 15f979c.*