### PR TITLE
revert stable version of Spotify to 1.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1652,7 +1652,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.spotify-premium/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.spotify-premium/master/admin/spotify-premium.png",
     "type": "multimedia",
-    "version": "1.1.3"
+    "version": "1.0.0"
   },
   "sprinklecontrol": {
     "meta": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/io-package.json",


### PR DESCRIPTION
@GermanBluefox @Apollon77 in mass update https://github.com/ioBroker/ioBroker.repositories/commit/7551fe35db09dd59daa2421dc237faa085ab749f version of Spotify was a updated to stable but this release is not working at all. (see. git issue) please revert