### PR TITLE
Update homeconnect to 1.4.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -996,7 +996,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.homeconnect/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.homeconnect/master/admin/homeconnect.png",
     "type": "household",
-    "version": "1.3.0"
+    "version": "1.4.0"
   },
   "homee": {
     "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.homee/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.homeconnect to version 1.4.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*