### PR TITLE
Update lgtv to 2.2.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1326,7 +1326,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.lgtv/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.lgtv/master/admin/lgtv.png",
     "type": "multimedia",
-    "version": "2.1.2"
+    "version": "2.2.0"
   },
   "lgtv-rs": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.lgtv-rs/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.lgtv to version 2.2.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*