### PR TITLE
Bump TibberLink stable to 1.6.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2531,7 +2531,7 @@
     "meta": "https://raw.githubusercontent.com/hombach/ioBroker.tibberlink/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/hombach/ioBroker.tibberlink/master/admin/tibberlink.png",
     "type": "energy",
-    "version": "1.5.0"
+    "version": "1.6.1"
   },
   "tinker": {
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.tinker/master/io-package.json",


### PR DESCRIPTION
1.6.1 isn't old enough, but a functional regression has been discovered in 1.5.0 - so I want to replace it earlier. Usage count of 1.6.0 and 1.6.1 could be added, cause there are no functional changes.