### PR TITLE
Update shelly to 6.9.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2286,7 +2286,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.shelly/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.shelly/master/admin/shelly.png",
     "type": "iot-systems",
-    "version": "6.8.0"
+    "version": "6.9.0"
   },
   "shuttercontrol": {
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.shuttercontrol/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.shelly to version 6.9.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*