### PR TITLE
Bump of web to 6.1.0 , ws to 2.5.3 , socketio to 6.5.2 (stable)

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2249,7 +2249,7 @@
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.socketio/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.socketio/master/admin/socketio.png",
     "type": "communication",
-    "version": "4.2.0"
+    "version": "6.5.2"
   },
   "solarlog": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solarlog/master/io-package.json",
@@ -2777,7 +2777,7 @@
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.web/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.web/master/admin/web.png",
     "type": "general",
-    "version": "4.3.0"
+    "version": "6.1.0"
   },
   "webuntis": {
     "meta": "https://raw.githubusercontent.com/Newan/ioBroker.webuntis/main/io-package.json",
@@ -2885,7 +2885,7 @@
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.ws/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.ws/main/admin/ws.png",
     "type": "communication",
-    "version": "1.3.0"
+    "version": "2.5.3"
   },
   "xbox": {
     "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.xbox/master/io-package.json",


### PR DESCRIPTION
Should be released before controller v5

I will write a forum post too

https://forum.iobroker.net/topic/67996/neue-stable-versionen-der-adapter-web-socketio-und-ws