### PR TITLE
Add fully-mqtt to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -649,6 +649,11 @@
     "icon": "https://raw.githubusercontent.com/arteck/ioBroker.fullybrowser/master/admin/fully.png",
     "type": "utility"
   },
+  "fully-mqtt": {
+    "meta": "https://raw.githubusercontent.com/Acgua/ioBroker.fully-mqtt/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Acgua/ioBroker.fully-mqtt/master/admin/fully-mqtt.png",
+    "type": "multimedia"
+  },
   "g-homa": {
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.g-homa/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.g-homa/master/admin/g-homa.png",


### PR DESCRIPTION
Please add https://github.com/Acgua/ioBroker.fully-mqtt to latest.

Following error will appear when executing adapter check:
> [E201] Bluefox was not found in the collaborators on NPM!. Please execute in adapter directory: "npm owner add bluefox iobroker.fully-mqtt"

I have executed the command, but invite has not yet been confirmed by bluefox.