### PR TITLE
Update coronavirus-statistics to 0.8.7

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -219,7 +219,7 @@
     "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.coronavirus-statistics/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.coronavirus-statistics/main/admin/coronavirus-statistics.png",
     "type": "health",
-    "version": "0.8.6"
+    "version": "0.8.7"
   },
   "countdown": {
     "meta": "https://raw.githubusercontent.com/jack-blackson/ioBroker.countdown/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.coronavirus-statistics to version 0.8.7.

*This pull request was created by https://www.iobroker.dev 937807c.*