### PR TITLE
Growatt version to 3.1.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -768,7 +768,7 @@
     "meta": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/admin/growatt.png",
     "type": "energy",
-    "version": "3.0.4"
+    "version": "3.1.2"
   },
   "gruenbeck": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.gruenbeck/master/io-package.json",


### PR DESCRIPTION
GermanBluefox commented 15 hours ago
Think about update stable version to 3.1.2
Version: stable=3.0.4 (59 days old) => latest=3.1.2 (15 days old) Installs: stable=660 (46.35%), latest=83 (5.83%), total=1424