### PR TITLE
Update e3dc-rscp to 1.4.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -523,7 +523,7 @@
     "meta": "https://raw.githubusercontent.com/git-kick/ioBroker.e3dc-rscp/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/git-kick/ioBroker.e3dc-rscp/master/admin/e3dc-rscp.png",
     "type": "energy",
-    "version": "1.4.1"
+    "version": "1.4.2"
   },
   "e3oncan": {
     "meta": "https://raw.githubusercontent.com/MyHomeMyData/ioBroker.e3oncan/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.e3dc-rscp to version 1.4.2.

*This pull request was created by https://www.iobroker.dev 33803d6.*