### PR TITLE
Update logparser to 2.2.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1385,7 +1385,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.logparser/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.logparser/master/admin/logparser.png",
     "type": "logic",
-    "version": "2.2.1"
+    "version": "2.2.2"
   },
   "loqed": {
     "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.loqed/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.logparser to version 2.2.2.

*This pull request was created by https://www.iobroker.dev c0726ff.*