### PR TITLE
Update vis-2-widgets-inventwo to 0.2.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2947,7 +2947,7 @@
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-inventwo/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-inventwo/main/admin/vis-2-widgets-inventwo.png",
     "type": "visualization-widgets",
-    "version": "0.1.11"
+    "version": "0.2.2"
   },
   "vis-2-widgets-jaeger-design": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-jaeger-design/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-2-widgets-inventwo to version 0.2.2.

*This pull request was created by https://www.iobroker.dev 659c7b1.*