### PR TITLE
Update espresense to 0.4.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -642,7 +642,7 @@
     "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.espresense/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.espresense/main/admin/espresense.png",
     "type": "geoposition",
-    "version": "0.4.4"
+    "version": "0.4.6"
   },
   "eusec": {
     "meta": "https://raw.githubusercontent.com/bropat/ioBroker.eusec/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.espresense to version 0.4.6.

*This pull request was created by https://www.iobroker.dev c0726ff.*