### PR TITLE
update sureflap to 1.2.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2339,7 +2339,7 @@
     "meta": "https://raw.githubusercontent.com/Sickboy78/ioBroker.sureflap/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Sickboy78/ioBroker.sureflap/master/admin/sureflap.png",
     "type": "iot-systems",
-    "version": "1.1.8"
+    "version": "1.2.0"
   },
   "swiss-weather-api": {
     "meta": "https://raw.githubusercontent.com/baerengraben/ioBroker.swiss-weather-api/master/io-package.json",


### PR DESCRIPTION
external API has become slower, need to increase timeout from 60s to 120s to avoid too much timeouts