### PR TITLE
Update lowpass-filter to 2.2.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1440,7 +1440,7 @@
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lowpass-filter/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lowpass-filter/main/admin/lowpass-filter.png",
     "type": "misc-data",
-    "version": "2.2.3"
+    "version": "2.2.5"
   },
   "loxone": {
     "meta": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.loxone/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.lowpass-filter to version 2.2.5.

*This pull request was created by https://www.iobroker.dev c0726ff.*