### PR TITLE
Update lowpass-filter to 2.0.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1090,6 +1090,12 @@
     "type": "visualization",
     "version": "2.2.0"
   },
+  "lowpass-filter": {
+    "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lowpass-filter/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lowpass-filter/main/admin/lowpass-filter.png",
+    "type": "misc-data",
+    "version": "2.0.5"
+  },
   "loxone": {
     "meta": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.loxone/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.loxone/master/admin/loxone.png",


### PR DESCRIPTION
Please update my adapter ioBroker.lowpass-filter to version 2.0.5.

*This pull request was created by https://www.iobroker.dev 79ffd9b.*