### PR TITLE
Update tado to 0.7.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2629,7 +2629,7 @@
     "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.tado/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.tado/main/admin/tado.png",
     "type": "climate-control",
-    "version": "0.7.1"
+    "version": "0.7.2"
   },
   "tagesschau": {
     "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.tagesschau/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.tado to version 0.7.2.

Final update to be prepared for (older versions will no longer work starting on March 21)
https://github.com/DrozmotiX/ioBroker.tado/issues/954

Please pull latest on Monday, thanks!

*This pull request was created by https://www.iobroker.dev 33803d6.*