### PR TITLE
Update e3dc-rscp to 1.2.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -516,7 +516,7 @@
     "meta": "https://raw.githubusercontent.com/git-kick/ioBroker.e3dc-rscp/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/git-kick/ioBroker.e3dc-rscp/master/admin/e3dc-rscp.png",
     "type": "energy",
-    "version": "1.2.5"
+    "version": "1.2.6"
   },
   "easee": {
     "meta": "https://raw.githubusercontent.com/Newan/ioBroker.easee/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.e3dc-rscp to version 1.2.6.

*This pull request was created by https://www.iobroker.dev c0726ff.*