### PR TITLE
Update awtrix-light to 0.16.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -174,7 +174,7 @@
     "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.awtrix-light/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.awtrix-light/master/admin/awtrix-light.png",
     "type": "iot-systems",
-    "version": "0.13.1"
+    "version": "0.16.0"
   },
   "b-control-em": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.b-control-em/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.awtrix-light to version 0.16.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*