### PR TITLE
Update epson_ecotank_et_2750 to 1.0.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -630,7 +630,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.epson_ecotank_et_2750/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.epson_ecotank_et_2750/master/admin/epson_ecotank_et_2750.png",
     "type": "infrastructure",
-    "version": "0.0.12"
+    "version": "1.0.1"
   },
   "epson_stylus_px830": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.epson_stylus_px830/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.epson_ecotank_et_2750 to version 1.0.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*