### PR TITLE
Add emporia 0.0.12 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -548,6 +548,12 @@
     "type": "multimedia",
     "version": "1.1.1"
   },
+  "emporia": {
+    "meta": "https://raw.githubusercontent.com/Chris-656/ioBroker.emporia/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Chris-656/ioBroker.emporia/main/admin/emporia.png",
+    "type": "energy",
+    "version": "0.0.12"
+  },
   "ems-esp": {
     "meta": "https://raw.githubusercontent.com/tp1de/ioBroker.ems-esp/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/tp1de/ioBroker.ems-esp/main/admin/ems-esp.png",


### PR DESCRIPTION
Please update my adapter ioBroker.emporia to version 0.0.12.

*This pull request was created by https://www.iobroker.dev c0726ff.*