### PR TITLE
Add ta-blnet to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2470,6 +2470,11 @@
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.systeminfo/master/admin/systeminfo.png",
     "type": "misc-data"
   },
+  "ta-blnet": {
+    "meta": "https://raw.githubusercontent.com/weberk/ioBroker.ta-blnet/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/weberk/ioBroker.ta-blnet/main/admin/ta-blnet.png",
+    "type": "climate-control"
+  },
   "tado": {
     "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.tado/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.tado/main/admin/tado.png",


### PR DESCRIPTION
Added an ioBroker adapter for the device BL-NET from Technische Alternative
This PR superseds [Add uvr16xx-blnet to latest #4298](https://github.com/ioBroker/ioBroker.repositories/pull/4298)