### PR TITLE
Update tinker to 1.3.9

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2815,7 +2815,7 @@
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.tinker/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/simatec/ioBroker.tinker/master/admin/tinker.png",
     "type": "hardware",
-    "version": "1.3.8"
+    "version": "1.3.9"
   },
   "tinymqttbroker": {
     "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.tinymqttbroker/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.tinker to version 1.3.9.

*This pull request was created by https://www.iobroker.dev 615369f.*