### PR TITLE
Update schoolfree to 1.1.9

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2365,7 +2365,7 @@
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.schoolfree/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/simatec/ioBroker.schoolfree/master/admin/schoolfree.png",
     "type": "date-and-time",
-    "version": "1.1.8"
+    "version": "1.1.9"
   },
   "schwoerer-ventcube": {
     "meta": "https://raw.githubusercontent.com/Excodibur/ioBroker.schwoerer-ventcube/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.schoolfree to version 1.1.9.

*This pull request was created by https://www.iobroker.dev 20f0116.*