### PR TITLE
Update rssfeed to 3.0.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2208,7 +2208,7 @@
     "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.rssfeed/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.rssfeed/main/admin/rssfeed.png",
     "type": "misc-data",
-    "version": "2.9.7"
+    "version": "3.0.2"
   },
   "s7": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.s7/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.rssfeed to version 3.0.2.

*This pull request was created by https://www.iobroker.dev c0726ff.*