### PR TITLE
Update lowpass-filter to 2.4.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1471,7 +1471,7 @@
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lowpass-filter/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lowpass-filter/main/admin/lowpass-filter.png",
     "type": "misc-data",
-    "version": "2.3.0"
+    "version": "2.4.0"
   },
   "loxone": {
     "meta": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.loxone/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.lowpass-filter to version 2.4.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*