### PR TITLE
Update envertech-pv to 1.3.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -618,7 +618,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.envertech-pv/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.envertech-pv/master/admin/envertech-pv.png",
     "type": "energy",
-    "version": "1.1.0"
+    "version": "1.3.2"
   },
   "epson_ecotank_et_2750": {
     "meta": "https://raw.githubusercontent.com/o0shojo0o/ioBroker.epson_ecotank_et_2750/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.envertech-pv to version 1.3.2.

*This pull request was created by https://www.iobroker.dev c0726ff.*