### PR TITLE
Update ico-cloud to 2.0.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1171,7 +1171,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ico-cloud/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ico-cloud/main/admin/ico-cloud.png",
     "type": "metering",
-    "version": "1.1.0"
+    "version": "2.0.3"
   },
   "icons-addictive-flavour-png": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-addictive-flavour-png/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.ico-cloud to version 2.0.3.

*This pull request was created by https://www.iobroker.dev 659c7b1.*