### PR TITLE
Add mytime 1.2.2 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1737,6 +1737,12 @@
     "type": "iot-systems",
     "version": "3.0.0"
   },
+  "mytime": {
+    "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.mytime/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.mytime/main/admin/mytime.png",
+    "type": "visualization",
+    "version": "1.2.2"
+  },
   "myuplink": {
     "meta": "https://raw.githubusercontent.com/sebilm/ioBroker.myuplink/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/sebilm/ioBroker.myuplink/main/admin/myuplink.png",


### PR DESCRIPTION
Please update my adapter ioBroker.mytime to version 1.2.2.

*This pull request was created by https://www.iobroker.dev c0726ff.*