### PR TITLE
Update worx to 3.2.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3319,7 +3319,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.worx/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.worx/master/admin/worx.png",
     "type": "garden",
-    "version": "3.2.0"
+    "version": "3.2.4"
   },
   "ws": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.ws/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.worx to version 3.2.4.

*This pull request was created by https://www.iobroker.dev 659c7b1.*

[Hot Fix](https://github.com/iobroker-community-adapters/ioBroker.worx/issues/1009)