### PR TITLE
Bump alias manager to 1.2.6 at stable (*)

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -90,7 +90,7 @@
     "meta": "https://raw.githubusercontent.com/sbormann/ioBroker.alias-manager/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/sbormann/ioBroker.alias-manager/master/admin/alias-manager.png",
     "type": "general",
-    "version": "1.2.4"
+    "version": "1.2.6"
   },
   "alpha-ess": {
     "meta": "https://raw.githubusercontent.com/Gaspode69/ioBroker.alpha-ess/main/io-package.json",


### PR DESCRIPTION
Override update
see https://github.com/sbormann/ioBroker.alias-manager/issues/37