### PR TITLE
Update alpha-ess to 2.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -96,7 +96,7 @@
     "meta": "https://raw.githubusercontent.com/Gaspode69/ioBroker.alpha-ess/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Gaspode69/ioBroker.alpha-ess/main/admin/alpha-ess.png",
     "type": "energy",
-    "version": "1.1.1"
+    "version": "2.0.0"
   },
   "alpha2": {
     "meta": "https://raw.githubusercontent.com/Eisbaeeer/ioBroker.alpha2/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.alpha-ess to version 2.0.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*