### PR TITLE
REMOVE outdated vw-connect 0.0.67 from stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2953,12 +2953,6 @@
     "type": "household",
     "version": "1.0.0"
   },
-  "vw-connect": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.vw-connect/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.vw-connect/master/admin/vw-connect.png",
-    "type": "vehicle",
-    "version": "0.0.67"
-  },
   "wallpanel": {
     "meta": "https://raw.githubusercontent.com/xXBJXx/ioBroker.wallpanel/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/xXBJXx/ioBroker.wallpanel/main/admin/wallpanel.png",


### PR DESCRIPTION
Functionality of 0.0.67 has not been cofirmed. See https://github.com/TA2k/ioBroker.vw-connect/issues/316

