### PR TITLE
Update vis-justgage to 2.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2735,7 +2735,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-justgage/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-justgage/master/admin/justgage.png",
     "type": "visualization-widgets",
-    "version": "1.0.2"
+    "version": "2.0.0"
   },
   "vis-keyboard": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-keyboard/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-justgage to version 2.0.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*