### PR TITLE
Update weather-warnings to 0.6.7

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2970,7 +2970,7 @@
     "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.weather-warnings/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.weather-warnings/main/admin/weather-warnings.png",
     "type": "weather",
-    "version": "0.6.6"
+    "version": "0.6.7"
   },
   "weatherflow_udp": {
     "meta": "https://raw.githubusercontent.com/woessmich/ioBroker.weatherflow_udp/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.weather-warnings to version 0.6.7.

*This pull request was created by https://www.iobroker.dev c0726ff.*