### PR TITLE
Update vis-homekittiles to 0.4.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2947,7 +2947,7 @@
     "meta": "https://raw.githubusercontent.com/Standarduser/ioBroker.vis-homekittiles/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Standarduser/ioBroker.vis-homekittiles/main/admin/vis-homekittiles.png",
     "type": "visualization-widgets",
-    "version": "0.4.0"
+    "version": "0.4.6"
   },
   "vis-hqwidgets": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-hqwidgets/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-homekittiles to version 0.4.6.

*This pull request was created by https://www.iobroker.dev 33803d6.*