### PR TITLE
Update ring to 6.3.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2226,7 +2226,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ring/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ring/master/admin/ring.png",
     "type": "hardware",
-    "version": "6.2.1"
+    "version": "6.3.0"
   },
   "robonect": {
     "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.robonect/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.ring to version 6.3.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*