### PR TITLE
Update jablotron to 0.1.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1273,7 +1273,7 @@
     "meta": "https://raw.githubusercontent.com/DEV2DEV-DE/ioBroker.jablotron/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/DEV2DEV-DE/ioBroker.jablotron/main/admin/jablotron.png",
     "type": "alarm",
-    "version": "0.1.5"
+    "version": "0.1.6"
   },
   "janitza-gridvis": {
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.janitza-gridvis/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.jablotron to version 0.1.6.

*This pull request was created by https://www.iobroker.dev 33803d6.*