### PR TITLE
Update net-tools to 1.0.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1704,7 +1704,7 @@
     "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.net-tools/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.net-tools/master/admin/net-tools.png",
     "type": "network",
-    "version": "0.2.0"
+    "version": "1.0.6"
   },
   "netatmo": {
     "meta": "https://raw.githubusercontent.com/PArns/ioBroker.netatmo/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.net-tools to version 1.0.6.

*This pull request was created by https://www.iobroker.dev c0726ff.*