### PR TITLE
Update rssfeed to 3.5.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2305,7 +2305,7 @@
     "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.rssfeed/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.rssfeed/main/admin/rssfeed.png",
     "type": "misc-data",
-    "version": "3.3.1"
+    "version": "3.5.2"
   },
   "s7": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.s7/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.rssfeed to version 3.5.2.

*This pull request was created by https://www.iobroker.dev 20f0116.*