### PR TITLE
Update vis-inventwo to 3.3.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3049,7 +3049,7 @@
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-inventwo/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-inventwo/master/admin/inventwo.png",
     "type": "visualization-widgets",
-    "version": "3.3.4"
+    "version": "3.3.5"
   },
   "vis-jqui-mfd": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-jqui-mfd/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-inventwo to version 3.3.5.

*This pull request was created by https://www.iobroker.dev 659c7b1.*