### PR TITLE
Update broadlink2 to 2.3.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -288,7 +288,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.broadlink2/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.broadlink2/master/admin/broadlink.png",
     "type": "iot-systems",
-    "version": "2.2.0"
+    "version": "2.3.0"
   },
   "bsblan": {
     "meta": "https://raw.githubusercontent.com/hacki11/ioBroker.bsblan/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.broadlink2 to version 2.3.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*