### PR TITLE
Bump drag-indicator to 2.1.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -468,7 +468,7 @@
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.drag-indicator/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.drag-indicator/main/admin/drag-indicator.png",
     "type": "misc-data",
-    "version": "2.1.3"
+    "version": "2.1.4"
   },
   "ds18b20": {
     "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.ds18b20/master/io-package.json",


### PR DESCRIPTION
2.1.4 is since more weeks without problems in beta.