### PR TITLE
Update odl to 5.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1903,7 +1903,7 @@
     "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.odl/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.odl/master/admin/odl.png",
     "type": "misc-data",
-    "version": "4.0.2"
+    "version": "5.0.0"
   },
   "oekofen-json": {
     "meta": "https://raw.githubusercontent.com/chaozmc/ioBroker.oekofen-json/main/io-package.json",


### PR DESCRIPTION
Version 5.0.0 is considered stable and fixes some minor issues.
See crycode-de/ioBroker.odl#136