### PR TITLE
Bump zwave2 to 2.2.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2168,6 +2168,6 @@
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/admin/zwave2.svg?sanitize=true",
     "type": "hardware",
-    "version": "2.2.4"
+    "version": "2.2.5"
   }
 }


### PR DESCRIPTION
This version is basically the same as the currently stable 2.2.4, but prevents installation of new, incompatible lib versions.