### PR TITLE
Update solarwetter to 1.2.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2430,7 +2430,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solarwetter/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solarwetter/master/admin/solarwetter.png",
     "type": "weather",
-    "version": "1.1.5"
+    "version": "1.2.0"
   },
   "solax": {
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.solax/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.solarwetter to version 1.2.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*