### PR TITLE
Update nibeuplink stable to 1.3.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1637,7 +1637,7 @@
     "meta": "https://raw.githubusercontent.com/sebilm/ioBroker.nibeuplink/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/sebilm/ioBroker.nibeuplink/master/admin/nibeuplink.png",
     "type": "climate-control",
-    "version": "1.2.2"
+    "version": "1.3.0"
   },
   "nina": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.nina/master/io-package.json",


### PR DESCRIPTION
Version: stable=1.2.2 (157 days old) => latest=1.3.0 (15 days old)
Installs: stable=214 (66.88%), latest=19 (5.94%), total=320