### PR TITLE
Update vis-2-widgets-weather-and-heating to 0.9.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2905,7 +2905,7 @@
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-2-widgets-weather-and-heating/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-2-widgets-weather-and-heating/master/admin/vis-2-widgets-weather-and-heating.png",
     "type": "visualization-widgets",
-    "version": "0.8.0"
+    "version": "0.9.1"
   },
   "vis-bars": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-bars/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-2-widgets-weather-and-heating to version 0.9.1.

*This pull request was created by https://www.iobroker.dev 33803d6.*