### PR TITLE
Update snmp to 2.1.8

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1931,7 +1931,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snmp/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snmp/master/admin/snmp.png",
     "type": "infrastructure",
-    "version": "2.1.7"
+    "version": "2.1.8"
   },
   "socketio": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.socketio/master/io-package.json",


### PR DESCRIPTION
Note: v2.1.8 is a hotfix correcting one bug in migration code only.

https://github.com/iobroker-community-adapters/ioBroker.snmp/commits/master 

Related issue: https://github.com/iobroker-community-adapters/ioBroker.snmp/issues/163

v1.2.8 is in latest only for short time, but 79 installations without issues seem to justify a fast update at stable from 2.1.7 to 2.1.8 to avoid further incomplete migrations for existings users. Code has been corrected only inside one-time migration are at one place.