### PR TITLE
Add ankersolix2 2.1.0 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -135,6 +135,12 @@
     "type": "iot-systems",
     "version": "1.0.15"
   },
+  "ankersolix2": {
+    "meta": "https://raw.githubusercontent.com/ronny130286/ioBroker.ankersolix2/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/ronny130286/ioBroker.ankersolix2/main/admin/ankersolix2.png",
+    "type": "iot-systems",
+    "version": "2.1.0"
+  },
   "apcups": {
     "meta": "https://raw.githubusercontent.com/XHunter74/ioBroker.apcups/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/XHunter74/ioBroker.apcups/master/admin/ups.png",


### PR DESCRIPTION
Please update my adapter ioBroker.ankersolix2 to version 2.1.0.

*This pull request was created by https://www.iobroker.dev 20f0116.*