### PR TITLE
Add procon-ip adapter to stable repository

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1921,6 +1921,12 @@
     "type": "energy",
     "version": "0.0.12"
   },
+  "procon-ip": {
+    "meta": "https://raw.githubusercontent.com/ylabonte/ioBroker.procon-ip/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/ylabonte/ioBroker.procon-ip/master/admin/procon-ip.png",
+    "type": "iot-systems",
+    "version": "1.4.0"
+  },
   "proxmox": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.proxmox/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.proxmox/master/admin/logo.png",


### PR DESCRIPTION
As proposed by you in [this issue](https://github.com/ylabonte/ioBroker.procon-ip/issues/35), I want to add my procon-ip adapter to the stable repository.