### PR TITLE
Update ebus to 3.4.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -523,7 +523,7 @@
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.ebus/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.ebus/master/admin/ebus.png",
     "type": "hardware",
-    "version": "3.3.6"
+    "version": "3.4.0"
   },
   "echarts": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.echarts/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.ebus to version 3.4.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*