### PR TITLE
Add bayernluft 3.0.0 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -201,6 +201,12 @@
     "type": "general",
     "version": "3.0.31"
   },
+  "bayernluft": {
+    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.bayernluft/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.bayernluft/main/admin/bayernluft.png",
+    "type": "climate-control",
+    "version": "3.0.0"
+  },
   "beckhoff": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.beckhoff/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.beckhoff/master/admin/beckhoff.png",


### PR DESCRIPTION
Please update my adapter ioBroker.bayernluft to version 3.0.0.

*This pull request was created by https://www.iobroker.dev 33803d6.*