### PR TITLE
Update wireguard to 1.7.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3108,7 +3108,7 @@
     "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.wireguard/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.wireguard/main/admin/wireguard.svg",
     "type": "infrastructure",
-    "version": "1.6.4"
+    "version": "1.7.0"
   },
   "wireless-mbus": {
     "meta": "https://raw.githubusercontent.com/lvogt/ioBroker.wireless-mbus/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.wireguard to version 1.7.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*