### PR TITLE
Update gree-hvac to 1.1.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -895,7 +895,7 @@
     "meta": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/admin/air-conditioner.png",
     "type": "climate-control",
-    "version": "1.1.2"
+    "version": "1.1.5"
   },
   "growatt": {
     "meta": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.gree-hvac to version 1.1.5.

*This pull request was created by https://www.iobroker.dev 33803d6.*