### PR TITLE
bump BLE to 0.13.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -198,7 +198,7 @@
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.ble/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.ble/master/admin/ble.png",
     "type": "hardware",
-    "version": "0.13.0"
+    "version": "0.13.4"
   },
   "blebox": {
     "meta": "https://raw.githubusercontent.com/ka-vaNu/ioBroker.blebox/master/io-package.json",


### PR DESCRIPTION
The feedback seems to indicate that the latest `noble` version is finally working, so we can mark this as stable now.