### PR TITLE
Update pvforecast to 4.1.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2118,7 +2118,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pvforecast/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pvforecast/main/admin/pvforecast.png",
     "type": "energy",
-    "version": "3.0.0"
+    "version": "4.1.0"
   },
   "pvoutputorg": {
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.pvoutputorg/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.pvforecast to version 4.1.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*