### PR TITLE
Added euSec to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -424,6 +424,11 @@
     "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.esphome/main/admin/esphome.png",
     "type": "hardware"
   },
+  "eusec": {
+    "meta": "https://raw.githubusercontent.com/bropat/ioBroker.euSec/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/bropat/ioBroker.euSec/master/admin/euSec.png",
+    "type": "alarm"
+  },
   "eventlist": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.eventlist/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.eventlist/master/admin/eventlist.png",


### PR DESCRIPTION
I have now renamed the adapter eufy-security to euSec, changed the logo, added a disclaimer and ask for reinstatement.

Old pull request:
https://github.com/ioBroker/ioBroker.repositories/commit/868b53f73e43b52cb024157848e1abbd26d8f1d3