### PR TITLE
Update reolink to 1.2.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2257,7 +2257,7 @@
     "meta": "https://raw.githubusercontent.com/aendue/ioBroker.reolink/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/aendue/ioBroker.reolink/main/admin/reolink_logo.png",
     "type": "alarm",
-    "version": "1.2.2"
+    "version": "1.2.3"
   },
   "residents": {
     "meta": "https://raw.githubusercontent.com/jpawlowski/ioBroker.residents/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.reolink to version 1.2.3.

*This pull request was created by https://www.iobroker.dev 659c7b1.*