### PR TITLE
Add pid to 1.1.3 to stabled

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1952,6 +1952,12 @@
     "type": "network",
     "version": "1.3.6"
   },
+  "pid": {
+    "meta": "https://raw.githubusercontent.com/mcm4iob/ioBroker.pid/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/mcm4iob/ioBroker.pid/master/admin/pid.png",
+    "type": "general",
+    "version": "1.1.3"
+  },
   "piface": {
     "meta": "https://raw.githubusercontent.com/eisbaeeer/ioBroker.piface/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/eisbaeeer/ioBroker.piface/master/admin/piface.png",


### PR DESCRIPTION
Please update my adapter ioBroker.pid to version 1.1.3.

*This pull request was created by https://www.iobroker.dev c0726ff.*