### PR TITLE
Update ems-esp to 2.6.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -552,7 +552,7 @@
     "meta": "https://raw.githubusercontent.com/tp1de/ioBroker.ems-esp/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/tp1de/ioBroker.ems-esp/main/admin/ems-esp.png",
     "type": "climate-control",
-    "version": "2.6.1"
+    "version": "2.6.2"
   },
   "energymanager": {
     "meta": "https://raw.githubusercontent.com/unltdnetworx/ioBroker.energymanager/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.ems-esp to version 2.6.2.

*This pull request was created by https://www.iobroker.dev c0726ff.*