### PR TITLE
Update Device-Reminder V3.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -408,7 +408,7 @@
     "meta": "https://raw.githubusercontent.com/xenon-s/ioBroker.device-reminder/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/xenon-s/ioBroker.device-reminder/master/admin/icon.png",
     "type": "energy",
-    "version": "1.2.9"
+    "version": "3.0.0"
   },
   "device-watcher": {
     "meta": "https://raw.githubusercontent.com/ciddi89/ioBroker.device-watcher/main/io-package.json",


### PR DESCRIPTION
Numerous changes Device-Reminder, because the old version was no longer executable with the new JS controller Update to V3.0.0