### PR TITLE
Update enigma2 to 2.0.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -572,6 +572,12 @@
     "type": "iot-systems",
     "version": "1.0.1"
   },
+  "enigma2": {
+    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.enigma2/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.enigma2/master/admin/enigma2.png",
+    "type": "multimedia",
+    "version": "2.0.5"
+  },
   "envertech-pv": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.envertech-pv/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.envertech-pv/master/admin/envertech-pv.png",


### PR DESCRIPTION
Please update my adapter ioBroker.enigma2 to version 2.0.5.

*This pull request was created by https://www.iobroker.dev c0726ff.*