### PR TITLE
Update alexa2 to 3.26.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -84,7 +84,7 @@
     "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.alexa2/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.alexa2/master/admin/alexa.png",
     "type": "iot-systems",
-    "version": "3.26.1"
+    "version": "3.26.3"
   },
   "alias-manager": {
     "meta": "https://raw.githubusercontent.com/sbormann/ioBroker.alias-manager/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.alexa2 to version 3.26.3.

Fix included that prevented new cookie generation, should go to to stable not too late ... 

*This pull request was created by https://www.iobroker.dev c0726ff.*