### PR TITLE
Update deconz to 1.3.23

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -396,7 +396,7 @@
     "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.deconz/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.deconz/master/admin/deconz.png",
     "type": "hardware",
-    "version": "1.3.21"
+    "version": "1.3.23"
   },
   "denon": {
     "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.denon/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.deconz to version 1.3.23.

*This pull request was created by https://www.iobroker.dev c0726ff.*