### PR TITLE
Update knx to 2.0.28

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1284,7 +1284,7 @@
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.knx/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.knx/master/admin/knx.png",
     "type": "iot-systems",
-    "version": "2.0.26"
+    "version": "2.0.28"
   },
   "kodi": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.kodi/master/io-package.json",


### PR DESCRIPTION
@chefkoch009 
This is a follow up to reverted #3636 ( Update license related data and fix package version ).

#3636 has been merged on error. As 2.0.28 has been released just an hour ago it should (must) be available at latest some time before going to stable. **If this release should be considered a hotfix requiring immidiate release, please comment.**

Otherwise I will keep this PR in evidence and release it to stable if no major Issues occure during availability at latest repository. No action is required by you.

mcm1957

reminder 26.5.2024