### PR TITLE
Update cec2 to 0.1.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -336,7 +336,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.cec2/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.cec2/master/admin/cec2.png",
     "type": "multimedia",
-    "version": "0.1.1"
+    "version": "0.1.2"
   },
   "chromecast": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.chromecast/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.cec2 to version 0.1.2.

*This pull request was created by https://www.iobroker.dev c0726ff.*