### PR TITLE
Update dysonairpurifier to 3.2.7

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -535,7 +535,7 @@
     "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.dysonairpurifier/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.dysonairpurifier/main/admin/dyson_logo.svg",
     "type": "climate-control",
-    "version": "3.2.6"
+    "version": "3.2.7"
   },
   "e3dc-rscp": {
     "meta": "https://raw.githubusercontent.com/git-kick/ioBroker.e3dc-rscp/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.dysonairpurifier to version 3.2.7.

*This pull request was created by https://www.iobroker.dev 20f0116.*