### PR TITLE
add batrium-bms 0.6.0 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -201,6 +201,12 @@
     "type": "general",
     "version": "3.0.31"
   },
+  "batrium-bms": {
+    "meta": "https://raw.githubusercontent.com/bembelstemmer/ioBroker.batrium-bms/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/bembelstemmer/ioBroker.batrium-bms/main/admin/batrium-bms.png",
+    "type": "energy",
+    "version": "0.6.0"
+  },
   "bayernluft": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.bayernluft/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.bayernluft/main/admin/bayernluft.png",


### PR DESCRIPTION
Please update my adapter ioBroker.batrium-bms to version 0.6.0.

*This pull request was created by https://www.iobroker.dev 33803d6.*