### PR TITLE
Update nibeuplink to 1.3.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1782,7 +1782,7 @@
     "meta": "https://raw.githubusercontent.com/sebilm/ioBroker.nibeuplink/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/sebilm/ioBroker.nibeuplink/master/admin/nibeuplink.png",
     "type": "climate-control",
-    "version": "1.3.1"
+    "version": "1.3.2"
   },
   "nina": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.nina/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.nibeuplink to version 1.3.2.

*This pull request was created by https://www.iobroker.dev c0726ff.*