### PR TITLE
Update backitup to 2.11.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -186,7 +186,7 @@
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.backitup/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/simatec/ioBroker.backitup/master/admin/backitup.png",
     "type": "general",
-    "version": "2.10.11"
+    "version": "2.11.0"
   },
   "beckhoff": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.beckhoff/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.backitup to version 2.11.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*