### PR TITLE
Update mielecloudservice to 6.5.7

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1596,7 +1596,7 @@
     "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.mielecloudservice/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.mielecloudservice/master/admin/mielecloudservice.svg",
     "type": "household",
-    "version": "6.5.6"
+    "version": "6.5.7"
   },
   "mihome": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.mihome/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.mielecloudservice to version 6.5.7.

*This pull request was created by https://www.iobroker.dev c0726ff.*