### PR TITLE
set janitza-gridvis 2.1.23 into stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -984,7 +984,7 @@
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.janitza-gridvis/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.janitza-gridvis/main/admin/janitza-gridvis.png",
     "type": "energy",
-    "version": "2.1.22"
+    "version": "2.1.23"
   },
   "jarvis": {
     "meta": "https://raw.githubusercontent.com/Zefau/ioBroker.jarvis/master/io-package.json",


### PR DESCRIPTION
warning (logging) for axios response 404 implemented. tested => works fine.
User need this information in case of error directly. Otherwise the reading of data will be blocked.