### PR TITLE
Update tado to 0.7.1 [emergency update]

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2629,7 +2629,7 @@
     "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.tado/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.tado/main/admin/tado.png",
     "type": "climate-control",
-    "version": "0.6.1"
+    "version": "0.7.1"
   },
   "tagesschau": {
     "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.tagesschau/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.tado to version 0.7.1.

**IMPORTANT:**
As described in https://github.com/DrozmotiX/ioBroker.tado/issues/954 older versions of the adapter will no longer work starting on March 21, 2025.
Adapter is running in 0.7.1 for more than 40 users w/o troubles.
![image](https://github.com/user-attachments/assets/1f8a8339-a9c7-4845-89e4-20378a931285)

**Therefore I highly recommend to push it to production by today, so that as many users as possible, will update before March 21, 2025.**

@mcm1957, please take this info into account. Thanks!

*This pull request was created by https://www.iobroker.dev 33803d6.*