### PR TITLE
Add soliscloud 1.4.2 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2383,6 +2383,12 @@
     "type": "energy",
     "version": "0.8.0"
   },
+  "soliscloud": {
+    "meta": "https://raw.githubusercontent.com/Trixx34/ioBroker.soliscloud/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Trixx34/ioBroker.soliscloud/main/admin/solis.png",
+    "type": "energy",
+    "version": "1.4.2"
+  },
   "sonnen": {
     "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.sonnen/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/foxriver76/ioBroker.sonnen/master/admin/sonnen.png",


### PR DESCRIPTION
Adding soliscloud adapter to stable.
It has been tested by a couple users now:
https://forum.iobroker.net/topic/69026/new-adapter-soliscloud/52
