### PR TITLE
Update operating-hours to 1.1.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1890,7 +1890,7 @@
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.operating-hours/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.operating-hours/main/admin/operating-hours.png",
     "type": "metering",
-    "version": "1.0.6"
+    "version": "1.1.0"
   },
   "opi": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.opi/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.operating-hours to version 1.1.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*