### PR TITLE
Update procon-ip to 1.5.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2022,7 +2022,7 @@
     "meta": "https://raw.githubusercontent.com/ylabonte/ioBroker.procon-ip/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ylabonte/ioBroker.procon-ip/master/admin/procon-ip.png",
     "type": "iot-systems",
-    "version": "1.5.1"
+    "version": "1.5.4"
   },
   "proxmox": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.proxmox/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.procon-ip to version 1.5.4.

*This pull request was created by https://www.iobroker.dev c0726ff.*