### PR TITLE
Update hausbus_de to 1.2.12

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -846,7 +846,7 @@
     "meta": "https://raw.githubusercontent.com/hausbus/ioBroker.hausbus_de/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/hausbus/ioBroker.hausbus_de/main/admin/hausbusde.png",
     "type": "iot-systems",
-    "version": "1.2.11"
+    "version": "1.2.12"
   },
   "heatingcontrol": {
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.heatingcontrol/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.hausbus_de to version 1.2.12.

*This pull request was created by https://www.iobroker.dev c0726ff.*