### PR TITLE
Update weatherunderground to 3.7.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3006,7 +3006,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.weatherunderground/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.weatherunderground/master/admin/wu.png",
     "type": "weather",
-    "version": "3.6.0"
+    "version": "3.7.0"
   },
   "web": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.web/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.weatherunderground to version 3.7.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*