### PR TITLE
Update squeezeboxrpc to 1.6.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2641,7 +2641,7 @@
     "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.squeezeboxrpc/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.squeezeboxrpc/main/admin/squeezeboxrpc.png",
     "type": "multimedia",
-    "version": "1.5.2"
+    "version": "1.6.2"
   },
   "starline": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.starline/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.squeezeboxrpc to version 1.6.2.

*This pull request was created by https://www.iobroker.dev 659c7b1.*