### PR TITLE
Update spotify-premium to 1.5.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2466,7 +2466,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.spotify-premium/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.spotify-premium/master/admin/spotify-premium.png",
     "type": "multimedia",
-    "version": "1.4.0"
+    "version": "1.5.0"
   },
   "sprinklecontrol": {
     "meta": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.spotify-premium to version 1.5.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*