### PR TITLE
Add energy-tracker to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -620,6 +620,11 @@
     "icon": "https://raw.githubusercontent.com/SKB-CGN/ioBroker.energiefluss-erweitert/main/admin/energiefluss-erweitert.png",
     "type": "visualization"
   },
+  "energy-tracker": {
+    "meta": "https://raw.githubusercontent.com/energy-tracker/ioBroker.energy-tracker/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/energy-tracker/ioBroker.energy-tracker/main/admin/energy-tracker.png",
+    "type": "iot-systems"
+  },
   "energymanager": {
     "meta": "https://raw.githubusercontent.com/unltdnetworx/ioBroker.energymanager/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/unltdnetworx/ioBroker.energymanager/master/admin/energymanager.png",


### PR DESCRIPTION
This pull request adds the adapter `energy-tracker` to the `latest` repository.

- Type: `iot-systems`
- Source: https://github.com/energy-tracker/ioBroker.energy-tracker
- Meta: https://github.com/energy-tracker/ioBroker.energy-tracker/blob/main/io-package.json
- Icon: https://raw.githubusercontent.com/energy-tracker/ioBroker.energy-tracker/main/admin/energy-tracker.png

Description:
Adapter for sending meter readings to the Energy Tracker platform (REST API). Supports periodic submission, rounding configuration, and secure bearer token authentication.
