### PR TITLE
Update snmp to 3.3.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2557,7 +2557,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snmp/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snmp/master/admin/snmp.png",
     "type": "infrastructure",
-    "version": "3.2.0"
+    "version": "3.3.0"
   },
   "socketio": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.socketio/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.snmp to version 3.3.0.

*This pull request was created by https://www.iobroker.dev 615369f.*