### PR TITLE
Update matrix-org to 1.1.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1507,7 +1507,7 @@
     "meta": "https://raw.githubusercontent.com/oelison/ioBroker.matrix-org/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/oelison/ioBroker.matrix-org/main/admin/matrix-logo.png",
     "type": "messaging",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "maveo": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.maveo/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.matrix-org to version 1.1.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*