### PR TITLE
Update sources-dist-stable.json

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2249,7 +2249,7 @@
     "meta": "https://raw.githubusercontent.com/Sickboy78/ioBroker.sureflap/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Sickboy78/ioBroker.sureflap/master/admin/sureflap.png",
     "type": "iot-systems",
-    "version": "1.1.5"
+    "version": "1.1.8"
   },
   "swiss-weather-api": {
     "meta": "https://raw.githubusercontent.com/baerengraben/ioBroker.swiss-weather-api/master/io-package.json",


### PR DESCRIPTION
sureflap
v1.1.7 has been tested vor several weeks and is stable
v1.1.8 fixes critical issue for changes in external API as of 01.06.2023