### PR TITLE
Update maxxi-charge to 1.4.32

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1567,7 +1567,7 @@
     "meta": "https://raw.githubusercontent.com/blabond/ioBroker.maxxi-charge/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/blabond/ioBroker.maxxi-charge/main/admin/maxxi-charge.png",
     "type": "energy",
-    "version": "1.4.9"
+    "version": "1.4.32"
   },
   "mbus": {
     "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.mbus/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.maxxi-charge to version 1.4.32.

*This pull request was created by https://www.iobroker.dev 9d775be.*