### PR TITLE
Update epson_ecotank_et_2750 to 0.0.12

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -447,7 +447,7 @@
     "meta": "https://raw.githubusercontent.com/o0shojo0o/ioBroker.epson_ecotank_et_2750/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/o0shojo0o/ioBroker.epson_ecotank_et_2750/master/admin/epson_ecotank_et_2750.png",
     "type": "infrastructure",
-    "version": "0.0.11"
+    "version": "0.0.12"
   },
   "epson_stylus_px830": {
     "meta": "https://raw.githubusercontent.com/Pix---/ioBroker.epson_stylus_px830/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.epson_ecotank_et_2750 to version 0.0.12.

*This pull request was created by https://www.iobroker.dev 79ffd9b.*