### PR TITLE
Update roomba to 1.2.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2075,7 +2075,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.roomba/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.roomba/master/admin/roomba.png",
     "type": "household",
-    "version": "1.1.4"
+    "version": "1.2.2"
   },
   "rpi2": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.rpi2/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.roomba to version 1.2.2.

*This pull request was created by https://www.iobroker.dev c0726ff.*