### PR TITLE
Update plenticore to 2.3.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1913,7 +1913,7 @@
     "meta": "https://raw.githubusercontent.com/StrathCole/ioBroker.plenticore/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/StrathCole/ioBroker.plenticore/master/admin/plenticore.png",
     "type": "energy",
-    "version": "2.2.0"
+    "version": "2.3.1"
   },
   "plex": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.plex/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.plenticore to version 2.3.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*