### PR TITLE
Update reolink to 1.1.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2142,7 +2142,7 @@
     "meta": "https://raw.githubusercontent.com/aendue/ioBroker.reolink/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/aendue/ioBroker.reolink/main/admin/reolink_logo.png",
     "type": "alarm",
-    "version": "1.1.0"
+    "version": "1.1.1"
   },
   "residents": {
     "meta": "https://raw.githubusercontent.com/jpawlowski/ioBroker.residents/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.reolink to version 1.1.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*