### PR TITLE
Ico

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -791,6 +791,12 @@
     "type": "date-and-time",
     "version": "1.12.1"
   },
+  "ico-cloud": {
+    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ico-cloud/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ico-cloud/main/admin/ico-cloud.png",
+    "type": "metering",
+    "version": "1.0.0"
+  },
   "icons-addictive-flavour-png": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-addictive-flavour-png/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-addictive-flavour-png/master/admin/icons-addictive-flavour-png.png",

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -801,7 +801,7 @@
   },
   "ico-cloud": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ico-cloud/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ico-cloud/master/admin/ico-cloud.png",
+    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ico-cloud/main/admin/ico-cloud.png",
     "type": "metering"
   },
   "icons-addictive-flavour-png": {


### PR DESCRIPTION
Add [ico-cloud](https://github.com/iobroker-community-adapters/ioBroker.ico-cloud)1.0.0 to stable. The original version has been in latest for over a year. I made some changes and made it a schedule adapter. This transition seems quite smooth. 

Feel free to re-review, main changes are in this commit: https://github.com/iobroker-community-adapters/ioBroker.ico-cloud/commit/4d01ee64a7f28f9aa9ddc3469116877840cbda2f

