### PR TITLE
Update dysonairpurifier to 3.2.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -498,7 +498,7 @@
     "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.dysonairpurifier/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.dysonairpurifier/master/admin/dyson_logo.svg",
     "type": "climate-control",
-    "version": "3.2.3"
+    "version": "3.2.4"
   },
   "e3dc-rscp": {
     "meta": "https://raw.githubusercontent.com/git-kick/ioBroker.e3dc-rscp/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.dysonairpurifier to version 3.2.4.

*This pull request was created by https://www.iobroker.dev c0726ff.*