### PR TITLE
add nsclient 0.1.2 to stable 

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1491,7 +1491,7 @@
   },
   "nsclient": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.nsclient/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.nsclient/master/admin/snmp.png",
+    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.nsclient/master/admin/nsclient.png",
     "type": "infrastructure",
     "version": "0.1.2"
   },

--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1489,6 +1489,12 @@
     "type": "logic",
     "version": "4.0.0"
   },
+  "nsclient": {
+    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.nsclient/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.nsclient/master/admin/snmp.png",
+    "type": "infrastructure",
+    "version": "0.1.2"
+  },
   "nuki": {
     "meta": "https://raw.githubusercontent.com/smaragdschlange/ioBroker.nuki/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/smaragdschlange/ioBroker.nuki/master/admin/nuki-logo.png",


### PR DESCRIPTION
nsclient 0.1.1 was provieded at lastes since several weeks without logged issues
nscleint 0.1.2 added sentry support without any errors logged so far 