### PR TITLE
Update lupusec to 2.0.7

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1501,7 +1501,7 @@
     "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.lupusec/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/schmupu/ioBroker.lupusec/master/admin/lupusec.png",
     "type": "alarm",
-    "version": "2.0.5"
+    "version": "2.0.7"
   },
   "luxtronik1": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.luxtronik1/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.lupusec to version 2.0.7.

*This pull request was created by https://www.iobroker.dev 33803d6.*