### PR TITLE
Update pegelalarm to 1.3.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1907,7 +1907,7 @@
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.pegelalarm/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/simatec/ioBroker.pegelalarm/master/admin/pegelalarm.png",
     "type": "weather",
-    "version": "1.3.2"
+    "version": "1.3.3"
   },
   "ph803w": {
     "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.ph803w/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.pegelalarm to version 1.3.3.

*This pull request was created by https://www.iobroker.dev c0726ff.*