### PR TITLE
Update fb-checkpresence to 1.2.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -600,7 +600,7 @@
     "meta": "https://raw.githubusercontent.com/afuerhoff/ioBroker.fb-checkpresence/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/afuerhoff/ioBroker.fb-checkpresence/master/admin/fb-checkpresence.png",
     "type": "infrastructure",
-    "version": "1.1.26"
+    "version": "1.2.2"
   },
   "feiertage": {
     "meta": "https://raw.githubusercontent.com/Pix---/ioBroker.feiertage/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.fb-checkpresence to version 1.2.2.

*This pull request was created by https://www.iobroker.dev c0726ff.*