### PR TITLE
Update drag-indicator to 2.0.9

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -390,7 +390,7 @@
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.drag-indicator/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.drag-indicator/main/admin/drag-indicator.png",
     "type": "misc-data",
-    "version": "2.0.6"
+    "version": "2.0.9"
   },
   "ds18b20": {
     "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.ds18b20/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.drag-indicator to version 2.0.9.

cronjob type for config changed.

*This pull request was created by https://www.iobroker.dev 79ffd9b.*