### PR TITLE
Add energy-tracker 0.2.8 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -651,6 +651,12 @@
     "type": "visualization",
     "version": "0.7.7"
   },
+  "energy-tracker": {
+    "meta": "https://raw.githubusercontent.com/energy-tracker/ioBroker.energy-tracker/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/energy-tracker/ioBroker.energy-tracker/main/admin/energy-tracker.png",
+    "type": "iot-systems",
+    "version": "0.2.8"
+  },
   "energymanager": {
     "meta": "https://raw.githubusercontent.com/unltdnetworx/ioBroker.energymanager/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/unltdnetworx/ioBroker.energymanager/master/admin/energymanager.png",


### PR DESCRIPTION
Please update my adapter ioBroker.energy-tracker to version 0.2.8.

*This pull request was created by https://www.iobroker.dev 659c7b1.*