### PR TITLE
Update govee-local to 0.2.8

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -919,7 +919,7 @@
     "meta": "https://raw.githubusercontent.com/boergegrunicke/ioBroker.govee-local/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/boergegrunicke/ioBroker.govee-local/main/admin/govee-local.png",
     "type": "lighting",
-    "version": "0.2.7"
+    "version": "0.2.8"
   },
   "gree-hvac": {
     "meta": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.govee-local to version 0.2.8.

*This pull request was created by https://www.iobroker.dev 20f0116.*