### PR TITLE
Dump SCHEDULER to 1.1.9 (ioBroker orga)

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2045,7 +2045,7 @@
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.scheduler/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.scheduler/master/admin/scheduler.png",
     "type": "logic",
-    "version": "1.1.7"
+    "version": "1.1.9"
   },
   "schoolfree": {
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.schoolfree/master/io-package.json",


### PR DESCRIPTION
Version: stable=1.1.7 (111 days old) => latest=1.1.9 (15 days old)
Installs: stable=158 (40.51%), latest=82 (21.03%), total=390

@Apollon77 