### PR TITLE
ioBroker.growatt ### 1.1.12 (06.04.2022)

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -603,7 +603,7 @@
     "meta": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/admin/growatt.png",
     "type": "energy",
-    "version": "1.1.9"
+    "version": "1.1.12"
   },
   "gruenbeck": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.gruenbeck/master/io-package.json",


### PR DESCRIPTION
- (PLCHome) api maintance
- (PLCHome) fixed readme
- (PLCHome) fixed version
- (PLCHome) suppressed the warning for the Firsttime: /error.do?errorMess=errorNoLogin