### PR TITLE
Update stable version of ecovacs-deebot to 1.4.8

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -450,7 +450,7 @@
     "meta": "https://raw.githubusercontent.com/mrbungle64/ioBroker.ecovacs-deebot/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/mrbungle64/ioBroker.ecovacs-deebot/master/admin/ecovacs-deebot.png",
     "type": "household",
-    "version": "1.4.4"
+    "version": "1.4.8"
   },
   "egigeozone": {
     "meta": "https://raw.githubusercontent.com/BasGo/ioBroker.egigeozone/master/io-package.json",


### PR DESCRIPTION
This version was released on Nov 12, 2022

Thanks :)