### PR TITLE
Update tractive-gps to 1.2.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2646,7 +2646,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tractive-gps/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tractive-gps/main/admin/tractive-gps.png",
     "type": "geoposition",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "tradfri": {
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.tradfri/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.tractive-gps to version 1.2.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*