### PR TITLE
Update rpi2 to 2.2.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2232,7 +2232,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.rpi2/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.rpi2/master/admin/rpi2.png",
     "type": "hardware",
-    "version": "1.3.2"
+    "version": "2.2.1"
   },
   "rssfeed": {
     "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.rssfeed/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.rpi2 to version 2.2.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*