### PR TITLE
Bump SNMP to 2.4.5 (stable) hotfix

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2123,7 +2123,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snmp/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snmp/master/admin/snmp.png",
     "type": "infrastructure",
-    "version": "2.4.4"
+    "version": "2.4.5"
   },
   "socketio": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.socketio/master/io-package.json",


### PR DESCRIPTION
Hotfix as SHA authentication was not working due to incorrect case in constants. See https://github.com/iobroker-community-adapters/ioBroker.snmp/issues/236