### PR TITLE
bump admin stable to 6.13.16

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -42,7 +42,7 @@
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.admin/master/packages/admin/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.admin/master/packages/admin/admin/admin.png",
     "type": "general",
-    "version": "6.13.15"
+    "version": "6.13.16"
   },
   "aio": {
     "meta": "https://raw.githubusercontent.com/Newan/ioBroker.aio/master/io-package.json",


### PR DESCRIPTION
because of the `too much recursion` bug which lead to crashes with some firefox addons