### PR TITLE
Update drag-indicator to 2.1.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -492,7 +492,7 @@
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.drag-indicator/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.drag-indicator/main/admin/drag-indicator.png",
     "type": "misc-data",
-    "version": "2.1.4"
+    "version": "2.1.6"
   },
   "ds18b20": {
     "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.ds18b20/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.drag-indicator to version 2.1.6.

*This pull request was created by https://www.iobroker.dev c0726ff.*