### PR TITLE
Update opendtu to 3.1.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1896,7 +1896,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.opendtu/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.opendtu/main/admin/opendtu.png",
     "type": "energy",
-    "version": "2.0.0"
+    "version": "3.1.0"
   },
   "openhab": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.openhab/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.opendtu to version 3.1.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*