### PR TITLE
Update wireguard to 1.5.10

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -656,7 +656,7 @@
     "type": "vehicle",
     "version": "0.0.14"
   },
-    "frigate": {
+  "frigate": {
     "meta": "https://raw.githubusercontent.com/Bettman66/ioBroker.frigate/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Bettman66/ioBroker.frigate/master/admin/frigate.png",
     "type": "alarm",
@@ -2813,7 +2813,7 @@
     "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.wireguard/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.wireguard/main/admin/wireguard.svg",
     "type": "infrastructure",
-    "version": "1.3.1"
+    "version": "1.5.10"
   },
   "wireless-mbus": {
     "meta": "https://raw.githubusercontent.com/lvogt/ioBroker.wireless-mbus/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.wireguard to version 1.5.10.

*This pull request was created by https://www.iobroker.dev c0726ff.*