### PR TITLE
Update unifi-protect to 1.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2696,6 +2696,12 @@
     "type": "network",
     "version": "0.6.7"
   },
+  "unifi-protect": {
+    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.unifi-protect/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.unifi-protect/master/admin/unifi-protect.png",
+    "type": "alarm",
+    "version": "1.0.0"
+  },
   "upnp": {
     "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.upnp/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.upnp/master/admin/upnp.png",


### PR DESCRIPTION
Please update my adapter ioBroker.unifi-protect to version 1.0.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*