### PR TITLE
Update frigate to 1.2.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -750,7 +750,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.frigate/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.frigate/main/admin/frigate.png",
     "type": "alarm",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "fritzbox": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fritzbox/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.frigate to version 1.2.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*