### PR TITLE
Update shelly to 8.5.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2383,7 +2383,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.shelly/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.shelly/master/admin/shelly.png",
     "type": "iot-systems",
-    "version": "8.2.1"
+    "version": "8.5.1"
   },
   "shuttercontrol": {
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.shuttercontrol/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.shelly to version 8.5.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*