### PR TITLE
Update vis-2-widgets-rssfeed to 1.1.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2947,7 +2947,7 @@
     "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-2-widgets-rssfeed/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-2-widgets-rssfeed/main/admin/vis-2-widgets-rssfeed.png",
     "type": "visualization-widgets",
-    "version": "1.0.0"
+    "version": "1.1.2"
   },
   "vis-2-widgets-weather-and-heating": {
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-2-widgets-weather-and-heating/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-2-widgets-rssfeed to version 1.1.2.

*This pull request was created by https://www.iobroker.dev 20f0116.*