### PR TITLE
Update fronius-wattpilot to 4.7.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -841,7 +841,7 @@
     "meta": "https://raw.githubusercontent.com/tim2zg/ioBroker.fronius-wattpilot/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/tim2zg/ioBroker.fronius-wattpilot/main/admin/fronius-wattpilot.png",
     "type": "vehicle",
-    "version": "4.6.3"
+    "version": "4.7.0"
   },
   "frontier_silicon": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.frontier_silicon/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.fronius-wattpilot to version 4.7.0.

*This pull request was created by https://www.iobroker.dev 659c7b1.*