### PR TITLE
update innoxel to 0.4.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1182,7 +1182,7 @@
     "meta": "https://raw.githubusercontent.com/matthsc/ioBroker.innoxel/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/matthsc/ioBroker.innoxel/main/admin/innoxel.png",
     "type": "iot-systems",
-    "version": "0.3.1"
+    "version": "0.4.1"
   },
   "intex": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.intex/master/io-package.json",


### PR DESCRIPTION
Update innoxel adapter to 0.4.1
- fixes for bug reported by a user (private chat)
- drop support for node 16
- dependency updates