### PR TITLE
Update net-tools to 1.1.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1801,7 +1801,7 @@
     "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.net-tools/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.net-tools/master/admin/net-tools.png",
     "type": "network",
-    "version": "1.0.11"
+    "version": "1.1.2"
   },
   "netatmo": {
     "meta": "https://raw.githubusercontent.com/PArns/ioBroker.netatmo/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.net-tools to version 1.1.2.

*This pull request was created by https://www.iobroker.dev 20f0116.*