### PR TITLE
Update ems-esp to 2.6.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -558,7 +558,7 @@
     "meta": "https://raw.githubusercontent.com/tp1de/ioBroker.ems-esp/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/tp1de/ioBroker.ems-esp/main/admin/ems-esp.png",
     "type": "climate-control",
-    "version": "2.5.1"
+    "version": "2.6.1"
   },
   "energymanager": {
     "meta": "https://raw.githubusercontent.com/unltdnetworx/ioBroker.energymanager/master/io-package.json",
@@ -2160,7 +2160,7 @@
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.samsung_tizen/master/admin/samsung.png",
     "type": "multimedia",
     "version": "1.0.0"
-  },  
+  },
   "sanext": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.sanext/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.sanext/master/admin/sanext.png",


### PR DESCRIPTION
Please update my adapter ioBroker.ems-esp to version 2.6.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*