### PR TITLE
Update doorio to 2.1.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -492,7 +492,7 @@
     "meta": "https://raw.githubusercontent.com/Bettman66/ioBroker.doorio/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Bettman66/ioBroker.doorio/master/admin/doorio.png",
     "type": "communication",
-    "version": "2.1.4"
+    "version": "2.1.5"
   },
   "drag-indicator": {
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.drag-indicator/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.doorio to version 2.1.5.

*This pull request was created by https://www.iobroker.dev c0726ff.*