### PR TITLE
Update proxmox to 2.2.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2009,7 +2009,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.proxmox/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.proxmox/master/admin/proxmox.png",
     "type": "infrastructure",
-    "version": "2.2.1"
+    "version": "2.2.2"
   },
   "proxy": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.proxy/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.proxmox to version 2.2.2.

*This pull request was created by https://www.iobroker.dev c0726ff.*