### PR TITLE
Update opendtu to 2.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1860,7 +1860,7 @@
     "meta": "https://raw.githubusercontent.com/o0shojo0o/ioBroker.opendtu/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/o0shojo0o/ioBroker.opendtu/main/admin/opendtu.png",
     "type": "energy",
-    "version": "1.0.1"
+    "version": "2.0.0"
   },
   "openhab": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.openhab/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.opendtu to version 2.0.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*