### PR TITLE
Update boschindego to 1.2.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -260,6 +260,12 @@
     "type": "vehicle",
     "version": "0.0.3"
   },
+  "boschindego": {
+    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.boschindego/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.boschindego/main/admin/boschindego.png",
+    "type": "garden",
+    "version": "1.2.0"
+  },
   "bosesoundtouch": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.bosesoundtouch/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.bosesoundtouch/master/admin/bosesoundtouch.png",


### PR DESCRIPTION
Please update my adapter ioBroker.boschindego to version 1.2.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*