### PR TITLE
Update mqtt-client to 3.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1705,7 +1705,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mqtt-client/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mqtt-client/master/admin/mqtt-client.png",
     "type": "protocols",
-    "version": "2.1.0"
+    "version": "3.0.0"
   },
   "musiccast": {
     "meta": "https://raw.githubusercontent.com/foxthefox/ioBroker.musiccast/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.mqtt-client to version 3.0.0.

*This pull request was created by https://www.iobroker.dev 33803d6.*