### PR TITLE
Add paperless-ngx 0.2.1 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1989,6 +1989,12 @@
     "type": "multimedia",
     "version": "2.1.0"
   },
+  "paperless-ngx": {
+    "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.paperless-ngx/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.paperless-ngx/main/admin/paperless-ngx.png",
+    "type": "storage",
+    "version": "0.2.1"
+  },
   "parser": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.parser/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.parser/master/admin/parser.png",


### PR DESCRIPTION
Please update my adapter ioBroker.paperless-ngx to version 0.2.1.

*This pull request was created by https://www.iobroker.dev d0bb7c3.*