### PR TITLE
Update vis-material to 0.2.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3025,7 +3025,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-material/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-material/master/admin/material.png",
     "type": "visualization-widgets",
-    "version": "0.1.3"
+    "version": "0.2.0"
   },
   "vis-material-advanced": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-material-advanced/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-material to version 0.2.0.

*This pull request was created by https://www.iobroker.dev 9bea956.*