### PR TITLE
Update go-e 1.0.41

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -846,7 +846,7 @@
     "meta": "https://raw.githubusercontent.com/MK-2001/ioBroker.go-e/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/MK-2001/ioBroker.go-e/main/admin/go-echarger.png",
     "type": "vehicle",
-    "version": "1.0.29"
+    "version": "1.0.41"
   },
   "gotify-ws": {
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.gotify-ws/master/io-package.json",


### PR DESCRIPTION
Closes https://github.com/MK-2001/ioBroker.go-e/issues/268 
1.0.41 is the same as 1.0.40; 
Just adjusted testing because it was not functional