### PR TITLE
Update tahoma to 0.6.1 (stable)

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1940,7 +1940,7 @@
     "meta": "https://raw.githubusercontent.com/Excodibur/ioBroker.tahoma/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Excodibur/ioBroker.tahoma/master/admin/tahoma.png",
     "type": "iot-systems",
-    "version": "0.5.2"
+    "version": "0.6.1"
   },
   "tankerkoenig": {
     "meta": "https://raw.githubusercontent.com/Pix---/ioBroker.tankerkoenig/master/io-package.json",


### PR DESCRIPTION
Increased tahoma to 0.6.1 (new features & bugfixes)

The fixes were tested [here](https://github.com/Excodibur/ioBroker.tahoma/issues/109) and a required also for the stable version of the adapter.