### PR TITLE
Update backitup to 3.0.16

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -192,7 +192,7 @@
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.backitup/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/simatec/ioBroker.backitup/master/admin/backitup.png",
     "type": "general",
-    "version": "2.11.0"
+    "version": "3.0.16"
   },
   "beckhoff": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.beckhoff/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.backitup to version 3.0.16.

*This pull request was created by https://www.iobroker.dev c0726ff.*