### PR TITLE
Update signifylights to 0.2.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2239,6 +2239,12 @@
     "type": "messaging",
     "version": "0.3.0"
   },
+  "signifylights": {
+    "meta": "https://raw.githubusercontent.com/disaster123/ioBroker.signifylights/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/disaster123/ioBroker.signifylights/main/admin/signifylights.png",
+    "type": "lighting",
+    "version": "0.2.0"
+  },
   "simple-api": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.simple-api/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.simple-api/master/admin/simple-api.png",


### PR DESCRIPTION
Please update my adapter ioBroker.signifylights to version 0.2.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*