### PR TITLE
Update lg-thinq to 0.3.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1289,7 +1289,7 @@
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.lg-thinq/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.lg-thinq/master/admin/lg-thinq.png",
     "type": "household",
-    "version": "0.1.4"
+    "version": "0.3.1"
   },
   "lgtv": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.lgtv/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.lg-thinq to version 0.3.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*