### PR TITLE
Add discord v1.1.4 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -329,6 +329,12 @@
     "type": "iot-systems",
     "version": "2.3.0"
   },
+  "discord": {
+    "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.discord/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.discord/main/admin/discord.png",
+    "type": "messaging",
+    "version": "1.1.4"
+  },
   "discovergy": {
     "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.discovergy/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.discovergy/main/admin/discovergy.png",


### PR DESCRIPTION
Tested by some users. Seems to be stable now.

Repo: https://github.com/crycode-de/ioBroker.discord

Forum test thread: https://forum.iobroker.net/topic/54928/test-adapter-discord-v1-1-x
