### PR TITLE
Update hiob to 0.1.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -990,7 +990,7 @@
     "meta": "https://raw.githubusercontent.com/moba15/ioBroker.hiob/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/moba15/ioBroker.hiob/main/admin/hiob.png",
     "type": "visualization",
-    "version": "0.1.5"
+    "version": "0.1.6"
   },
   "history": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.history/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.hiob to version 0.1.6.

*This pull request was created by https://www.iobroker.dev c0726ff.*