### PR TITLE
Update espresense to 0.6.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -697,7 +697,7 @@
     "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.espresense/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.espresense/main/admin/espresense.png",
     "type": "geoposition",
-    "version": "0.4.8"
+    "version": "0.6.3"
   },
   "eusec": {
     "meta": "https://raw.githubusercontent.com/bropat/ioBroker.eusec/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.espresense to version 0.6.3.

*This pull request was created by https://www.iobroker.dev 26b8a51.*