### PR TITLE
Bump Tradfri to 3.1.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1778,7 +1778,7 @@
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.tradfri/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.tradfri/master/admin/tradfri.png",
     "type": "lighting",
-    "version": "3.0.1"
+    "version": "3.1.2"
   },
   "trashschedule": {
     "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.trashschedule/master/io-package.json",


### PR DESCRIPTION
3.1.0/1 have been out a while and they are required to get rid of the warnings for the new firmware.
3.1.2 is newer but only fixed a minor bug related to air purifiers (actually, 1 character).