### PR TITLE
Update govee-local to 0.2.7

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -852,7 +852,7 @@
     "meta": "https://raw.githubusercontent.com/boergegrunicke/ioBroker.govee-local/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/boergegrunicke/ioBroker.govee-local/main/admin/govee-local.png",
     "type": "lighting",
-    "version": "0.2.6"
+    "version": "0.2.7"
   },
   "gree-hvac": {
     "meta": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.govee-local to version 0.2.7.

*This pull request was created by https://www.iobroker.dev c0726ff.*