### PR TITLE
Update vis-2-widgets-icontwo to 0.28.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2988,8 +2988,8 @@
   "vis-2-widgets-icontwo": {
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-icontwo/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-icontwo/main/admin/vis-2-widgets-icontwo.png",
-    "type": "visualization-widgets",
-    "version": "0.22.0"
+    "type": "visualization-icons",
+    "version": "0.28.0"
   },
   "vis-2-widgets-jaeger-design": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-jaeger-design/main/io-package.json",


### PR DESCRIPTION
Update vis-2-widgets-icontwo to 0.28.0 and change "type": "visualization-widgets" to "type": "visualization-icons" for ioBroker.vis-2-widgets-icontwo