### PR TITLE
bumb lovelace to 2.1.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1040,7 +1040,7 @@
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.lovelace/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.lovelace/master/admin/lovelace.png",
     "type": "visualization",
-    "version": "2.0.6"
+    "version": "2.1.4"
   },
   "loxone": {
     "meta": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.loxone/master/io-package.json",


### PR DESCRIPTION
Update Lovelace to 2.1.4

2.1.4 is in latest for > 30 days now and not a lot of reports did come in. 
2.1.4 fixes some bugs and updates frontend to December release.