### PR TITLE
Add air-q adapter to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -29,6 +29,11 @@
     "icon": "https://raw.githubusercontent.com/Newan/ioBroker.aio/master/admin/aio.png",
     "type": "energy"
   },
+  "air-q": {
+    "meta": "https://raw.githubusercontent.com/CorantGmbH/ioBroker.air-q/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/CorantGmbH/ioBroker.air-q/main/admin/air-q.png",
+    "type": "weather"
+  },
   "airconwithme": {
     "meta": "https://raw.githubusercontent.com/weggetor/ioBroker.airconwithme/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/weggetor/ioBroker.airconwithme/main/admin/airconwithme.png",


### PR DESCRIPTION
Please consider adding our air-q adapter to the latest repo. 
The thread for the testing forum is here: https://forum.iobroker.net/topic/70188/test-adapter-air-q-air-q-luftanalysator-v0-0-x/4

Thank you in advance! 