### PR TITLE
Update zendure-solarflow to 1.2.3 (or 1.2.6?)

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3192,7 +3192,7 @@
     "meta": "https://raw.githubusercontent.com/nograx/ioBroker.zendure-solarflow/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/nograx/ioBroker.zendure-solarflow/main/admin/zendure-solarflow.png",
     "type": "energy",
-    "version": "1.0.7"
+    "version": "1.2.3"
   },
   "zigbee": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.zigbee/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.zendure-solarflow to version 1.2.3.

*This pull request was created by https://www.iobroker.dev c0726ff.*