### PR TITLE
Update zendure-solarflow to 1.10.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3276,7 +3276,7 @@
     "meta": "https://raw.githubusercontent.com/nograx/ioBroker.zendure-solarflow/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/nograx/ioBroker.zendure-solarflow/main/admin/zendure-solarflow.png",
     "type": "energy",
-    "version": "1.8.8"
+    "version": "1.10.0"
   },
   "zigbee": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.zigbee/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.zendure-solarflow to version 1.10.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*