### PR TITLE
Update vis-justgage to 2.1.7

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2868,7 +2868,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-justgage/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-justgage/master/admin/justgage.png",
     "type": "visualization-widgets",
-    "version": "2.1.0"
+    "version": "2.1.7"
   },
   "vis-keyboard": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-keyboard/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-justgage to version 2.1.7.

*This pull request was created by https://www.iobroker.dev c0726ff.*