### PR TITLE
Update ebus to 3.2.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -510,7 +510,7 @@
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.ebus/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.ebus/master/admin/ebus.png",
     "type": "hardware",
-    "version": "3.2.4"
+    "version": "3.2.5"
   },
   "echarts": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.echarts/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.ebus to version 3.2.5.

*This pull request was created by https://www.iobroker.dev c0726ff.*