### PR TITLE
Update tinker to 1.3.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2713,7 +2713,7 @@
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.tinker/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/simatec/ioBroker.tinker/master/admin/tinker.png",
     "type": "hardware",
-    "version": "1.3.5"
+    "version": "1.3.6"
   },
   "tinymqttbroker": {
     "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.tinymqttbroker/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.tinker to version 1.3.6.

*This pull request was created by https://www.iobroker.dev 9bea956.*