### PR TITLE
Update alpha-ess to 2.1.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -102,7 +102,7 @@
     "meta": "https://raw.githubusercontent.com/Gaspode69/ioBroker.alpha-ess/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Gaspode69/ioBroker.alpha-ess/main/admin/alpha-ess.png",
     "type": "energy",
-    "version": "2.0.2"
+    "version": "2.1.4"
   },
   "alpha2": {
     "meta": "https://raw.githubusercontent.com/Eisbaeeer/ioBroker.alpha2/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.alpha-ess to version 2.1.4.

*This pull request was created by https://www.iobroker.dev c0726ff.*