### PR TITLE
Move tankerkoenig from misc-data to "vehicle" type

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2152,7 +2152,7 @@
   "tankerkoenig": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tankerkoenig/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tankerkoenig/master/admin/tankerkoenig.png",
-    "type": "misc-data",
+    "type": "vehicle",
     "version": "2.1.1"
   },
   "tapo": {

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2110,7 +2110,7 @@
   "tankerkoenig": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tankerkoenig/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tankerkoenig/master/admin/tankerkoenig.png",
-    "type": "misc-data"
+    "type": "vehicle"
   },
   "tapo": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.tapo/master/io-package.json",


### PR DESCRIPTION
Hello @Apollon77 I noticed that in the json schema the type `vehicle` is missing

```json
        "type": {
          "description": "Type of the adapter",
          "type": "string",
          "enum": [
            "alarm",
            "climate-control",
            "communication",
            "date-and-time",
            "energy",
            "metering",
            "garden",
            "general",
            "geoposition",
            "hardware",
            "health",
            "household",
            "infrastructure",
            "iot-systems",
            "lighting",
            "logic",
            "messaging",
            "misc-data",
            "multimedia",
            "network",
            "protocols",
            "storage",
            "utility",
            "visualization",
            "visualization-icons",
            "visualization-widgets",
            "weather"
          ]
```