### PR TITLE
Add ta-blnet 1.0.36 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2619,6 +2619,12 @@
     "type": "misc-data",
     "version": "1.2.0"
   },
+  "ta-blnet": {
+    "meta": "https://raw.githubusercontent.com/weberk/ioBroker.ta-blnet/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/weberk/ioBroker.ta-blnet/main/admin/ta-blnet.png",
+    "type": "climate-control",
+    "version": "1.0.36"
+  },
   "tado": {
     "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.tado/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.tado/main/admin/tado.png",


### PR DESCRIPTION
Please update my adapter ioBroker.ta-blnet to version 1.0.36.

*This pull request was created by https://www.iobroker.dev c0726ff.*

- Addition to Latest was done via PR https://github.com/ioBroker/ioBroker.repositories/pull/4334
- Testing was covered by discussion at https://forum.iobroker.net/topic/78225/test-adapter-ta-blnet-npm-latest