### PR TITLE
bumped kostal-piko-ba stable to 2.3.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1127,7 +1127,7 @@
     "meta": "https://raw.githubusercontent.com/hombach/ioBroker.kostal-piko-ba/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/hombach/ioBroker.kostal-piko-ba/master/admin/picoba.png",
     "type": "energy",
-    "version": "2.2.2"
+    "version": "2.3.1"
   },
   "lametric": {
     "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.lametric/master/io-package.json",


### PR DESCRIPTION
fix error with zero values in DC & AC
replaced got by axios
added warning for not supported Piko MP inverters
removed travis