### PR TITLE
Update janitza-gridvis to 2.1.19

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -948,7 +948,7 @@
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.janitza-gridvis/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.janitza-gridvis/main/admin/janitza-gridvis.png",
     "type": "energy",
-    "version": "2.1.17"
+    "version": "2.1.19"
   },
   "jarvis": {
     "meta": "https://raw.githubusercontent.com/Zefau/ioBroker.jarvis/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.janitza-gridvis to version 2.1.19.

I just removed some loggings (log.info)

*This pull request was created by https://www.iobroker.dev 79ffd9b.*