### PR TITLE
Update paperless-ngx to 0.4.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1975,7 +1975,7 @@
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.paperless-ngx/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.paperless-ngx/main/admin/paperless-ngx.png",
     "type": "storage",
-    "version": "0.2.1"
+    "version": "0.4.1"
   },
   "parser": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.parser/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.paperless-ngx to version 0.4.1.

*This pull request was created by https://www.iobroker.dev 33803d6.*