### PR TITLE
Bump snmp to 2.2.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2009,7 +2009,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snmp/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snmp/master/admin/snmp.png",
     "type": "infrastructure",
-    "version": "2.1.10"
+    "version": "2.2.1"
   },
   "socketio": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.socketio/master/io-package.json",


### PR DESCRIPTION
release 2.2.1 has been available at stable since 19.10. app 245 installs from latest currently
no sentries
no open bug issues execept one problem with pure binary data which will be fixed with 2.3.x

I think the release is ready to go public