### PR TITLE
Update unifi to 0.6.7

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2627,7 +2627,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.unifi/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.unifi/master/admin/unifi.png",
     "type": "network",
-    "version": "0.6.6"
+    "version": "0.6.7"
   },
   "upnp": {
     "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.upnp/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.unifi to version 0.6.7.

*This pull request was created by https://www.iobroker.dev c0726ff.*