### PR TITLE
Update vis-homekittiles to 0.4.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2971,7 +2971,7 @@
     "meta": "https://raw.githubusercontent.com/Standarduser/ioBroker.vis-homekittiles/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Standarduser/ioBroker.vis-homekittiles/main/admin/vis-homekittiles.png",
     "type": "visualization-widgets",
-    "version": "0.3.2"
+    "version": "0.4.0"
   },
   "vis-hqwidgets": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-hqwidgets/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-homekittiles to version 0.4.0.

*This pull request was created by https://www.iobroker.dev 9bea956.*