### PR TITLE
Update tinker to 1.3.8

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2779,7 +2779,7 @@
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.tinker/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/simatec/ioBroker.tinker/master/admin/tinker.png",
     "type": "hardware",
-    "version": "1.3.7"
+    "version": "1.3.8"
   },
   "tinymqttbroker": {
     "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.tinymqttbroker/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.tinker to version 1.3.8.

*This pull request was created by https://www.iobroker.dev 659c7b1.*