### PR TITLE
Update apcups to 3.0.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -132,7 +132,7 @@
     "meta": "https://raw.githubusercontent.com/XHunter74/ioBroker.apcups/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/XHunter74/ioBroker.apcups/master/admin/ups.png",
     "type": "hardware",
-    "version": "2.0.0"
+    "version": "3.0.1"
   },
   "apg-info": {
     "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.apg-info/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.apcups to version 3.0.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*