### PR TITLE
Added SolarEdge 1.2.2 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2365,6 +2365,12 @@
     "type": "communication",
     "version": "6.6.0"
   },
+  "solaredge": {
+    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solaredge/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solaredge/master/admin/solaredge.png",
+    "type": "energy",
+    "version": "1.2.2"
+  },
   "solarlog": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solarlog/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solarlog/master/admin/solarlog.png",


### PR DESCRIPTION
The SolarEdge adapter has been added to the stable sources list in the sources-dist-stable.json file. Relevant details such as meta data, icon link, type and version have been included.