### PR TITLE
Update lametric to 3.1.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1229,7 +1229,7 @@
     "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.lametric/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.lametric/master/admin/lametric.png",
     "type": "hardware",
-    "version": "2.4.1"
+    "version": "3.1.1"
   },
   "landroid": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.landroid/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.lametric to version 3.1.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*