### PR TITLE
Update fb-checkpresence to 1.2.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -672,7 +672,7 @@
     "meta": "https://raw.githubusercontent.com/afuerhoff/ioBroker.fb-checkpresence/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/afuerhoff/ioBroker.fb-checkpresence/master/admin/fb-checkpresence.png",
     "type": "infrastructure",
-    "version": "1.2.3"
+    "version": "1.2.4"
   },
   "feiertage": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.feiertage/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.fb-checkpresence to version 1.2.4.

*This pull request was created by https://www.iobroker.dev c0726ff.*