### PR TITLE
Update shelly to 6.4.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2213,7 +2213,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.shelly/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.shelly/master/admin/shelly.png",
     "type": "iot-systems",
-    "version": "6.4.1"
+    "version": "6.4.5"
   },
   "shuttercontrol": {
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.shuttercontrol/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.shelly to version 6.4.5.

*This pull request was created by https://www.iobroker.dev c0726ff.*