### PR TITLE
Add discord to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -324,6 +324,11 @@
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.digitalstrom/master/admin/digitalstrom.png",
     "type": "iot-systems"
   },
+  "discord": {
+    "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.discord/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.discord/main/admin/discord.png",
+    "type": "messaging"
+  },
   "discovergy": {
     "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.discovergy/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.discovergy/main/admin/discovergy.png",


### PR DESCRIPTION
Repo: https://github.com/crycode-de/ioBroker.discord

Adapter Request: https://github.com/ioBroker/AdapterRequests/issues/322

Channel on ioBroker Discord server: [`#discord`](https://discord.gg/ZdkzZvKwmD)

Forum testing thread: https://forum.iobroker.net/topic/54928/test-adapter-discord-v1-0-x

_Note:_ Node.js >= 16.9 is required for this adapter, since it a requirement of the used discord.js library.