### PR TITLE
Update snmp to 2.4.11

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2207,7 +2207,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snmp/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snmp/master/admin/snmp.png",
     "type": "infrastructure",
-    "version": "2.4.7"
+    "version": "2.4.11"
   },
   "socketio": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.socketio/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.snmp to version 2.4.11.

*This pull request was created by https://www.iobroker.dev c0726ff.*