### PR TITLE
Add weather-warnings to 0.6.2 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2875,6 +2875,12 @@
     "type": "vehicle",
     "version": "1.2.2"
   },
+  "weather-warnings": {
+    "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.weather-warnings/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.weather-warnings/main/admin/weather-warnings.png",
+    "type": "weather",
+    "version": "0.6.2"
+  },
   "weatherflow_udp": {
     "meta": "https://raw.githubusercontent.com/woessmich/ioBroker.weatherflow_udp/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/woessmich/ioBroker.weatherflow_udp/master/admin/weatherflow_udp.png",


### PR DESCRIPTION
Please update my adapter ioBroker.weather-warnings to version 0.6.2.

*This pull request was created by https://www.iobroker.dev c0726ff.*