### PR TITLE
Update onlycat to 0.3.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1929,6 +1929,12 @@
     "type": "multimedia",
     "version": "2.1.2"
   },
+  "onlycat": {
+    "meta": "https://raw.githubusercontent.com/Sickboy78/ioBroker.onlycat/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Sickboy78/ioBroker.onlycat/main/admin/onlycat.png",
+    "type": "iot-systems",
+    "version": "0.3.0"
+  },
   "onvif": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.onvif/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.onvif/main/admin/onvif.png",


### PR DESCRIPTION
Please update my adapter ioBroker.onlycat to version 0.3.0.

*This pull request was created by https://www.iobroker.dev 659c7b1.*