### PR TITLE
Add alpha-ess v0.2.0 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -80,6 +80,12 @@
     "type": "general",
     "version": "1.2.4"
   },
+  "alpha-ess": {
+    "meta": "https://raw.githubusercontent.com/Gaspode69/ioBroker.alpha-ess/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Gaspode69/ioBroker.alpha-ess/main/admin/alpha-ess.png",
+    "type": "energy",
+    "version": "0.2.0"
+  },
   "alpha2": {
     "meta": "https://raw.githubusercontent.com/Eisbaeeer/ioBroker.alpha2/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Eisbaeeer/ioBroker.alpha2/master/admin/mh-logo.png",

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -59,6 +59,11 @@
     "icon": "https://raw.githubusercontent.com/sbormann/ioBroker.alias-manager/master/admin/alias-manager.png",
     "type": "general"
   },
+  "alpha-ess": {
+    "meta": "https://raw.githubusercontent.com/Gaspode69/ioBroker.alpha-ess/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Gaspode69/ioBroker.alpha-ess/main/admin/alpha-ess.png",
+    "type": "energy"
+  },
   "alpha2": {
     "meta": "https://raw.githubusercontent.com/Eisbaeeer/ioBroker.alpha2/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Eisbaeeer/ioBroker.alpha2/master/admin/mh-logo.png",


### PR DESCRIPTION
The group of potential users for this adapter is pretty small. Currently, I have no feedback that something doesn't work as expected and feedback from a small amount of users that the adapter works as expected.
I plan to go on with development and to offer to write several configuration settings to the cloud API soon.
I would be happy if you accept version 0.2.0 as stable to be able to use the latest repository for Beta testing of the new functionality.
Thanks
Gaspode