### PR TITLE
Intex 0.1.0 in service as a collaborator for TA2k

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1038,7 +1038,7 @@
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.intex/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.intex/master/admin/intex.png",
     "type": "household",
-    "version": "0.0.7"
+    "version": "0.1.0"
   },
   "iogopro": {
     "meta": "https://raw.githubusercontent.com/nisiode/ioBroker.iogopro/master/io-package.json",


### PR DESCRIPTION
The stable adapter is currently no longer usable due to the slow cloud from Intex. There is no connection anymore. 
This update uses a local connection and enables operation. 
