### PR TITLE
Update icons-freepic to 1.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1046,6 +1046,12 @@
     "type": "visualization-icons",
     "version": "0.1.0"
   },
+  "icons-freepic": {
+    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.icons-freepic/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.icons-freepic/main/admin/icons-freepic.png",
+    "type": "visualization-icons",
+    "version": "1.0.0"
+  },
   "icons-icons8": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-icons8/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-icons8/master/admin/icons8.png",


### PR DESCRIPTION
Please update my adapter ioBroker.icons-freepic to version 1.0.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*