### PR TITLE
Add TibberLink to stable repo

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2395,6 +2395,12 @@
     "type": "logic",
     "version": "3.0.2"
   },
+  "tibberlink": {
+    "meta": "https://raw.githubusercontent.com/hombach/ioBroker.tibberlink/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/hombach/ioBroker.tibberlink/master/admin/tibberlink.png",
+    "type": "energy",
+    "version": "0.1.6"
+  },
   "tinker": {
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.tinker/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/simatec/ioBroker.tinker/master/admin/tinker.png",


### PR DESCRIPTION
Please add TibberLink 0.1.6 to stable repo. 
Version 0.1.7 and 0.1.8 with small enhancements/fixes will follow soon after validation.
0.1.6 runs stable since >14 days - 62 users so far, according to sentry.