### PR TITLE
New location of smartcontrol

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1958,8 +1958,8 @@
     "version": "0.0.3"
   },
   "smartcontrol": {
-    "meta": "https://raw.githubusercontent.com/Mic-M/ioBroker.smartcontrol/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Mic-M/ioBroker.smartcontrol/master/admin/smartcontrol.png",
+    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.smartcontrol/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.smartcontrol/master/admin/smartcontrol.png",
     "type": "logic",
     "version": "1.2.1"
   },

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1903,8 +1903,8 @@
     "type": "vehicle"
   },
   "smartcontrol": {
-    "meta": "https://raw.githubusercontent.com/Mic-M/ioBroker.smartcontrol/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Mic-M/ioBroker.smartcontrol/master/admin/smartcontrol.png",
+    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.smartcontrol/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.smartcontrol/master/admin/smartcontrol.png",
     "type": "logic"
   },
   "smartgarden": {


### PR DESCRIPTION
[E405] Icon must be in the following path: https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.smartcontrol/master/
[E407] Meta URL (latest) must be equal to https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.smartcontrol/master/io-package.json
[E426] Icon (stable) must be in the following path: https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.smartcontrol/master/
[E428] Meta URL (stable) must be equal to https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.smartcontrol/master/io-package.json