### PR TITLE
Update vis-icontwo to 1.18.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3067,7 +3067,7 @@
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-icontwo/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-icontwo/master/admin/icontwo.png",
     "type": "visualization-icons",
-    "version": "1.12.0"
+    "version": "1.18.0"
   },
   "vis-inventwo": {
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-inventwo/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-icontwo to version 1.18.0.

*This pull request was created by https://www.iobroker.dev 615369f.*