### PR TITLE
Update info to 1.9.26

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1014,7 +1014,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.info/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.info/master/admin/info.png",
     "type": "misc-data",
-    "version": "1.9.19"
+    "version": "1.9.26"
   },
   "innogy-smarthome": {
     "meta": "https://raw.githubusercontent.com/PArns/ioBroker.innogy-smarthome/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.info to version 1.9.26.

*This pull request was created by https://www.iobroker.dev c0726ff.*

Releae was active as latest since 3.2.2023, no issues reported