### PR TITLE
Update shuttercontrol to 1.6.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2255,7 +2255,7 @@
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.shuttercontrol/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/simatec/ioBroker.shuttercontrol/master/admin/shuttercontrol.png",
     "type": "climate-control",
-    "version": "1.6.2"
+    "version": "1.6.3"
   },
   "sia": {
     "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.sia/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.shuttercontrol to version 1.6.3.

*This pull request was created by https://www.iobroker.dev c0726ff.*