### PR TITLE
Update rct to 1.2.9

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2118,7 +2118,7 @@
     "meta": "https://raw.githubusercontent.com/aruttkamp/ioBroker.rct/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/aruttkamp/ioBroker.rct/main/admin/rct-logo.square.png",
     "type": "energy",
-    "version": "1.2.7"
+    "version": "1.2.9"
   },
   "renacidc": {
     "meta": "https://raw.githubusercontent.com/raschy/ioBroker.renacidc/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.rct to version 1.2.9.

*This pull request was created by https://www.iobroker.dev c0726ff.*