### PR TITLE
Update pvoutputorg to 1.9.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2137,7 +2137,7 @@
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.pvoutputorg/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.pvoutputorg/master/admin/pvoutputorg.png",
     "type": "energy",
-    "version": "1.8.13"
+    "version": "1.9.0"
   },
   "pylontech": {
     "meta": "https://raw.githubusercontent.com/PLCHome/ioBroker.pylontech/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.pvoutputorg to version 1.9.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*