### PR TITLE
Update ds18b20 stable to 2.0.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -456,7 +456,7 @@
     "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.ds18b20/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.ds18b20/master/admin/ds18b20.png",
     "type": "hardware",
-    "version": "1.6.1"
+    "version": "2.0.4"
   },
   "dwd": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.dwd/master/io-package.json",


### PR DESCRIPTION
Major version increase since compatibility of old node.js versions is dropped and the admin ui is completely rewritten.
On first start after upgrading from v1.x the config will be migrated automatically.

v2.0.4 is required for js-controller 5 compatibility for users upgrading from ds18b20 1.x in some cases.