### PR TITLE
Update daikin-cloud to 0.4.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -402,7 +402,7 @@
     "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.daikin-cloud/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.daikin-cloud/master/admin/daikin-cloud.jpg",
     "type": "climate-control",
-    "version": "0.3.0"
+    "version": "0.4.6"
   },
   "daswetter": {
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.daswetter/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.daikin-cloud to version 0.4.6.

@mcm1957 Fast lane needed because Daikin-Cloud Integration of old adapter broken since 3 days. tested in tester Thread

*This pull request was created by https://www.iobroker.dev c0726ff.*