### PR TITLE
Add tractive-gps 1.1.0 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2563,6 +2563,12 @@
     "type": "geoposition",
     "version": "1.1.4"
   },
+  "tractive-gps": {
+    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tractive-gps/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tractive-gps/main/admin/tractive-gps.png",
+    "type": "geoposition",
+    "version": "1.1.0"
+  },
   "tradfri": {
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.tradfri/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.tradfri/master/admin/tradfri.png",


### PR DESCRIPTION
Please update my adapter ioBroker.tractive-gps to version 1.1.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*