### PR TITLE
Update renacidc to 0.1.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2148,7 +2148,7 @@
     "meta": "https://raw.githubusercontent.com/raschy/ioBroker.renacidc/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/raschy/ioBroker.renacidc/main/admin/renacidc.png",
     "type": "energy",
-    "version": "0.0.6"
+    "version": "0.1.2"
   },
   "reolink": {
     "meta": "https://raw.githubusercontent.com/aendue/ioBroker.reolink/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.renacidc to version 0.1.2.

*This pull request was created by https://www.iobroker.dev c0726ff.*