### PR TITLE
Update harmony to 1.5.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -906,7 +906,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.harmony/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.harmony/master/admin/harmony.png",
     "type": "multimedia",
-    "version": "1.4.0"
+    "version": "1.5.0"
   },
   "hass": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.hass/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.harmony to version 1.5.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*