### PR TITLE
Update zigbee2mqtt to 2.13.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2969,7 +2969,7 @@
     "meta": "https://raw.githubusercontent.com/o0shojo0o/ioBroker.zigbee2mqtt/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/o0shojo0o/ioBroker.zigbee2mqtt/main/admin/zigbee2mqtt.png",
     "type": "hardware",
-    "version": "2.9.0"
+    "version": "2.13.1"
   },
   "zont": {
     "meta": "https://raw.githubusercontent.com/kirovilya/ioBroker.zont/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.zigbee2mqtt to version 2.13.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*