### PR TITLE
Update vbus-gw to 0.3.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2925,6 +2925,12 @@
     "type": "misc-data",
     "version": "1.1.0"
   },
+  "vbus-gw": {
+    "meta": "https://raw.githubusercontent.com/pdbjjens/ioBroker.vbus-gw/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/pdbjjens/ioBroker.vbus-gw/main/admin/vbus-gw.png",
+    "type": "network",
+    "version": "0.3.0"
+  },
   "vds2465-server": {
     "meta": "https://raw.githubusercontent.com/Hirsch-DE/ioBroker.vds2465-server/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Hirsch-DE/ioBroker.vds2465-server/main/admin/vds2465-server.png",


### PR DESCRIPTION
Please update my adapter ioBroker.vbus-gw to version 0.3.0.

*This pull request was created by https://www.iobroker.dev 615369f.*