### PR TITLE
add senec 1.6.11 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2269,6 +2269,12 @@
     "type": "energy",
     "version": "1.3.14"
   },
+  "senec": {
+    "meta": "https://raw.githubusercontent.com/nobl/ioBroker.senec/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/nobl/ioBroker.senec/master/admin/senec.png",
+    "type": "energy",
+    "version": "1.6.11"
+  },
   "seq": {
     "meta": "https://raw.githubusercontent.com/arteck/ioBroker.seq/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/arteck/ioBroker.seq/master/admin/seq.png",


### PR DESCRIPTION
Please update my adapter ioBroker.senec to version 1.6.11.

*This pull request was created by https://www.iobroker.dev c0726ff.*