### PR TITLE
Update tankerkoenig to 3.3.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2201,7 +2201,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tankerkoenig/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tankerkoenig/master/admin/tankerkoenig.png",
     "type": "vehicle",
-    "version": "3.1.0"
+    "version": "3.3.6"
   },
   "tapo": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.tapo/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.tankerkoenig to version 3.3.6.

*This pull request was created by https://www.iobroker.dev 2fef783.*