### PR TITLE
Update panasonic-comfort-cloud to 2.2.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1841,7 +1841,7 @@
     "meta": "https://raw.githubusercontent.com/marc2016/ioBroker.panasonic-comfort-cloud/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/marc2016/ioBroker.panasonic-comfort-cloud/master/admin/panasonic-comfort-cloud.png",
     "type": "climate-control",
-    "version": "2.2.2"
+    "version": "2.2.4"
   },
   "panasonic-viera": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.panasonic-viera/master/io-package.json",


### PR DESCRIPTION
AppVersion changed and there was an error in the automatic loading of the app version from Github. The previous adapter versions will no longer work if users do not manually enter the new AppVersion. With this version the automation works again.