### PR TITLE
Update vis-weather to 2.5.11

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3055,7 +3055,7 @@
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-weather/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-weather/master/admin/vis-weather.png",
     "type": "visualization-widgets",
-    "version": "2.5.9"
+    "version": "2.5.11"
   },
   "vivitek": {
     "meta": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.vivitek/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-weather to version 2.5.11.

*This pull request was created by https://www.iobroker.dev 33803d6.*