### PR TITLE
Add srm 1.0.0 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2571,6 +2571,12 @@
     "type": "multimedia",
     "version": "1.5.1"
   },
+  "srm": {
+    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.srm/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.srm/main/admin/srm.png",
+    "type": "hardware",
+    "version": "1.0.0"
+  },
   "starline": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.starline/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.starline/master/admin/starline.png",


### PR DESCRIPTION
Please update my adapter ioBroker.srm to version 1.0.0.

*This pull request was created by https://www.iobroker.dev c0726ff.*