### PR TITLE
Update heizoel24-mex to 1.3.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -914,6 +914,12 @@
     "type": "misc-data",
     "version": "1.0.3"
   },
+  "heizoel24-mex": {
+    "meta": "https://raw.githubusercontent.com/ltspicer/ioBroker.heizoel24-mex/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/ltspicer/ioBroker.heizoel24-mex/main/admin/heizoel24-mex.png",
+    "type": "metering",
+    "version": "1.3.1"
+  },
   "heizungssteuerung": {
     "meta": "https://raw.githubusercontent.com/jbeenenga/ioBroker.heizungssteuerung/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/jbeenenga/ioBroker.heizungssteuerung/main/admin/heizungssteuerung.png",


### PR DESCRIPTION
Please update my adapter ioBroker.heizoel24-mex to version 1.3.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*