### PR TITLE
Update cloudflare to 1.2.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -367,7 +367,7 @@
     "meta": "https://raw.githubusercontent.com/Marco15453/ioBroker.cloudflare/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Marco15453/ioBroker.cloudflare/main/admin/cloudflare.png",
     "type": "infrastructure",
-    "version": "1.2.4"
+    "version": "1.2.6"
   },
   "comfoair": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.comfoair/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.cloudflare to version 1.2.6.

*This pull request was created by https://www.iobroker.dev 33803d6.*