### PR TITLE
Update apcups to 4.0.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -139,7 +139,7 @@
     "meta": "https://raw.githubusercontent.com/XHunter74/ioBroker.apcups/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/XHunter74/ioBroker.apcups/master/admin/ups.png",
     "type": "hardware",
-    "version": "4.0.2"
+    "version": "4.0.5"
   },
   "apg-info": {
     "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.apg-info/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.apcups to version 4.0.5.

*This pull request was created by https://www.iobroker.dev 33803d6.*