### PR TITLE
Update sony-bravia to 1.1.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2466,7 +2466,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.sony-bravia/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.sony-bravia/master/admin/sony-bravia.png",
     "type": "multimedia",
-    "version": "1.0.9"
+    "version": "1.1.0"
   },
   "spotify-premium": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.spotify-premium/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.sony-bravia to version 1.1.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*