### PR TITLE
Add renacidc 0.0.6 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2065,6 +2065,12 @@
     "type": "energy",
     "version": "1.2.2"
   },
+  "renacidc": {
+    "meta": "https://raw.githubusercontent.com/raschy/ioBroker.renacidc/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/raschy/ioBroker.renacidc/main/admin/renacidc.png",
+    "type": "energy",
+    "version": "0.0.6"
+  },
   "renault": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.renault/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.renault/master/admin/renault.png",


### PR DESCRIPTION
Please update my adapter ioBroker.renacidc to version 0.0.6.

*This pull request was created by https://www.iobroker.dev c0726ff.*