### PR TITLE
Update apg-info to 0.1.14

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -145,7 +145,7 @@
     "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.apg-info/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/HGlab01/ioBroker.apg-info/main/admin/apg-info.png",
     "type": "general",
-    "version": "0.1.13"
+    "version": "0.1.14"
   },
   "artnet": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.artnet/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.apg-info to version 0.1.14.

*This pull request was created by https://www.iobroker.dev 33803d6.*