### PR TITLE
Update remeha-home to 1.0.7

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2245,7 +2245,7 @@
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.remeha-home/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/simatec/ioBroker.remeha-home/master/admin/remeha-home.png",
     "type": "climate-control",
-    "version": "1.0.6"
+    "version": "1.0.7"
   },
   "renacidc": {
     "meta": "https://raw.githubusercontent.com/raschy/ioBroker.renacidc/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.remeha-home to version 1.0.7.

*This pull request was created by https://www.iobroker.dev 659c7b1.*