### PR TITLE
Update drag-indicator to 2.4.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -493,7 +493,7 @@
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.drag-indicator/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.drag-indicator/main/admin/drag-indicator.png",
     "type": "misc-data",
-    "version": "2.3.0"
+    "version": "2.4.0"
   },
   "ds18b20": {
     "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.ds18b20/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.drag-indicator to version 2.4.0.

*This pull request was created by https://www.iobroker.dev 33803d6.*