### PR TITLE
added atlas-scientific-ezo-i2c Adapter

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -134,11 +134,6 @@
     "type": "hardware",
     "version": "1.0.1"
   },
-  "atlas-scientific-ezo-i2c": {
-    "meta": "https://raw.githubusercontent.com/Buzze11/ioBroker.atlas-scientific-ezo-i2c/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Buzze11/ioBroker.atlas-scientific-ezo-i2c/master/admin/atlas-scientific-ezo-i2c.png",
-    "type": "metering"
-  },
   "awattar": {
     "meta": "https://raw.githubusercontent.com/sirjojo69/ioBroker.awattar/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/sirjojo69/ioBroker.awattar/master/admin/awattar.png",

--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -134,6 +134,11 @@
     "type": "hardware",
     "version": "1.0.1"
   },
+  "atlas-scientific-ezo-i2c": {
+    "meta": "https://raw.githubusercontent.com/Buzze11/ioBroker.atlas-scientific-ezo-i2c/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Buzze11/ioBroker.atlas-scientific-ezo-i2c/master/admin/atlas-scientific-ezo-i2c.png",
+    "type": "metering"
+  },
   "awattar": {
     "meta": "https://raw.githubusercontent.com/sirjojo69/ioBroker.awattar/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/sirjojo69/ioBroker.awattar/master/admin/awattar.png",

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -114,6 +114,11 @@
     "icon": "https://raw.githubusercontent.com/mcdhrts/ioBroker.asuswrt/master/admin/asuswrt.png",
     "type": "hardware"
   },
+  "atlas-scientific-ezo-i2c": {
+    "meta": "https://raw.githubusercontent.com/Buzze11/ioBroker.atlas-scientific-ezo-i2c/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Buzze11/ioBroker.atlas-scientific-ezo-i2c/master/admin/atlas-scientific-ezo-i2c.png",
+    "type": "metering"
+  },
   "awattar": {
     "meta": "https://raw.githubusercontent.com/sirjojo69/ioBroker.awattar/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/sirjojo69/ioBroker.awattar/master/admin/awattar.png",


### PR DESCRIPTION
Hi, 
unfortunately the UI in ioBroker-dev for adding to latests fails even though the adapter check is running fine.

The commandline addToLatest throws an error:

> iobroker.repositories@1.0.4 addToLatest
> node lib/scripts.js addToLatest --name atlas-scientific-ezo-i2c --type metering

ERROR: Unsupported protocol ssh:

So I`ve added my adapter manually to the source-dist-stable.json and source-dist.json
Hope that works out. 
 
Best regards
Thomas