### PR TITLE
Update iqontrol to 3.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1242,7 +1242,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.iqontrol/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.iqontrol/master/admin/iqontrol.png",
     "type": "visualization",
-    "version": "2.3.0"
+    "version": "3.0.0"
   },
   "iwg-vpn": {
     "meta": "https://raw.githubusercontent.com/iwg-vpn/ioBroker.iwg-vpn/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.iqontrol to version 3.0.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*