### PR TITLE
Update seq to 0.3.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2123,7 +2123,7 @@
     "meta": "https://raw.githubusercontent.com/o0shojo0o/ioBroker.seq/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/o0shojo0o/ioBroker.seq/master/admin/seq.png",
     "type": "logic",
-    "version": "0.2.10"
+    "version": "0.3.0"
   },
   "shelly": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.shelly/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.seq to version 0.3.0.

Closed https://github.com/o0shojo0o/ioBroker.seq/issues/478

*This pull request was created by https://www.iobroker.dev c0726ff.*