### PR TITLE
Add bluesound 1.1.4 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -243,6 +243,12 @@
     "type": "vehicle",
     "version": "2.3.6"
   },
+  "bluesound": {
+    "meta": "https://raw.githubusercontent.com/Uwe1958/ioBroker.bluesound/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Uwe1958/ioBroker.bluesound/main/admin/bluesound.png",
+    "type": "multimedia",
+    "version": "1.1.4"
+  },
   "boschindego": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.boschindego/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.boschindego/main/admin/boschindego.png",


### PR DESCRIPTION
Please update my adapter ioBroker.bluesound to version 1.1.4.

*This pull request was created by https://www.iobroker.dev c0726ff.*