### PR TITLE
Add skiinfo 0.5.0 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2487,6 +2487,12 @@
     "type": "communication",
     "version": "2.8.0"
   },
+  "skiinfo": {
+    "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.skiinfo/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.skiinfo/main/admin/skiinfo.png",
+    "type": "misc-data",
+    "version": "0.5.0"
+  },
   "sma-em": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.sma-em/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.sma-em/master/admin/sma-em.png",


### PR DESCRIPTION
Please update my adapter ioBroker.skiinfo to version 0.5.0.

*This pull request was created by https://www.iobroker.dev 659c7b1.*