### PR TITLE
Update zwave2 to 3.1.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3029,6 +3029,6 @@
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/admin/zwave2.svg?sanitize=true",
     "type": "hardware",
-    "version": "3.0.5"
+    "version": "3.1.0"
   }
 }


### PR DESCRIPTION
Please update my adapter ioBroker.zwave2 to version 3.1.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*