### PR TITLE
Update google-spreadsheet to 0.3.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -848,6 +848,12 @@
     "type": "vehicle",
     "version": "1.0.29"
   },
+  "google-spreadsheet": {
+    "meta": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.google-spreadsheet/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.google-spreadsheet/main/admin/google-spreadsheet.png",
+    "type": "storage",
+    "version": "0.3.1"
+  },
   "gotify-ws": {
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.gotify-ws/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/simatec/ioBroker.gotify-ws/master/admin/gotify-ws.png",


### PR DESCRIPTION
Please update my adapter ioBroker.google-spreadsheet to version 0.3.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*