### PR TITLE
Update bshb to 0.5.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -295,7 +295,7 @@
     "meta": "https://raw.githubusercontent.com/holomekc/ioBroker.bshb/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/holomekc/ioBroker.bshb/master/admin/bshb-logo.jpg",
     "type": "iot-systems",
-    "version": "0.4.1"
+    "version": "0.5.0"
   },
   "bwt": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.bwt/master/io-package.json",


### PR DESCRIPTION
Update bshb to 0.5.0

I know it is a bit early, but there was an issue with 0.4.1,
which was fixed with 0.4.2 and 0.5.0

See: https://github.com/holomekc/ioBroker.bshb/issues/493 
and: https://forum.iobroker.net/topic/25370/test-adapter-bshb-bosch-smart-home-v0-0-x/430?_=1738870147327 