### PR TITLE
Revert "Update vis-icontwo to 1.6.3 (#4275)"

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2904,7 +2904,7 @@
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-icontwo/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-icontwo/master/admin/icontwo.png",
     "type": "visualization-icons",
-    "version": "1.6.3"
+    "version": "1.5.0"
   },
   "vis-inventwo": {
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-inventwo/master/io-package.json",


### PR DESCRIPTION
This reverts commit a909c3ded31fa63c358224f3f1a7f6c6e1d638df.

@skvarel
As updating vis-icontwo is obviously against your will, I revert my PR.
STABLE repository release of vis-icontwo is now reset to 1.5.0 again.
I hope thats ok for you.

Sorry for problem I have caused for you. There will no more automatic updated for adapters owned by inventwo.

@Apollon77 FYI