### PR TITLE
Add hiob 0.1.5 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -974,6 +974,12 @@
     "type": "alarm",
     "version": "0.1.0"
   },
+  "hiob": {
+    "meta": "https://raw.githubusercontent.com/moba15/ioBroker.hiob/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/moba15/ioBroker.hiob/main/admin/hiob.png",
+    "type": "visualization",
+    "version": "0.1.5"
+  },
   "history": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.history/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.history/master/admin/history.png",


### PR DESCRIPTION
Please update my adapter ioBroker.hiob to version 0.1.6.

*This pull request was created by https://www.iobroker.dev c0726ff.*