### PR TITLE
Update pushbullet to 2.0.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2003,7 +2003,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pushbullet/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pushbullet/master/admin/pushbullet.png",
     "type": "messaging",
-    "version": "1.0.1"
+    "version": "2.0.1"
   },
   "pushover": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.pushover/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.pushbullet to version 2.0.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*