### PR TITLE
Update rct to 1.2.23

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2251,7 +2251,7 @@
     "meta": "https://raw.githubusercontent.com/aruttkamp/ioBroker.rct/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/aruttkamp/ioBroker.rct/main/admin/rct-logo.square.png",
     "type": "energy",
-    "version": "1.2.22"
+    "version": "1.2.23"
   },
   "refoss": {
     "meta": "https://raw.githubusercontent.com/Refoss/ioBroker.refoss/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.rct to version 1.2.23.

*This pull request was created by https://www.iobroker.dev 615369f.*