### PR TITLE
Update sources-dist-stable.json: swiss-weather-api

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1700,7 +1700,7 @@
     "meta": "https://raw.githubusercontent.com/baerengraben/ioBroker.swiss-weather-api/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/baerengraben/ioBroker.swiss-weather-api/master/admin/swiss-weather-api.png",
     "type": "weather",
-    "version": "0.9.9"
+    "version": "1.0.0"
   },
   "synology": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.synology/master/io-package.json",


### PR DESCRIPTION
And another "bugfix" in the swiss-weather-api adapter, which caused the change in the SRF API. This version has been tested by several people and seems to be stable now. 
Now the adapter is worthy of version 1.0.0 *drum roll* :)