### PR TITLE
Update weather-warnings to 0.6.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2915,7 +2915,7 @@
     "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.weather-warnings/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.weather-warnings/main/admin/weather-warnings.png",
     "type": "weather",
-    "version": "0.6.4"
+    "version": "0.6.6"
   },
   "weatherflow_udp": {
     "meta": "https://raw.githubusercontent.com/woessmich/ioBroker.weatherflow_udp/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.weather-warnings to version 0.6.6.

*This pull request was created by https://www.iobroker.dev c0726ff.*