### PR TITLE
Add vis-2-widgets-icontwo to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2004,7 +2004,7 @@
   "pirate-weather": {
     "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.pirate-weather/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.pirate-weather/main/admin/pirate-weather.png",
-    "type": "weather"    
+    "type": "weather"
   },
   "pixelit": {
     "meta": "https://raw.githubusercontent.com/pixelit-project/ioBroker.pixelit/master/io-package.json",
@@ -2863,6 +2863,11 @@
   "vis-2-widgets-gauges": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-gauges/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-gauges/main/admin/vis-2-widgets-gauges.png",
+    "type": "visualization-widgets"
+  },
+  "vis-2-widgets-icontwo": {
+    "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-icontwo/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-icontwo/master/admin/vis-2-widgets-icontwo.svg",
     "type": "visualization-widgets"
   },
   "vis-2-widgets-inventwo": {


### PR DESCRIPTION
Please add my adapter ioBroker.vis-2-widgets-icontwo to latest.

*This pull request was created by https://www.iobroker.dev 26b8a51.*