### PR TITLE
Update pvforecast to 2.9.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2045,7 +2045,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pvforecast/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pvforecast/main/admin/pvforecast.png",
     "type": "energy",
-    "version": "2.9.0"
+    "version": "2.9.1"
   },
   "pvoutputorg": {
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.pvoutputorg/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.pvforecast to version 2.9.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*