### PR TITLE
Update growatt to 3.2.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -864,7 +864,7 @@
     "meta": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/admin/growatt.png",
     "type": "energy",
-    "version": "3.2.4"
+    "version": "3.2.5"
   },
   "gruenbeck": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.gruenbeck/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.growatt to version 3.2.5.

*This pull request was created by https://www.iobroker.dev c0726ff.*