### PR TITLE
Update heatingcontrol to 2.12.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -882,7 +882,7 @@
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.heatingcontrol/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.heatingcontrol/master/admin/heatingcontrol.png",
     "type": "climate-control",
-    "version": "2.12.2"
+    "version": "2.12.3"
   },
   "heizoel": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.heizoel/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.heatingcontrol to version 2.12.3.

*This pull request was created by https://www.iobroker.dev c0726ff.*