### PR TITLE
Update ems-esp to 1.26.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -510,7 +510,7 @@
     "meta": "https://raw.githubusercontent.com/tp1de/ioBroker.ems-esp/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/tp1de/ioBroker.ems-esp/main/admin/ems-esp.png",
     "type": "climate-control",
-    "version": "1.21.0"
+    "version": "1.26.0"
   },
   "energymanager": {
     "meta": "https://raw.githubusercontent.com/unltdnetworx/ioBroker.energymanager/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.ems-esp to version 1.26.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*