### PR TITLE
Update dysonairpurifier to 2.5.9

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -456,7 +456,7 @@
     "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.dysonairpurifier/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.dysonairpurifier/master/admin/dyson_logo.svg",
     "type": "climate-control",
-    "version": "2.5.7"
+    "version": "2.5.9"
   },
   "e3dc-rscp": {
     "meta": "https://raw.githubusercontent.com/git-kick/ioBroker.e3dc-rscp/master/io-package.json",
@@ -656,7 +656,7 @@
     "type": "vehicle",
     "version": "0.0.14"
   },
-    "frigate": {
+  "frigate": {
     "meta": "https://raw.githubusercontent.com/Bettman66/ioBroker.frigate/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Bettman66/ioBroker.frigate/master/admin/frigate.png",
     "type": "alarm",


### PR DESCRIPTION
Please update my adapter ioBroker.dysonairpurifier to version 2.5.9.

*This pull request was created by https://www.iobroker.dev c0726ff.*