### PR TITLE
Update snmp to 2.1.7

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1925,7 +1925,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snmp/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snmp/master/admin/snmp.png",
     "type": "infrastructure",
-    "version": "1.0.0"
+    "version": "2.1.7"
   },
   "socketio": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.socketio/master/io-package.json",


### PR DESCRIPTION
Please consider releasing ioBroker.snmp 2.1.7 to stable repository.

Test-Thread at Forum: https://forum.iobroker.net/topic/56816/test-adapter-snmp-v2-1-x-github-lastest/10
no open issues (except feature requests)
2.1.7 released 2022-08-27 - contains ONLY docu changes
2.1.6 released 2022-08-19 - contains 2 fixes reported by sentry
2.1.5 released 2022-08-11 - newest release with "real" fixes

Currently installed: app. 200 systems wit 2.1.6 and newer
![image](https://user-images.githubusercontent.com/28575778/187274852-3eae4a73-8181-48d5-a1e1-a7c5daa8a0d0.png)
