### PR TITLE
Update e3oncan to 0.10.9

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -553,7 +553,7 @@
     "meta": "https://raw.githubusercontent.com/MyHomeMyData/ioBroker.e3oncan/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/MyHomeMyData/ioBroker.e3oncan/main/admin/e3oncan_small.png",
     "type": "iot-systems",
-    "version": "0.10.8"
+    "version": "0.10.9"
   },
   "easee": {
     "meta": "https://raw.githubusercontent.com/Newan/ioBroker.easee/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.e3oncan to version 0.10.9.

*This pull request was created by https://www.iobroker.dev 659c7b1.*