### PR TITLE
Add tagesschau to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2501,6 +2501,11 @@
     "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.tado/main/admin/tado.png",
     "type": "climate-control"
   },
+  "tagesschau": {
+    "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.tagesschau/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.tagesschau/main/admin/tagesschau.png",
+    "type": "misc-data"
+  },
   "tahoma": {
     "meta": "https://raw.githubusercontent.com/Excodibur/ioBroker.tahoma/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Excodibur/ioBroker.tahoma/master/admin/tahoma.png",


### PR DESCRIPTION
Please add my adapter ioBroker.tagesschau to latest.

Notes:
I have everything permanently in German in the adapter, as the information retrieved is only available in German.
I didn't notice anything more suitable for the type, but I'm very unsure about that.

FYI: I removed unit from jsonConfig and go back to stable admin.
[tagesschau.0.json](https://github.com/user-attachments/files/18511814/tagesschau.0.json)

