### PR TITLE
### 1.1.7 (13.02.2022)

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -573,7 +573,7 @@
     "meta": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/admin/growatt.png",
     "type": "energy",
-    "version": "1.1.1"
+    "version": "1.1.7"
   },
   "gruenbeck": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.gruenbeck/master/io-package.json",


### PR DESCRIPTION
* (PLCHome) "Sentry" was added
* (PLCHome) Timeouts made maintainable and adjusted. Request timout is now 60 second like chrome
* (PLCHome) Server request improved and additionally secured against dying
* (PLCHome) Calculate sleep to next request to keep cycle. Minimum sleep is 100ms
* (PLCHome) Error output: if the key has expired, requests are forwarded with an error code, which is now in the log
* (PLCHome) Improved error handling
* (PLCHome) Improved debugging
* (PLCHome) Update the includes