### PR TITLE
BugFix: Update wled to 0.6.7

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2408,7 +2408,7 @@
     "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.wled/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.wled/main/admin/wled.png",
     "type": "lighting",
-    "version": "0.6.3"
+    "version": "0.6.7"
   },
   "wmswebcontrol": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.wmswebcontrol/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.wled to version 0.6.7.

*This pull request was created by https://www.iobroker.dev 79ffd9b.*