### PR TITLE
Update deyeidc to 0.1.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -432,7 +432,7 @@
     "meta": "https://raw.githubusercontent.com/raschy/ioBroker.deyeidc/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/raschy/ioBroker.deyeidc/main/admin/deyeidc.png",
     "type": "energy",
-    "version": "0.1.0"
+    "version": "0.1.1"
   },
   "digitalstrom": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.digitalstrom/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.deyeidc to version 0.1.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*