### PR TITLE
bumped kostal-piko-ba to 1.4.2 in stable repo

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -932,7 +932,7 @@
     "meta": "https://raw.githubusercontent.com/hombach/ioBroker.kostal-piko-ba/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/hombach/ioBroker.kostal-piko-ba/master/admin/picoba.png",
     "type": "energy",
-    "version": "1.2.1"
+    "version": "1.4.2"
   },
   "lametric": {
     "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.lametric/master/io-package.json",


### PR DESCRIPTION
bumped kostal-piko-ba to 1.4.2 in stable repo

Kostal issue: [https://github.com/hombach/ioBroker.kostal-piko-ba/issues/269](url)