### PR TITLE
Update bshb to 0.2.8

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -300,7 +300,7 @@
     "meta": "https://raw.githubusercontent.com/holomekc/ioBroker.bshb/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/holomekc/ioBroker.bshb/master/admin/bshb-logo.jpg",
     "type": "iot-systems",
-    "version": "0.2.7"
+    "version": "0.2.8"
   },
   "bwt": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.bwt/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.bshb to version 0.2.8.

*This pull request was created by https://www.iobroker.dev c0726ff.*