### PR TITLE
Add pi-hole2 to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1986,6 +1986,11 @@
     "icon": "https://raw.githubusercontent.com/unltdnetworx/ioBroker.pi-hole/master/admin/pi-hole.png",
     "type": "network"
   },
+  "pi-hole2": {
+    "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.pi-hole2/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.pi-hole2/main/admin/pi-hole2.png",
+    "type": "network"
+  },
   "pid": {
     "meta": "https://raw.githubusercontent.com/mcm4iob/ioBroker.pid/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/mcm4iob/ioBroker.pid/master/admin/pid.png",


### PR DESCRIPTION
Please add my adapter ioBroker.pi-hole2 to latest.

*This pull request was created by https://www.iobroker.dev 659c7b1.*