### PR TITLE
Update rct to 1.2.14

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2154,7 +2154,7 @@
     "meta": "https://raw.githubusercontent.com/aruttkamp/ioBroker.rct/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/aruttkamp/ioBroker.rct/main/admin/rct-logo.square.png",
     "type": "energy",
-    "version": "1.2.13"
+    "version": "1.2.14"
   },
   "renacidc": {
     "meta": "https://raw.githubusercontent.com/raschy/ioBroker.renacidc/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.rct to version 1.2.14.

*This pull request was created by https://www.iobroker.dev c0726ff.*