### PR TITLE
Update ebus to 3.6.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -571,7 +571,7 @@
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.ebus/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.ebus/master/admin/ebus.png",
     "type": "hardware",
-    "version": "3.6.2"
+    "version": "3.6.3"
   },
   "echarts": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.echarts/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.ebus to version 3.6.3.

*This pull request was created by https://www.iobroker.dev 659c7b1.*