### PR TITLE
Update worx to 3.2.7

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3349,7 +3349,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.worx/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.worx/master/admin/worx.png",
     "type": "garden",
-    "version": "3.2.6"
+    "version": "3.2.7"
   },
   "ws": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.ws/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.worx to version 3.2.7.

*This pull request was created by https://www.iobroker.dev 615369f.*