### PR TITLE
Adapter snmp - upgrade stable to v1.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1808,7 +1808,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snmp/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snmp/master/admin/snmp.png",
     "type": "infrastructure",
-    "version": "0.5.0"
+    "version": "1.0.0"
   },
   "socketio": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.socketio/master/io-package.json",


### PR DESCRIPTION
According to issue  https://github.com/iobroker-community-adapters/ioBroker.snmp/issues/107:

Version: stable=0.5.0 (1582 days old) => latest=1.0.0 (15 days old)
Installs: stable=1637 (85.62%), latest=271 (14.17%), total=1912

I did not receive any problem reports. There are now open sentry issues. 
Please consider releasing v1.0.0 to stable repository.