### PR TITLE
Update octoprint to 5.1.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1739,7 +1739,7 @@
     "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.octoprint/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.octoprint/master/admin/octoprint.png",
     "type": "hardware",
-    "version": "4.0.0"
+    "version": "5.1.0"
   },
   "odl": {
     "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.odl/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.octoprint to version 5.1.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*