### PR TITLE
add vis-2-widgets-rssfeed to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2699,6 +2699,11 @@
     "icon": "https://raw.githubusercontent.com/Steiger04/ioBroker.vis-2-widgets-radar-trap/main/admin/vis-2-widgets-radar-trap.png",
     "type": "visualization-widgets"
   },
+  "vis-2-widgets-rssfeed": {
+    "meta": "https://raw.githubusercontent.com/Steiger04/ioBroker.vis-2-widgets-rssfeed/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Steiger04/ioBroker.vis-2-widgets-rssfeed/main/admin/vis-2-widgets-rssfeed.png.png",
+    "type": "visualization-widgets"
+  },  
   "vis-2-widgets-sweethome3d": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-sweethome3d/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-sweethome3d/main/admin/vis-2-widgets-sweethome3d.png",


### PR DESCRIPTION

## existing adapter checker issues

[E124] Main file not found under URL: https://raw.githubusercontent.com/oweitman/ioBroker.vis-2-widgets-rssfeed/main/widgets/vis-2-widgets-rssfeed/customWidgets.js
**-> not changeable, the file is created in the build process**

[E201] Bluefox was not found in the collaborators on NPM!. Please execute in adapter directory: "npm owner add bluefox iobroker.vis-2-widgets-rssfeed"
**-> bluefox has been added, he has yet to accept**

[E519] "widgets/vis-2-widgets-rssfeed/customWidgets.js" found in package.json, but not found as file
**-> not changeable, the file is created in the build process**


[W400] Cannot find "vis-2-widgets-rssfeed" in latest repository
**-> yes, here it is**

[W513] "gulpfile.js" found in repo! Think about migrating to @iobroker/adapter-dev package
**-> for vis-2 widgets we need the gulpfile for the build process**