### PR TITLE
Update x-touch to 0.8.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3379,7 +3379,7 @@
     "meta": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.x-touch/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.x-touch/master/admin/x-touch.png",
     "type": "hardware",
-    "version": "0.8.1"
+    "version": "0.8.2"
   },
   "xbox": {
     "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.xbox/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.x-touch to version 0.8.2.

*This pull request was created by https://www.iobroker.dev 615369f.*