### PR TITLE
Add new Stable-Version for swiss-weather-api

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2135,7 +2135,7 @@
     "meta": "https://raw.githubusercontent.com/baerengraben/ioBroker.swiss-weather-api/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/baerengraben/ioBroker.swiss-weather-api/master/admin/swiss-weather-api.png",
     "type": "weather",
-    "version": "1.0.4"
+    "version": "1.0.5"
   },
   "synochat": {
     "meta": "https://raw.githubusercontent.com/phoeluga/ioBroker.synochat/master/io-package.json",


### PR DESCRIPTION
Bugfix-Version 1.0.5 is stable now. This Version fixes: https://github.com/baerengraben/ioBroker.swiss-weather-api/issues/81 https://github.com/baerengraben/ioBroker.swiss-weather-api/issues/76 https://github.com/baerengraben/ioBroker.swiss-weather-api/issues/75