### PR TITLE
Update apcups to 5.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -145,7 +145,7 @@
     "meta": "https://raw.githubusercontent.com/XHunter74/ioBroker.apcups/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/XHunter74/ioBroker.apcups/master/admin/ups.png",
     "type": "hardware",
-    "version": "4.0.5"
+    "version": "5.0.0"
   },
   "apg-info": {
     "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.apg-info/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.apcups to version 5.0.0.

*This pull request was created by https://www.iobroker.dev 20f0116.*