### PR TITLE
Bump synology to 1.2.13

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2129,7 +2129,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.synology/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.synology/master/admin/synology.png",
     "type": "infrastructure",
-    "version": "2.1.9"
+    "version": "2.1.13"
   },
   "systeminfo": {
     "meta": "https://raw.githubusercontent.com/frankjoke/ioBroker.systeminfo/master/io-package.json",


### PR DESCRIPTION
Release 2.1.13 has been released at lates since 6.11.2022 currently app 400 lates installs
no syntries
no new issued which seem to be related to changes in 2.1.13 (ssh password handling)

Think this release is ready for stable