### PR TITLE
Update janitza-gridvis to 2.1.17

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -911,6 +911,12 @@
     "type": "network",
     "version": "0.10.7"
   },
+  "janitza-gridvis": {
+    "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.janitza-gridvis/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.janitza-gridvis/main/admin/janitza-gridvis.png",
+    "type": "energy",
+    "version": "2.1.17"
+  },
   "jarvis": {
     "meta": "https://raw.githubusercontent.com/Zefau/ioBroker.jarvis/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Zefau/ioBroker.jarvis/master/admin/jarvis.png",


### PR DESCRIPTION
Please update my adapter ioBroker.janitza-gridvis to version 2.1.17.

*This pull request was created by https://www.iobroker.dev 79ffd9b.*