### PR TITLE
Update melcloud stable version to v1.3.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1409,7 +1409,7 @@
     "meta": "https://raw.githubusercontent.com/Black-Thunder/ioBroker.melcloud/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Black-Thunder/ioBroker.melcloud/master/admin/melcloud.png",
     "type": "climate-control",
-    "version": "1.3.4"
+    "version": "1.3.5"
   },
   "mercedesme": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.mercedesme/master/io-package.json",


### PR DESCRIPTION
Hotfix needed because of memory leak in current stable version (see https://github.com/Black-Thunder/ioBroker.melcloud/issues/542)