### PR TITLE
Update meater to 1.0.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1409,7 +1409,7 @@
     "meta": "https://raw.githubusercontent.com/Standarduser/ioBroker.meater/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Standarduser/ioBroker.meater/main/admin/meater.png",
     "type": "household",
-    "version": "1.0.0"
+    "version": "1.0.2"
   },
   "mediola-gateway": {
     "meta": "https://raw.githubusercontent.com/oelison/ioBroker.mediola-gateway/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.meater to version 1.0.2.

*This pull request was created by https://www.iobroker.dev c0726ff.*