### PR TITLE
Update semp to 1.5.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2419,7 +2419,7 @@
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.semp/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.semp/master/admin/semp.png",
     "type": "energy",
-    "version": "1.4.8"
+    "version": "1.5.1"
   },
   "senec": {
     "meta": "https://raw.githubusercontent.com/nobl/ioBroker.senec/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.semp to version 1.5.1.

*This pull request was created by https://www.iobroker.dev 659c7b1.*