### PR TITLE
Bitte erhöhen Sie die stable Version von Sprinkle Control auf 0.2.9

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1874,7 +1874,7 @@
     "meta": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/admin/sprinklecontrol.png",
     "type": "garden",
-    "version": "0.2.7"
+    "version": "0.2.9"
   },
   "sql": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.sql/master/io-package.json",

--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1366,6 +1366,12 @@
     "type": "multimedia",
     "version": "1.0.0"
   },
+  "sprinklecontrol": {
+    "meta": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/admin/sprinklecontrol.png",
+    "type": "garden",
+    "version": "0.1.7"
+  },
   "sql": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.sql/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.sql/master/admin/sql.png",

--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1370,7 +1370,7 @@
     "meta": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/admin/sprinklecontrol.png",
     "type": "garden",
-    "version": "0.1.7"
+    "version": "0.2.7"
   },
   "sql": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.sql/master/io-package.json",


### PR DESCRIPTION
- Fehlermeldungen von js-controller 4.0 behoben
- keine Fehlermeldungen im beta-Test