### PR TITLE
Add google-spreadsheet 0.4.0 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -848,6 +848,12 @@
     "type": "vehicle",
     "version": "1.0.41"
   },
+  "google-spreadsheet": {
+    "meta": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.google-spreadsheet/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.google-spreadsheet/main/admin/google-spreadsheet.png",
+    "type": "storage",
+    "version": "0.4.0"
+  },
   "gotify": {
     "meta": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.gotify/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.gotify/main/admin/gotify.png",


### PR DESCRIPTION
Please update my adapter ioBroker.google-spreadsheet to version 0.4.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*