### PR TITLE
Update rct to 1.2.21

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2239,7 +2239,7 @@
     "meta": "https://raw.githubusercontent.com/aruttkamp/ioBroker.rct/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/aruttkamp/ioBroker.rct/main/admin/rct-logo.square.png",
     "type": "energy",
-    "version": "1.2.19"
+    "version": "1.2.21"
   },
   "refoss": {
     "meta": "https://raw.githubusercontent.com/Refoss/ioBroker.refoss/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.rct to version 1.2.21.

*This pull request was created by https://www.iobroker.dev 659c7b1.*