### PR TITLE
Update shuttercontrol to 2.0.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2485,7 +2485,7 @@
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.shuttercontrol/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/simatec/ioBroker.shuttercontrol/master/admin/shuttercontrol.png",
     "type": "climate-control",
-    "version": "2.0.3"
+    "version": "2.0.5"
   },
   "sia": {
     "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.sia/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.shuttercontrol to version 2.0.5.

*This pull request was created by https://www.iobroker.dev 615369f.*