### PR TITLE
Update device-watcher to 2.11.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -426,7 +426,7 @@
     "meta": "https://raw.githubusercontent.com/ciddi89/ioBroker.device-watcher/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ciddi89/ioBroker.device-watcher/main/admin/device-watcher.png",
     "type": "misc-data",
-    "version": "2.10.5"
+    "version": "2.11.0"
   },
   "devices": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.devices/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.device-watcher to version 2.11.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*