### PR TITLE
Add egigeozone2 1.0.6 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -548,6 +548,12 @@
     "type": "household",
     "version": "1.4.15"
   },
+  "egigeozone2": {
+    "meta": "https://raw.githubusercontent.com/obakuhl/ioBroker.egigeozone2/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/obakuhl/ioBroker.egigeozone2/master/admin/egigeozone.png",
+    "type": "geoposition",
+    "version": "1.0.6"
+  },
   "ekey": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.ekey/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.ekey/master/admin/ekey.png",


### PR DESCRIPTION
Please update my adapter ioBroker.egigeozone2 to version 1.0.6.

*This pull request was created by https://www.iobroker.dev c0726ff.*