### PR TITLE
Update feiertage to 1.2.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -684,7 +684,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.feiertage/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.feiertage/master/admin/feiertage.png",
     "type": "date-and-time",
-    "version": "1.1.4"
+    "version": "1.2.0"
   },
   "fhem": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fhem/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.feiertage to version 1.2.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*