### PR TITLE
Update heatingcontrol to 2.12.14

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -967,7 +967,7 @@
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.heatingcontrol/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.heatingcontrol/master/admin/heatingcontrol.png",
     "type": "climate-control",
-    "version": "2.12.13"
+    "version": "2.12.14"
   },
   "heizoel": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.heizoel/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.heatingcontrol to version 2.12.14.

*This pull request was created by https://www.iobroker.dev 33803d6.*