### PR TITLE
Update mqtt-client to 1.6.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1601,7 +1601,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mqtt-client/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mqtt-client/master/admin/mqtt-client.png",
     "type": "protocols",
-    "version": "1.6.3"
+    "version": "1.6.5"
   },
   "musiccast": {
     "meta": "https://raw.githubusercontent.com/foxthefox/ioBroker.musiccast/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.mqtt-client to version 1.6.5.

*This pull request was created by https://www.iobroker.dev c0726ff.*