### PR TITLE
Update deyeidc to 0.0.10

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -392,6 +392,12 @@
     "type": "general",
     "version": "1.1.5"
   },
+  "deyeidc": {
+    "meta": "https://raw.githubusercontent.com/raschy/ioBroker.deyeidc/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/raschy/ioBroker.deyeidc/main/admin/deyeidc.png",
+    "type": "energy",
+    "version": "0.0.10"
+  },
   "digitalstrom": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.digitalstrom/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.digitalstrom/master/admin/digitalstrom.png",


### PR DESCRIPTION
Please update my adapter ioBroker.deyeidc to version 0.0.10.

*This pull request was created by https://www.iobroker.dev c0726ff.*