### PR TITLE
Update tado to 0.6.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2586,7 +2586,7 @@
     "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.tado/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.tado/main/admin/tado.png",
     "type": "climate-control",
-    "version": "0.5.9"
+    "version": "0.6.1"
   },
   "tahoma": {
     "meta": "https://raw.githubusercontent.com/Excodibur/ioBroker.tahoma/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.tado to version 0.6.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*