### PR TITLE
fyta - update icon URL at LATEST

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -802,7 +802,7 @@
   },
   "fyta": {
     "meta": "https://raw.githubusercontent.com/muffin142/ioBroker.fyta/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/muffin142/iobroker.fyta/main/admin/fyta.png",
+    "icon": "https://raw.githubusercontent.com/muffin142/ioBroker.fyta/main/admin/fyta.png",
     "type": "garden"
   },
   "g-homa": {


### PR DESCRIPTION
Corrected capitalization in icon-URL to pass AdapterChecker test:

[E405] Icon must be in the following path: https://raw.githubusercontent.com/muffin142/ioBroker.fyta/main/admin/; correct sources-dist.json