### PR TITLE
Update snmp to 2.1.10

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1949,7 +1949,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snmp/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snmp/master/admin/snmp.png",
     "type": "infrastructure",
-    "version": "2.1.8"
+    "version": "2.1.10"
   },
   "socketio": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.socketio/master/io-package.json",


### PR DESCRIPTION
snmp 2.1.10 is published at lastest since 22.9.
currently 206 installations (from latest)
no open Issues or Sentries

Think its ready for rollout (so that latest gets free for thenext improvements)