### PR TITLE
Bump valuetrackerovertime to 1.0.1 at stable (*)

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2615,7 +2615,7 @@
     "meta": "https://raw.githubusercontent.com/Omega236/ioBroker.valuetrackerovertime/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Omega236/ioBroker.valuetrackerovertime/master/admin/valuetrackerovertime.png",
     "type": "misc-data",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "vcard": {
     "meta": "https://raw.githubusercontent.com/hometm/ioBroker.vcard/master/io-package.json",


### PR DESCRIPTION
https://github.com/Omega236/ioBroker.valuetrackerovertime/issues/55