### PR TITLE
Bumped dysonAirPurifier to v2.3.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -315,7 +315,7 @@
     "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.dysonairpurifier/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.dysonairpurifier/master/admin/dyson_logo.svg",
     "type": "climate-control",
-    "version": "2.2.0"
+    "version": "2.3.0"
   },
   "easee": {
     "meta": "https://raw.githubusercontent.com/Newan/ioBroker.easee/master/io-package.json",


### PR DESCRIPTION
##  Changelog
### V2.3.0 (2021-12-02) (Fairytale of doom)
* (grizzelbee) New: Added some GUI elements for air quality in folder icons
* (grizzelbee) New: Added support for HEPA PTFE filters
* (grizzelbee) New: Added support for Combined PTFE filters
* (grizzelbee) Chg: Fanspeed is now a number (not string anymore) to work properly with IoT-Adapter. Please delete this data point and let get recreated. 
