### PR TITLE
Update beckhoff to 1.6.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -198,7 +198,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.beckhoff/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.beckhoff/master/admin/beckhoff.png",
     "type": "hardware",
-    "version": "1.5.3"
+    "version": "1.6.0"
   },
   "benchmark": {
     "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.benchmark/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.beckhoff to version 1.6.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*