### PR TITLE
Update sun2000-modbus to 0.1.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2508,7 +2508,7 @@
     "meta": "https://raw.githubusercontent.com/daolis/ioBroker.sun2000-modbus/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/daolis/ioBroker.sun2000-modbus/main/admin/sun2000-modbus.png",
     "type": "energy",
-    "version": "0.0.2"
+    "version": "0.1.3"
   },
   "sureflap": {
     "meta": "https://raw.githubusercontent.com/Sickboy78/ioBroker.sureflap/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.sun2000-modbus to version 0.1.3.

*This pull request was created by https://www.iobroker.dev c0726ff.*