### PR TITLE
Update fuelpricemonitor to 0.4.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -823,7 +823,7 @@
     "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.fuelpricemonitor/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/HGlab01/ioBroker.fuelpricemonitor/main/admin/fuelpricemonitor.png",
     "type": "vehicle",
-    "version": "0.4.1"
+    "version": "0.4.2"
   },
   "fullcalendar": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.fullcalendar/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.fuelpricemonitor to version 0.4.2.

*This pull request was created by https://www.iobroker.dev 33803d6.*