### PR TITLE
Renamed euSec Repository to eusec as requested

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -426,10 +426,10 @@
     "version": "1.0.6"
   },
   "eusec": {
-    "meta": "https://raw.githubusercontent.com/bropat/ioBroker.euSec/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/bropat/ioBroker.euSec/master/admin/euSec.png",
+    "meta": "https://raw.githubusercontent.com/bropat/ioBroker.eusec/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/bropat/ioBroker.eusec/master/admin/eusec.png",
     "type": "alarm",
-    "version": "0.8.2"
+    "version": "0.8.3"
   },
   "exchangerates": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.exchangerates/master/io-package.json",

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -425,8 +425,8 @@
     "type": "hardware"
   },
   "eusec": {
-    "meta": "https://raw.githubusercontent.com/bropat/ioBroker.euSec/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/bropat/ioBroker.euSec/master/admin/euSec.png",
+    "meta": "https://raw.githubusercontent.com/bropat/ioBroker.eusec/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/bropat/ioBroker.eusec/master/admin/eusec.png",
     "type": "alarm"
   },
   "eventlist": {


### PR DESCRIPTION
* Renamed euSec Repository to eusec as requested (followed issue https://github.com/bropat/ioBroker.eusec/issues/225)
* Incremented stable version to latest (0.8.3)