### PR TITLE
Update gotify-ws to 0.2.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -925,7 +925,7 @@
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.gotify-ws/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/simatec/ioBroker.gotify-ws/master/admin/gotify-ws.png",
     "type": "messaging",
-    "version": "0.2.1"
+    "version": "0.2.2"
   },
   "govee-local": {
     "meta": "https://raw.githubusercontent.com/boergegrunicke/ioBroker.govee-local/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.gotify-ws to version 0.2.2.

*This pull request was created by https://www.iobroker.dev 659c7b1.*