### PR TITLE
Update spotify-premium to 1.3.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2405,7 +2405,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.spotify-premium/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.spotify-premium/master/admin/spotify-premium.png",
     "type": "multimedia",
-    "version": "1.2.2"
+    "version": "1.3.1"
   },
   "sprinklecontrol": {
     "meta": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.spotify-premium to version 1.3.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*