### PR TITLE
Add webcal 1.3.0 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2905,6 +2905,12 @@
     "type": "general",
     "version": "6.1.10"
   },
+  "webcal": {
+    "meta": "https://raw.githubusercontent.com/dirkhe/ioBroker.webcal/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/dirkhe/ioBroker.webcal/master/admin/webcal.png",
+    "type": "date-and-time",
+    "version": "1.3.0"
+  },
   "webui": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.webui/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.webui/master/admin/logo.png",


### PR DESCRIPTION
Adapter is working several month stable on my side and also some other user are satifised, see https://forum.iobroker.net/topic/62479/test-neuer-adapter-webcal
So we should offer them more people