### PR TITLE
Update lametric to 3.3.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1314,7 +1314,7 @@
     "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.lametric/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.lametric/master/admin/lametric.png",
     "type": "hardware",
-    "version": "3.2.1"
+    "version": "3.3.0"
   },
   "lcn": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.lcn/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.lametric to version 3.3.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*