### PR TITLE
Move device-watcher to iobroker-community-adapters (stable)

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -423,8 +423,8 @@
     "version": "3.1.2"
   },
   "device-watcher": {
-    "meta": "https://raw.githubusercontent.com/ciddi89/ioBroker.device-watcher/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ciddi89/ioBroker.device-watcher/main/admin/device-watcher.png",
+    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.device-watcher/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.device-watcher/main/admin/device-watcher.png",
     "type": "misc-data",
     "version": "2.11.0"
   },


### PR DESCRIPTION
Changed owner and all links for the adapter device-watcher to iobroker-community. The only one thing I wasn't able to was to change the owner in npm altough I'm a dev member in the npm iobroker-community. Well, maybe you can change it or assist.