### PR TITLE
bump kostal-piko-ba to 2.4.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1127,7 +1127,7 @@
     "meta": "https://raw.githubusercontent.com/hombach/ioBroker.kostal-piko-ba/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/hombach/ioBroker.kostal-piko-ba/master/admin/picoba.png",
     "type": "energy",
-    "version": "2.4.5"
+    "version": "2.4.6"
   },
   "lametric": {
     "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.lametric/master/io-package.json",


### PR DESCRIPTION
fixed vulnerability in xml2js