### PR TITLE
Update robonect to 1.1.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2051,7 +2051,7 @@
     "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.robonect/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.robonect/master/admin/robonect.png",
     "type": "garden",
-    "version": "0.1.4"
+    "version": "1.1.5"
   },
   "roborock": {
     "meta": "https://raw.githubusercontent.com/copystring/ioBroker.roborock/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.robonect to version 1.1.5.

*This pull request was created by https://www.iobroker.dev c0726ff.*