### PR TITLE
Update shelly to 10.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2443,7 +2443,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.shelly/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.shelly/master/admin/shelly.png",
     "type": "iot-systems",
-    "version": "9.5.1"
+    "version": "10.0.0"
   },
   "shrdzm": {
     "meta": "https://raw.githubusercontent.com/mcm4iob/ioBroker.shrdzm/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.shelly to version 10.0.0.

*This pull request was created by https://www.iobroker.dev 659c7b1.*