### PR TITLE
Update heizoel24-mex to 1.4.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1015,7 +1015,7 @@
     "meta": "https://raw.githubusercontent.com/ltspicer/ioBroker.heizoel24-mex/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ltspicer/ioBroker.heizoel24-mex/main/admin/heizoel24-mex.png",
     "type": "metering",
-    "version": "1.3.5"
+    "version": "1.4.2"
   },
   "heizungssteuerung": {
     "meta": "https://raw.githubusercontent.com/jbeenenga/ioBroker.heizungssteuerung/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.heizoel24-mex to version 1.4.2.

*This pull request was created by https://www.iobroker.dev 659c7b1.*