### PR TITLE
Update cec2 to 0.1.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -312,7 +312,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.cec2/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.cec2/master/admin/cec2.png",
     "type": "multimedia",
-    "version": "0.1.0"
+    "version": "0.1.1"
   },
   "chromecast": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.chromecast/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.cec2 to version 0.1.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*