### PR TITLE
Add maxxi-charge 1.4.8 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1539,6 +1539,12 @@
     "type": "iot-systems",
     "version": "1.3.1"
   },
+  "maxxi-charge": {
+    "meta": "https://raw.githubusercontent.com/blabond/ioBroker.maxxi-charge/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/blabond/ioBroker.maxxi-charge/main/admin/maxxi-charge.png",
+    "type": "energy",
+    "version": "1.4.8"
+  },
   "mbus": {
     "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.mbus/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.mbus/master/admin/mbus.png",


### PR DESCRIPTION
Please update my adapter ioBroker.maxxi-charge to version 1.4.8.

*This pull request was created by https://www.iobroker.dev 9bea956.*