### PR TITLE
Update fahrplan to 1.2.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -393,7 +393,7 @@
     "meta": "https://raw.githubusercontent.com/gaudes/ioBroker.fahrplan/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/gaudes/ioBroker.fahrplan/master/admin/fahrplan.png",
     "type": "date-and-time",
-    "version": "1.0.7"
+    "version": "1.2.0"
   },
   "fakeroku": {
     "meta": "https://raw.githubusercontent.com/Pmant/ioBroker.fakeroku/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.fahrplan to version 1.2.0.

*This pull request was created by https://www.iobroker.dev 15f979c.*