### PR TITLE
Update lovelace to 4.1.15

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1483,7 +1483,7 @@
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.lovelace/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.lovelace/master/admin/lovelace.png",
     "type": "visualization",
-    "version": "4.1.11"
+    "version": "4.1.15"
   },
   "lowpass-filter": {
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lowpass-filter/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.lovelace to version 4.1.15.

*This pull request was created by https://www.iobroker.dev 33803d6.*