### PR TITLE
Update mihome-vacuum to 4.1.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1565,7 +1565,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mihome-vacuum/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mihome-vacuum/master/admin/mihome-vacuum.png",
     "type": "household",
-    "version": "4.0.0"
+    "version": "4.1.0"
   },
   "mikrotik": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mikrotik/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.mihome-vacuum to version 4.1.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*