### PR TITLE
Bumb TibberLink stable to 3.4.8

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2610,7 +2610,7 @@
     "meta": "https://raw.githubusercontent.com/hombach/ioBroker.tibberlink/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/hombach/ioBroker.tibberlink/master/admin/tibberlink.png",
     "type": "energy",
-    "version": "3.4.3"
+    "version": "3.4.8"
   },
   "tinker": {
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.tinker/master/io-package.json",


### PR DESCRIPTION
3.4.7 ist 7 days old 3.4.8 only fixes axios security issue on top. So i would like to speed up the release.