### PR TITLE
Bump intex to 0.1.5 at stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1104,7 +1104,7 @@
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.intex/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.intex/master/admin/intex.png",
     "type": "household",
-    "version": "0.1.0"
+    "version": "0.1.5"
   },
   "iot": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.iot/master/io-package.json",

--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -786,7 +786,7 @@
     "meta": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/admin/growatt.png",
     "type": "energy",
-    "version": "3.1.2"
+    "version": "3.2.1"
   },
   "gruenbeck": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.gruenbeck/master/io-package.json",

--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -786,7 +786,7 @@
     "meta": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/admin/growatt.png",
     "type": "energy",
-    "version": "3.2.1"
+    "version": "3.1.2"
   },
   "gruenbeck": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.gruenbeck/master/io-package.json",


### PR DESCRIPTION
Version: stable=0.1.0 (91 days old) => latest=0.1.5 (15 days old)
Installs: stable=63 (66.32%), latest=13 (13.68%), total=95

Click to use developer portal
Click to edit

Note: This is an automatically generated message and not personally authored by bluefox!