### PR TITLE
Update daikin-cloud to 0.4.8

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -402,7 +402,7 @@
     "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.daikin-cloud/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.daikin-cloud/master/admin/daikin-cloud.jpg",
     "type": "climate-control",
-    "version": "0.4.6"
+    "version": "0.4.8"
   },
   "daswetter": {
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.daswetter/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.daikin-cloud to version 0.4.8.

Fast lane please because of rate limit optimizations

*This pull request was created by https://www.iobroker.dev c0726ff.*