### PR TITLE
Update fenecon to 0.6.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -709,7 +709,7 @@
     "meta": "https://raw.githubusercontent.com/sg-app/ioBroker.fenecon/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/sg-app/ioBroker.fenecon/main/admin/fenecon.png",
     "type": "energy",
-    "version": "0.5.0"
+    "version": "0.6.1"
   },
   "fhem": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fhem/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.fenecon to version 0.6.1.

*This pull request was created by https://www.iobroker.dev 9bea956.*