### PR TITLE
Add extron 0.2.15 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -668,6 +668,12 @@
     "type": "misc-data",
     "version": "0.1.0"
   },
+  "extron": {
+    "meta": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.extron/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.extron/master/admin/extron.png",
+    "type": "hardware",
+    "version": "0.2.15"
+  },
   "fahrplan": {
     "meta": "https://raw.githubusercontent.com/gaudes/ioBroker.fahrplan/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/gaudes/ioBroker.fahrplan/master/admin/fahrplan.png",


### PR DESCRIPTION
Please update my adapter ioBroker.extron to version 0.2.15.

*This pull request was created by https://www.iobroker.dev c0726ff.*