### PR TITLE
Update lg-ess-home to 0.4.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1369,7 +1369,7 @@
     "meta": "https://raw.githubusercontent.com/Morluktom/ioBroker.lg-ess-home/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Morluktom/ioBroker.lg-ess-home/master/admin/lg-ess-home.png",
     "type": "energy",
-    "version": "0.3.0"
+    "version": "0.4.1"
   },
   "lg-thinq": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.lg-thinq/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.lg-ess-home to version 0.4.1.

*This pull request was created by https://www.iobroker.dev c0726ff.*