### PR TITLE
Update ems-esp to 5.1.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -589,7 +589,7 @@
     "meta": "https://raw.githubusercontent.com/tp1de/ioBroker.ems-esp/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/tp1de/ioBroker.ems-esp/main/admin/ems-esp.png",
     "type": "climate-control",
-    "version": "5.0.6"
+    "version": "5.1.2"
   },
   "energiefluss": {
     "meta": "https://raw.githubusercontent.com/SKB-CGN/ioBroker.energiefluss/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.ems-esp to version 5.1.2.

*This pull request was created by https://www.iobroker.dev c0726ff.*