### PR TITLE
Add govee-local 0.1.2 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -788,6 +788,12 @@
     "type": "vehicle",
     "version": "1.0.27"
   },
+  "govee-local": {
+    "meta": "https://raw.githubusercontent.com/boergegrunicke/ioBroker.govee-local/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/boergegrunicke/ioBroker.govee-local/main/admin/govee-local.png",
+    "type": "lighting",
+    "version": "0.1.2"
+  },
   "growatt": {
     "meta": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/admin/growatt.png",


### PR DESCRIPTION
Please update my adapter ioBroker.govee-local to version 0.1.2.

*This pull request was created by https://www.iobroker.dev c0726ff.*