### PR TITLE
Add iopooleco 0.5.1 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1196,6 +1196,12 @@
     "type": "household",
     "version": "0.1.5"
   },
+  "iopooleco": {
+    "meta": "https://raw.githubusercontent.com/mule1972/ioBroker.iopooleco/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/mule1972/ioBroker.iopooleco/main/admin/iopooleco.png",
+    "type": "metering",
+    "version": "0.5.1"
+  },
   "iot": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.iot/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.iot/master/admin/iot.png",


### PR DESCRIPTION
Please update my adapter ioBroker.iopooleco to version 0.5.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*