### PR TITLE
Update stable version of ecovacs-deebot to 1.4.13

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -480,7 +480,7 @@
     "meta": "https://raw.githubusercontent.com/mrbungle64/ioBroker.ecovacs-deebot/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/mrbungle64/ioBroker.ecovacs-deebot/master/admin/ecovacs-deebot.png",
     "type": "household",
-    "version": "1.4.11"
+    "version": "1.4.13"
   },
   "egigeozone": {
     "meta": "https://raw.githubusercontent.com/BasGo/ioBroker.egigeozone/master/io-package.json",


### PR DESCRIPTION
This version was released on 25.02.2023.
No issues have been reported to date.

Thanks :)