### PR TITLE
Update janitza-gridvis to 3.1.8

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1158,7 +1158,7 @@
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.janitza-gridvis/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.janitza-gridvis/main/admin/janitza-gridvis.png",
     "type": "energy",
-    "version": "3.1.3"
+    "version": "3.1.8"
   },
   "jarvis": {
     "meta": "https://raw.githubusercontent.com/Zefau/ioBroker.jarvis/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.janitza-gridvis to version 3.1.8.

*This pull request was created by https://www.iobroker.dev c0726ff.*