### PR TITLE
Update fritzdect to 2.6.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -817,7 +817,7 @@
     "meta": "https://raw.githubusercontent.com/foxthefox/ioBroker.fritzdect/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/foxthefox/ioBroker.fritzdect/master/admin/fritzdect_logo.png",
     "type": "hardware",
-    "version": "2.6.1"
+    "version": "2.6.2"
   },
   "froeling": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.froeling/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.fritzdect to version 2.6.2.

*This pull request was created by https://www.iobroker.dev 659c7b1.*