### PR TITLE
Update mydlink to 1.3.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1559,7 +1559,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mydlink/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mydlink/master/admin/mydlink.png",
     "type": "iot-systems",
-    "version": "1.3.1"
+    "version": "1.3.4"
   },
   "myenergi": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.myenergi/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.mydlink to version 1.3.4.

*This pull request was created by https://www.iobroker.dev c0726ff.*

(1.3.4 is very recent, but nearly identical to 1.3.2, which is in latest for a bit and mostly contains small fixes and dependency updates, one of the fixes is necessary for js-controller 5.x)