### PR TITLE
check.js - add reordering support (2nd try)

### DIFF
--- a/lib/check.js
+++ b/lib/check.js
@@ -74,12 +74,13 @@ async function detectChanges(commit) {
     const patch = commit.patch.split('@@').map(t => t.trim()).filter(t => t);
     if (commit.changes > 75) { /* Mcm1957: limit changed from 25 to 75. Resorting might create a bigger number of changed lines */
         console.log('Too many changes in this commit. Stop analysis.');
-        console.log(`Check ${commit.raw_url}.`);
+        console.log(`Check commit\n${JSON.stringify(commit)}`);
         return [];
     }
 
     json = json.split('\n');
-    const adapters = [];
+    let adapters = [];
+    const deleteds = [];
     let totalOffset = 0;
     for (let i = 0; i < patch.length; i += 2) {
         const changes = patch[i];
@@ -87,9 +88,9 @@ async function detectChanges(commit) {
         const added = lines
             .filter(line => line.match(/^\+\s*"[-_a-z\d]+"\s*:\s*{$/))
             .map(line => line.match(/^\+\s*"([-_a-z\d]+)"\s*:\s*{$/)[1]);
-        //const deleted = lines
-        //    .filter(line => line.match(/^\-\s*"[-_a-z\d]+"\s*:\s*{$/))
-        //    .map(line => line.match(/^\-\s*"([-_a-z\d]+)"\s*:\s*{$/)[1]);
+        const deleted = lines
+            .filter(line => line.match(/^\-\s*"[-_a-z\d]+"\s*:\s*{$/))
+            .map(line => line.match(/^\-\s*"([-_a-z\d]+)"\s*:\s*{$/)[1]);
 
         let found = false;
         let offset = 0;
@@ -125,20 +126,20 @@ async function detectChanges(commit) {
             }
         }
 
-        //console.log('added:');
-        //added.forEach(a => console.log(a));
-        //console.log('---');
-        //console.log('deleted:');
-        //deleted.forEach(a => console.log(a));
-        //console.log('---');
-              
         added.forEach(a => !adapters.includes(a) && adapters.push(a));
-        //added.forEach(a => !deleted.includes(a) && !adapters.includes(a) && adapters.push(a));
+        deleted.forEach(a => !deleteds.includes(a) && deleteds.push(a));
 
-        //console.log('adapters:');
-        //adapters.forEach(a => console.log(a));
-        //console.log('---');
     }
+
+    //console.log('adapters before filtering:');
+    //adapters.forEach(a => console.log(a));
+    //console.log('---');
+
+    adapters = adapters.filter(a => !deleteds.includes(a));
+    
+    console.log('adapters filtered:');
+    adapters.forEach(a => console.log(a));
+    console.log('---');
 
     const repo = JSON.parse(json.join('\n'));
 
@@ -360,7 +361,9 @@ async function doIt() {
     return 'done';
 }
 
-// process.env.GITHUB_REF = 'refs/pull/1923/merge';
+// activate for debugging purposes
+//process.env.GITHUB_REF = 'refs/pull/2298/merge';
+//process.env.OWN_GITHUB_TOKEN = 'add-token-here';
 // process.env.GITHUB_EVENT_PATH = __dirname + '/../event.json';
 
 console.log(`process.env.GITHUB_REF        = ${process.env.GITHUB_REF}`);


### PR DESCRIPTION
This PR adapts lib/check.js. removed adapters are now recorded and filtered from added ones. This way reordering does no longer add aditional adapters to checks.