### PR TITLE
Add controme 0.5.7 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -381,6 +381,12 @@
     "type": "network",
     "version": "2.0.1"
   },
+  "controme": {
+    "meta": "https://raw.githubusercontent.com/MadErstam/ioBroker.controme/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/MadErstam/ioBroker.controme/main/admin/controme.png",
+    "type": "climate-control",
+    "version": "0.5.7"
+  },
   "coronavirus-statistics": {
     "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.coronavirus-statistics/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.coronavirus-statistics/main/admin/coronavirus-statistics.png",


### PR DESCRIPTION
Please update my adapter ioBroker.controme to version 0.5.7.

*This pull request was created by https://www.iobroker.dev 33803d6.*