### PR TITLE
Bump selveRF stable to 0.6.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1622,7 +1622,7 @@
     "meta": "https://raw.githubusercontent.com/Rintrium/ioBroker.selverf/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Rintrium/ioBroker.selverf/master/admin/selverf.png",
     "type": "iot-systems",
-    "version": "0.6.1"
+    "version": "0.6.2"
   },
   "seq": {
     "meta": "https://raw.githubusercontent.com/o0shojo0o/ioBroker.seq/master/io-package.json",


### PR DESCRIPTION
Fixes a critical error in version 0.6.1 (caused by misspellings). Version 0.6.2 was released on 22.01.22 after feedback in the [tester thread](https://forum.iobroker.net/topic/47779/neuer-adapter-selverf/51). No further errors were reported.