### PR TITLE
Update jablotron to 0.1.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1178,6 +1178,12 @@
     "type": "communication",
     "version": "3.0.0"
   },
+  "jablotron": {
+    "meta": "https://raw.githubusercontent.com/DEV2DEV-DE/ioBroker.jablotron/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/DEV2DEV-DE/ioBroker.jablotron/main/admin/jablotron.png",
+    "type": "alarm",
+    "version": "0.1.3"
+  },
   "janitza-gridvis": {
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.janitza-gridvis/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.janitza-gridvis/main/admin/janitza-gridvis.png",


### PR DESCRIPTION
Please update my adapter ioBroker.jablotron to version 0.1.3.

*This pull request was created by https://www.iobroker.dev c0726ff.*