### PR TITLE
Update lorawan to 0.6.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1400,6 +1400,12 @@
     "type": "hardware",
     "version": "0.3.1"
   },
+  "lorawan": {
+    "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lorawan/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lorawan/main/admin/lorawan.png",
+    "type": "protocols",
+    "version": "0.6.6"
+  },
   "lovelace": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.lovelace/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.lovelace/master/admin/lovelace.png",


### PR DESCRIPTION
Please update my adapter ioBroker.lorawan to version 0.6.6.

*This pull request was created by https://www.iobroker.dev c0726ff.*