### PR TITLE
Update remeha-home to 1.0.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2191,7 +2191,7 @@
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.remeha-home/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/simatec/ioBroker.remeha-home/master/admin/remeha-home.png",
     "type": "climate-control",
-    "version": "0.2.7"
+    "version": "1.0.4"
   },
   "renacidc": {
     "meta": "https://raw.githubusercontent.com/raschy/ioBroker.renacidc/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.remeha-home to version 1.0.4.

*This pull request was created by https://www.iobroker.dev 33803d6.*