### PR TITLE
bumped dyson adapter to 2.4.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -363,7 +363,7 @@
     "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.dysonairpurifier/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.dysonairpurifier/master/admin/dyson_logo.svg",
     "type": "climate-control",
-    "version": "2.3.2"
+    "version": "2.4.1"
   },
   "e3dc-rscp": {
     "meta": "https://raw.githubusercontent.com/git-kick/ioBroker.e3dc-rscp/master/io-package.json",


### PR DESCRIPTION
### V2.4.1 (2022-03-20) (Echo from the past)
* (grizzelbee) New: Changed SystemState from text to boolean data points

### V2.4.0 (2022-03-17) (Echo from the past)
* (grizzelbee) New: Added warning code to device tree
* (grizzelbee) New: Added Device-faults as SystemState to device tree
* (grizzelbee) New: Added donate button to readme and config page
* (grizzelbee) Upd: Switched "Sending data to device" message from loglevel info to debug
* (grizzelbee) Upd: reduced amount of debug messages
* (grizzelbee) Upd: Updated dependencies