### PR TITLE
Add pi-hole2 1.1.1 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2073,6 +2073,12 @@
     "type": "network",
     "version": "1.3.6"
   },
+  "pi-hole2": {
+    "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.pi-hole2/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.pi-hole2/main/admin/pi-hole2.png",
+    "type": "network",
+    "version": "1.1.1"
+  },
   "pid": {
     "meta": "https://raw.githubusercontent.com/mcm4iob/ioBroker.pid/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/mcm4iob/ioBroker.pid/master/admin/pid.png",


### PR DESCRIPTION
Please update my adapter ioBroker.pi-hole2 to version 1.1.1.

*This pull request was created by https://www.iobroker.dev 659c7b1.*