### PR TITLE
Update sureflap to 2.1.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2508,7 +2508,7 @@
     "meta": "https://raw.githubusercontent.com/Sickboy78/ioBroker.sureflap/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Sickboy78/ioBroker.sureflap/master/admin/sureflap.png",
     "type": "iot-systems",
-    "version": "1.2.3"
+    "version": "2.1.1"
   },
   "swiss-weather-api": {
     "meta": "https://raw.githubusercontent.com/baerengraben/ioBroker.swiss-weather-api/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.sureflap to version 2.1.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*