### PR TITLE
Update opendtu to 1.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1775,7 +1775,7 @@
     "meta": "https://raw.githubusercontent.com/o0shojo0o/ioBroker.opendtu/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/o0shojo0o/ioBroker.opendtu/main/admin/opendtu.png",
     "type": "energy",
-    "version": "0.1.7"
+    "version": "1.0.0"
   },
   "openhab": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.openhab/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.opendtu to version 1.0.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*