### PR TITLE
Upgrade wireguard adapter to v1.5.7

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2793,9 +2793,9 @@
   },
   "wireguard": {
     "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.wireguard/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/grizzelbee/ioBroker.wireguard/main/admin/wireguard.svg",
+    "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.wireguard/main/admin/wireguard.svg",
     "type": "infrastructure",
-    "version": "1.3.1"
+    "version": "1.5.7"
   },
   "wireless-mbus": {
     "meta": "https://raw.githubusercontent.com/lvogt/ioBroker.wireless-mbus/master/io-package.json",

--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2792,8 +2792,8 @@
     "version": "2.0.1"
   },
   "wireguard": {
-    "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.wireguard/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/grizzelbee/ioBroker.wireguard/master/admin/wireguard.svg",
+    "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.wireguard/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/grizzelbee/ioBroker.wireguard/main/admin/wireguard.svg",
     "type": "infrastructure",
     "version": "1.3.1"
   },

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2753,7 +2753,7 @@
   },
   "wireguard": {
     "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.wireguard/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/grizzelbee/ioBroker.wireguard/main/admin/wireguard.svg",
+    "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.wireguard/main/admin/wireguard.svg",
     "type": "infrastructure"
   },
   "wireless-mbus": {

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2752,8 +2752,8 @@
     "type": "communication"
   },
   "wireguard": {
-    "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.wireguard/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/grizzelbee/ioBroker.wireguard/master/admin/wireguard.svg",
+    "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.wireguard/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/grizzelbee/ioBroker.wireguard/main/admin/wireguard.svg",
     "type": "infrastructure"
   },
   "wireless-mbus": {


### PR DESCRIPTION
fixed typo in icon path (capital G in Grizzelbee) and bumped stable to v1.5.7

Feel free to delay this fix for a few days if you feel uncomfortable with this version.
But ... last real work on this adapter has been some days ago and older versions incl. 1.5.0 are pretty well tested. Rest was to make adapterchecker happy (it's a pitty that you only can test main/master branch and not the current development branch - would make things much easier).

Anyway - from my point of view the adapter is fine for stable.