### PR TITLE
Bump accuweather to 1.2.4 (stable)

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -18,7 +18,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.accuweather/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.accuweather/master/admin/accuweather.png",
     "type": "weather",
-    "version": "1.2.1"
+    "version": "1.2.4"
   },
   "adb": {
     "meta": "https://raw.githubusercontent.com/om2804/ioBroker.adb/master/io-package.json",


### PR DESCRIPTION
1.2.4 is at latest since 10.02.2022
no issues

closes https://github.com/iobroker-community-adapters/ioBroker.accuweather/issues/165