### PR TITLE
Add vis-2-widgets-rssfeed  to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2699,6 +2699,11 @@
     "icon": "https://raw.githubusercontent.com/Steiger04/ioBroker.vis-2-widgets-radar-trap/main/admin/vis-2-widgets-radar-trap.png",
     "type": "visualization-widgets"
   },
+  "vis-2-widgets-rssfeed": {
+    "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-2-widgets-rssfeed/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-2-widgets-rssfeed/main/admin/ioBroker.vis-2-widgets-rssfeed.png",
+    "type": "visualization-widgets"
+  },
   "vis-2-widgets-sweethome3d": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-sweethome3d/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-sweethome3d/main/admin/vis-2-widgets-sweethome3d.png",

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2701,7 +2701,7 @@
   },
   "vis-2-widgets-rssfeed": {
     "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-2-widgets-rssfeed/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-2-widgets-rssfeed/main/admin/ioBroker.vis-2-widgets-rssfeed.png",
+    "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-2-widgets-rssfeed/main/admin/vis-2-widgets-rssfeed.png",
     "type": "visualization-widgets"
   },
   "vis-2-widgets-sweethome3d": {


### PR DESCRIPTION
[E124] Main file not found under URL: https://raw.githubusercontent.com/oweitman/ioBroker.vis-2-widgets-rssfeed/main/widgets/vis-2-widgets-rssfeed/customWidgets.js 
**-> datei wird im build prozess erzeugt**

[E201] Bluefox was not found in the collaborators on NPM!. Please execute in adapter directory: "npm owner add bluefox iobroker.vis-2-widgets-rssfeed" 
**-> bluefox wurde hinzugefügt und hat angenommen**

[E519] "widgets/vis-2-widgets-rssfeed/customWidgets.js" found in package.json, but not found as file 
**-> datei wird im build prozess erzeugt**

[W400] Cannot find "vis-2-widgets-rssfeed" in latest repository 
**-> ja genau, hier ist es**

[W513] "gulpfile.js" found in repo! Think about migrating to @iobroker/adapter-dev package 
**-> für vis-2 widgets wird es noch benötigt**