### PR TITLE
Update philips-air to 1.1.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1950,7 +1950,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.philips-air/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.philips-air/master/admin/philips-air.png",
     "type": "household",
-    "version": "1.0.3"
+    "version": "1.1.0"
   },
   "philips-tv": {
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.philips-tv/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.philips-air to version 1.1.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*