### PR TITLE
Update vis-weather to 2.5.9

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2873,7 +2873,7 @@
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-weather/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-weather/master/admin/vis-weather.png",
     "type": "visualization-widgets",
-    "version": "2.5.6"
+    "version": "2.5.9"
   },
   "voltoplus": {
     "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.voltoplus/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-weather to version 2.5.9.

*This pull request was created by https://www.iobroker.dev c0726ff.*