### PR TITLE
Update foobar2000 to 2.1.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -690,7 +690,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.foobar2000/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.foobar2000/master/admin/foobar2000.png",
     "type": "multimedia",
-    "version": "2.0.4"
+    "version": "2.1.0"
   },
   "ford": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.ford/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.foobar2000 to version 2.1.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*