### PR TITLE
Update lovelace to 4.1.8

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1410,7 +1410,7 @@
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.lovelace/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.lovelace/master/admin/lovelace.png",
     "type": "visualization",
-    "version": "4.1.2"
+    "version": "4.1.8"
   },
   "lowpass-filter": {
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lowpass-filter/main/io-package.json",


### PR DESCRIPTION
Please update adapter ioBroker.lovelace to version 4.1.8.

*This pull request was created by https://www.iobroker.dev c0726ff.*