### PR TITLE
Update device-watcher to 2.12.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -438,7 +438,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.device-watcher/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.device-watcher/main/admin/device-watcher.png",
     "type": "misc-data",
-    "version": "2.12.0"
+    "version": "2.12.1"
   },
   "devices": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.devices/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.device-watcher to version 2.12.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*