### PR TITLE
Update stable version of ecovacs-deebot to 1.4.15

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -534,7 +534,7 @@
     "meta": "https://raw.githubusercontent.com/mrbungle64/ioBroker.ecovacs-deebot/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/mrbungle64/ioBroker.ecovacs-deebot/master/admin/ecovacs-deebot.png",
     "type": "household",
-    "version": "1.4.14"
+    "version": "1.4.15"
   },
   "egigeozone": {
     "meta": "https://raw.githubusercontent.com/BasGo/ioBroker.egigeozone/master/io-package.json",


### PR DESCRIPTION
[Update stable version in repo from 1.4.14 to 1.4.15](https://github.com/mrbungle64/ioBroker.ecovacs-deebot/issues/662)