### PR TITLE
Update dnscope to 0.2.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -511,7 +511,7 @@
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.dnscope/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/simatec/ioBroker.dnscope/main/admin/dnscope.png",
     "type": "network",
-    "version": "0.2.4"
+    "version": "0.2.5"
   },
   "doorbird": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.doorbird/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.dnscope to version 0.2.5.

*This pull request was created by https://www.iobroker.dev 615369f.*