### PR TITLE
Update zendure-solarflow to 1.12.7

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3343,7 +3343,7 @@
     "meta": "https://raw.githubusercontent.com/nograx/ioBroker.zendure-solarflow/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/nograx/ioBroker.zendure-solarflow/main/admin/zendure-solarflow.png",
     "type": "energy",
-    "version": "1.11.0"
+    "version": "1.12.7"
   },
   "zigbee": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.zigbee/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.zendure-solarflow to version 1.12.7.

*This pull request was created by https://www.iobroker.dev 33803d6.*