### PR TITLE
Add remeha-home 0.2.4 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2156,6 +2156,12 @@
     "type": "energy",
     "version": "1.2.14"
   },
+  "remeha-home": {
+    "meta": "https://raw.githubusercontent.com/simatec/ioBroker.remeha-home/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/simatec/ioBroker.remeha-home/master/admin/remeha-home.png",
+    "type": "climate-control",
+    "version": "0.2.4"
+  },
   "renacidc": {
     "meta": "https://raw.githubusercontent.com/raschy/ioBroker.renacidc/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/raschy/ioBroker.renacidc/main/admin/renacidc.png",


### PR DESCRIPTION
Please update my adapter ioBroker.remeha-home to version 0.2.4.

*This pull request was created by https://www.iobroker.dev c0726ff.*