### PR TITLE
Update sprinklecontrol v 0.2.7

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1652,7 +1652,7 @@
     "meta": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/admin/sprinklecontrol.png",
     "type": "garden",
-    "version": "0.1.7"
+    "version": "0.2.7"
   },
   "sql": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.sql/master/io-package.json",


### PR DESCRIPTION
In SprinkleControl Version 0.2.7 wurden beim Testen unter https://forum.iobroker.net/topic/46043/test-adapter-sprinkle-control-0-2-x-mit-neuen-funktionen/127 keine Fehler mehr gefunden. Bitte veröffentlichen Sie diese Version unter stable.