### PR TITLE
hikvision-alarmserver now stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -770,6 +770,12 @@
     "type": "utility",
     "version": "0.1.17"
   },
+  "hikvision-alarmserver": {
+    "meta": "https://raw.githubusercontent.com/raintonr/ioBroker.hikvision-alarmserver/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/raintonr/ioBroker.hikvision-alarmserver/main/admin/hikvision-alarmserver.png",
+    "type": "alarm",
+    "version": "v0.0.6"
+  },
   "history": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.history/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.history/master/admin/history.png",

--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -774,7 +774,7 @@
     "meta": "https://raw.githubusercontent.com/raintonr/ioBroker.hikvision-alarmserver/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/raintonr/ioBroker.hikvision-alarmserver/main/admin/hikvision-alarmserver.png",
     "type": "alarm",
-    "version": "v0.0.6"
+    "version": "0.0.6"
   },
   "history": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.history/master/io-package.json",

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -755,7 +755,7 @@
     "type": "utility"
   },
   "hikvision-alarmserver": {
-    "meta": "https://raw.githubusercontent.com/raintonr/ioBroker.hikvision-alarmserver/master/io-package.json",
+    "meta": "https://raw.githubusercontent.com/raintonr/ioBroker.hikvision-alarmserver/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/raintonr/ioBroker.hikvision-alarmserver/main/admin/hikvision-alarmserver.png",
     "type": "alarm"
   },


### PR DESCRIPTION
FWIW, added manually as `npm run addToStable -- --name hikvision-alarmserver --version v0.0.6` did nothing.

Also fixed master/main naming snafu.