### PR TITLE
Update kecontact to 2.0.2 at stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1181,7 +1181,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.kecontact/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.kecontact/master/admin/kecontact.png",
     "type": "hardware",
-    "version": "2.0.1"
+    "version": "2.0.2"
   },
   "klf200": {
     "meta": "https://raw.githubusercontent.com/MiSchroe/ioBroker.klf200/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.kecontact to version 2.0.2.

*This pull request was created by https://www.iobroker.dev c0726ff.*