### PR TITLE
Update radar2 to 2.2.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2088,7 +2088,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.radar2/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.radar2/master/admin/radar2.png",
     "type": "network",
-    "version": "2.1.0"
+    "version": "2.2.0"
   },
   "radiohead": {
     "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.radiohead/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.radar2 to version 2.2.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*