### PR TITLE
Update odl stable to v4.0.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1836,7 +1836,7 @@
     "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.odl/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.odl/master/admin/odl.png",
     "type": "misc-data",
-    "version": "3.0.1"
+    "version": "4.0.2"
   },
   "oekofen-json": {
     "meta": "https://raw.githubusercontent.com/chaozmc/ioBroker.oekofen-json/main/io-package.json",


### PR DESCRIPTION
 v4.0.2 is the same as v4.0.1 but with the latest fixes for sizes in jsonConfig.