### PR TITLE
Update dnscope to 0.2.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -501,6 +501,12 @@
     "type": "alarm",
     "version": "0.2.0"
   },
+  "dnscope": {
+    "meta": "https://raw.githubusercontent.com/simatec/ioBroker.dnscope/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/simatec/ioBroker.dnscope/main/admin/dnscope.png",
+    "type": "network",
+    "version": "0.2.3"
+  },
   "doorbird": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.doorbird/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.doorbird/master/admin/doorbird.png",


### PR DESCRIPTION
Please update my adapter ioBroker.dnscope to version 0.2.3.

*This pull request was created by https://www.iobroker.dev 659c7b1.*