### PR TITLE
Fix icon path for govee-local (latest)

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -736,7 +736,7 @@
   },
   "govee-local": {
     "meta": "https://raw.githubusercontent.com/boergegrunicke/ioBroker.govee-local/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/boergegrunicke/ioBroker.govee-local/master/admin/govee-local.png",
+    "icon": "https://raw.githubusercontent.com/boergegrunicke/ioBroker.govee-local/main/admin/govee-local.png",
     "type": "lighting"
   },
   "growatt": {


### PR DESCRIPTION
Fix the icon path for govee-local, as this makes the repo-checker fail