### PR TITLE
Update ecoflow-mqtt to 1.0.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -530,6 +530,12 @@
     "type": "visualization",
     "version": "1.9.2"
   },
+  "ecoflow-mqtt": {
+    "meta": "https://raw.githubusercontent.com/foxthefox/ioBroker.ecoflow-mqtt/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/foxthefox/ioBroker.ecoflow-mqtt/main/admin/ecoflow-mqtt.png",
+    "type": "iot-systems",
+    "version": "1.0.4"
+  },
   "ecovacs-deebot": {
     "meta": "https://raw.githubusercontent.com/mrbungle64/ioBroker.ecovacs-deebot/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/mrbungle64/ioBroker.ecovacs-deebot/master/admin/ecovacs-deebot.png",


### PR DESCRIPTION
Please update my adapter ioBroker.ecoflow-mqtt to version 1.0.4.

*This pull request was created by https://www.iobroker.dev c0726ff.*