### PR TITLE
Add zendure-solarflow 1.0.7 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3127,6 +3127,12 @@
     "type": "climate-control",
     "version": "0.0.7"
   },
+  "zendure-solarflow": {
+    "meta": "https://raw.githubusercontent.com/nograx/ioBroker.zendure-solarflow/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/nograx/ioBroker.zendure-solarflow/main/admin/zendure-solarflow.png",
+    "type": "energy",
+    "version": "1.0.7"
+  },
   "zigbee": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.zigbee/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.zigbee/master/admin/zigbee.png",


### PR DESCRIPTION
Please update my adapter ioBroker.zendure-solarflow to version 1.0.7.

*This pull request was created by https://www.iobroker.dev c0726ff.*