### PR TITLE
Update energiefluss-erweitert to version 0.4.1- Hotfix

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -594,7 +594,7 @@
     "meta": "https://raw.githubusercontent.com/SKB-CGN/ioBroker.energiefluss-erweitert/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/SKB-CGN/ioBroker.energiefluss-erweitert/main/admin/energiefluss-erweitert.png",
     "type": "visualization",
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
   "energymanager": {
     "meta": "https://raw.githubusercontent.com/unltdnetworx/ioBroker.energymanager/master/io-package.json",


### PR DESCRIPTION
Hotfix: After uprading the Adapter, it could happen, that the first datasource was not updated properly