### PR TITLE
Update rct to 1.2.7

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2112,7 +2112,7 @@
     "meta": "https://raw.githubusercontent.com/aruttkamp/ioBroker.rct/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/aruttkamp/ioBroker.rct/main/admin/rct-logo.square.png",
     "type": "energy",
-    "version": "1.2.4"
+    "version": "1.2.7"
   },
   "renacidc": {
     "meta": "https://raw.githubusercontent.com/raschy/ioBroker.renacidc/main/io-package.json",


### PR DESCRIPTION
Please update stable version of ioBroker.rct from 1.2.4 to 1.2.7

Changelog:
1.2.7 (2024-05-05)
(Andreas Ruttkamp) prim_sm.state added
(NCIceWolf) handling of type errors added
(Andreas Ruttkamp) some Code cleaning
(NCIceWolf) Update io-package.json

1.2.6 (2024-05-03)
(Andreas Ruttkamp) unused parameter deleted

1.2.5 (2024-05-02)
(Andreas Ruttkamp) misspelling in rct_core2 corrected 
(Andreas Ruttkamp) Missing ack:true added
(Andreas Ruttkamp) datatypes corrected
(NCIceWolf) changes to correct loosing connection