### PR TITLE
Update hmip to 1.21.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -948,7 +948,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.hmip/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.hmip/master/admin/homematic.png",
     "type": "hardware",
-    "version": "1.20.0"
+    "version": "1.21.0"
   },
   "homeconnect": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.homeconnect/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.hmip to version 1.21.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*