### PR TITLE
Add seplos-v3-sniffer to 0.1.1 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2373,6 +2373,12 @@
     "type": "energy",
     "version": "1.6.17"
   },
+  "seplos-v3-sniffer": {
+    "meta": "https://raw.githubusercontent.com/DpunktS/ioBroker.seplos-v3-sniffer/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/DpunktS/ioBroker.seplos-v3-sniffer/main/admin/seplos-v3-sniffer.jpg",
+    "type": "iot-systems",
+    "version": "0.1.1"
+  },
   "seq": {
     "meta": "https://raw.githubusercontent.com/arteck/ioBroker.seq/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/arteck/ioBroker.seq/master/admin/seq.png",


### PR DESCRIPTION
Please update my adapter ioBroker.seplos-v3-sniffer to version 0.1.1.

*This pull request was created by https://www.iobroker.dev 33803d6.*