### PR TITLE
Update ems-esp to 1.11.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -423,7 +423,7 @@
     "meta": "https://raw.githubusercontent.com/tp1de/ioBroker.ems-esp/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/tp1de/ioBroker.ems-esp/main/admin/ems-esp.png",
     "type": "climate-control",
-    "version": "1.4.0"
+    "version": "1.11.2"
   },
   "energymanager": {
     "meta": "https://raw.githubusercontent.com/unltdnetworx/ioBroker.energymanager/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.ems-esp to version 1.11.2.

*This pull request was created by https://www.iobroker.dev 79ffd9b.*