### PR TITLE
Update mielecloudservice to 6.5.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1397,7 +1397,7 @@
     "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.mielecloudservice/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.mielecloudservice/master/admin/mielecloudservice.svg",
     "type": "household",
-    "version": "6.4.0"
+    "version": "6.5.2"
   },
   "mihome": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.mihome/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.mielecloudservice to version 6.5.2.

*This pull request was created by https://www.iobroker.dev c0726ff.*