### PR TITLE
Add gree-hvac 1.0.0 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -842,6 +842,12 @@
     "type": "lighting",
     "version": "0.2.6"
   },
+  "gree-hvac": {
+    "meta": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/admin/air-conditioner.png",
+    "type": "climate-control",
+    "version": "1.0.0"
+  },
   "growatt": {
     "meta": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/admin/growatt.png",


### PR DESCRIPTION
Please update my adapter ioBroker.gree-hvac to version 1.0.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*