### PR TITLE
Update SelveRF stable version to 0.6.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2183,7 +2183,7 @@
     "meta": "https://raw.githubusercontent.com/Rintrium/ioBroker.selverf/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Rintrium/ioBroker.selverf/master/admin/selverf.png",
     "type": "iot-systems",
-    "version": "0.6.2"
+    "version": "0.6.3"
   },
   "semp": {
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.semp/master/io-package.json",


### PR DESCRIPTION
As mentioned [here](https://github.com/Rintrium/ioBroker.selverf/issues/191#issuecomment-1742170933) the stable version can be bumped. I didn't have time to do this earlier.

There were no functional changes in this version and I have been using it since January this year without problems. I didn't see any problems in the forum either.