### PR TITLE
Add opendtu (0.1.7) to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1705,6 +1705,12 @@
     "type": "infrastructure",
     "version": "1.0.5"
   },
+  "opendtu": {
+    "meta": "https://raw.githubusercontent.com/o0shojo0o/ioBroker.opendtu/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/o0shojo0o/ioBroker.opendtu/main/admin/opendtu.png",
+    "type": "energy",
+    "version": "0.1.7"
+  },
   "openhab": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.openhab/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.openhab/master/admin/openhab.png",


### PR DESCRIPTION
Please update my adapter ioBroker.opendtu to version 0.1.7.

Closed https://github.com/o0shojo0o/ioBroker.opendtu/issues/81

*This pull request was created by https://www.iobroker.dev c0726ff.*