### PR TITLE
Bump Kostal-Piko-BA stable to 4.0.0.

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1296,7 +1296,7 @@
     "meta": "https://raw.githubusercontent.com/hombach/ioBroker.kostal-piko-ba/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/hombach/ioBroker.kostal-piko-ba/master/admin/picoba.png",
     "type": "energy",
-    "version": "3.1.0"
+    "version": "4.0.0"
   },
   "lametric": {
     "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.lametric/master/io-package.json",


### PR DESCRIPTION
drop support of node 16