### PR TITLE
Update rpi2 to 2.3.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2281,7 +2281,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.rpi2/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.rpi2/master/admin/rpi2.png",
     "type": "hardware",
-    "version": "2.2.1"
+    "version": "2.3.1"
   },
   "rssfeed": {
     "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.rssfeed/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.rpi2 to version 2.3.1.

*This pull request was created by https://www.iobroker.dev 9bea956.*