### PR TITLE
Update lametric to 3.4.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1338,7 +1338,7 @@
     "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.lametric/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.lametric/master/admin/lametric.png",
     "type": "hardware",
-    "version": "3.4.0"
+    "version": "3.4.1"
   },
   "lcn": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.lcn/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.lametric to version 3.4.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*