### PR TITLE
Update discord stable to v2.5.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -444,7 +444,7 @@
     "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.discord/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.discord/main/admin/discord.png",
     "type": "messaging",
-    "version": "2.4.0"
+    "version": "2.5.2"
   },
   "discovergy": {
     "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.discovergy/main/io-package.json",


### PR DESCRIPTION
v2.5.2 is the same as 2.5.1 but with the latest fixes for sizes in jsonConfig.
Ref crycode-de/ioBroker.discord#76