### PR TITLE
Update unifi-protect to 1.0.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2712,7 +2712,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.unifi-protect/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.unifi-protect/master/admin/unifi-protect.png",
     "type": "alarm",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "upnp": {
     "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.upnp/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.unifi-protect to version 1.0.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*