### PR TITLE
Update procon-ip to 1.6.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2070,7 +2070,7 @@
     "meta": "https://raw.githubusercontent.com/ylabonte/ioBroker.procon-ip/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ylabonte/ioBroker.procon-ip/master/admin/procon-ip.png",
     "type": "iot-systems",
-    "version": "1.5.4"
+    "version": "1.6.0"
   },
   "proxmox": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.proxmox/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.procon-ip to version 1.6.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*