### PR TITLE
Update solarlog to 2.2.6 (stable)

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2135,7 +2135,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solarlog/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solarlog/master/admin/solarlog.png",
     "type": "energy",
-    "version": "2.2.5"
+    "version": "2.2.6"
   },
   "solarmanpv": {
     "meta": "https://raw.githubusercontent.com/raschy/ioBroker.solarmanpv/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.solarlog to version 2.2.6.

*This pull request was created by https://www.iobroker.dev c0726ff.*