### PR TITLE
Update lametric to 3.1.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1265,7 +1265,7 @@
     "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.lametric/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.lametric/master/admin/lametric.png",
     "type": "hardware",
-    "version": "3.1.2"
+    "version": "3.1.3"
   },
   "lcn": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.lcn/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.lametric to version 3.1.3.

*This pull request was created by https://www.iobroker.dev c0726ff.*