### PR TITLE
Pls change vis-2-widgets-icontwo type

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2883,7 +2883,7 @@
   "vis-2-widgets-icontwo": {
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-icontwo/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-icontwo/main/admin/vis-2-widgets-icontwo.png",
-    "type": "visualization-widgets"
+    "type": "visualization-icons"
   },
   "vis-2-widgets-inventwo": {
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-inventwo/main/io-package.json",


### PR DESCRIPTION
Change "type": "visualization-widgets" to "type": "visualization-icons" for ioBroker.vis-2-widgets-icontwo