### PR TITLE
Update rct to 1.2.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2011,6 +2011,12 @@
     "type": "protocols",
     "version": "1.3.0"
   },
+  "rct": {
+    "meta": "https://raw.githubusercontent.com/aruttkamp/ioBroker.rct/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/aruttkamp/ioBroker.rct/main/admin/rct-logo.square.png",
+    "type": "energy",
+    "version": "1.2.2"
+  },
   "renault": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.renault/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.renault/master/admin/renault.png",


### PR DESCRIPTION
Please update my adapter ioBroker.rct to version 1.2.2.

*This pull request was created by https://www.iobroker.dev c0726ff.*