### PR TITLE
Update daswetter to 3.1.11

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -384,7 +384,7 @@
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.daswetter/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.daswetter/master/admin/daswettercom.png",
     "type": "weather",
-    "version": "3.1.10"
+    "version": "3.1.11"
   },
   "deconz": {
     "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.deconz/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.daswetter to version 3.1.11.

*This pull request was created by https://www.iobroker.dev c0726ff.*