### PR TITLE
Add asterisk 2.0.2 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -153,6 +153,12 @@
     "type": "lighting",
     "version": "0.0.5"
   },
+  "asterisk": {
+    "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.asterisk/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/schmupu/ioBroker.asterisk/master/admin/asterisk.png",
+    "type": "communication",
+    "version": "2.0.2"
+  },
   "asuswrt": {
     "meta": "https://raw.githubusercontent.com/mcdhrts/ioBroker.asuswrt/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/mcdhrts/ioBroker.asuswrt/master/admin/asuswrt.png",


### PR DESCRIPTION
Please update my adapter ioBroker.asterisk to version 2.0.2.

*This pull request was created by https://www.iobroker.dev 9bea956.*