### PR TITLE
Update atlas-scientific-ezo-i2c to 2.3.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -146,6 +146,12 @@
     "type": "hardware",
     "version": "1.0.1"
   },
+  "atlas-scientific-ezo-i2c": {
+    "meta": "https://raw.githubusercontent.com/Buzze11/ioBroker.atlas-scientific-ezo-i2c/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Buzze11/ioBroker.atlas-scientific-ezo-i2c/master/admin/atlas-scientific-ezo-i2c.png",
+    "type": "hardware",
+    "version": "2.3.0"
+  },
   "awattar": {
     "meta": "https://raw.githubusercontent.com/sirjojo69/ioBroker.awattar/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/sirjojo69/ioBroker.awattar/master/admin/awattar.png",


### PR DESCRIPTION
Please update my adapter ioBroker.atlas-scientific-ezo-i2c to version 2.3.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*