### PR TITLE
Update tinker to 1.3.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2598,7 +2598,7 @@
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.tinker/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/simatec/ioBroker.tinker/master/admin/tinker.png",
     "type": "hardware",
-    "version": "1.3.0"
+    "version": "1.3.2"
   },
   "tinymqttbroker": {
     "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.tinymqttbroker/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.tinker to version 1.3.2.

*This pull request was created by https://www.iobroker.dev c0726ff.*