### PR TITLE
Update ecoflow-mqtt to 1.4.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -589,7 +589,7 @@
     "meta": "https://raw.githubusercontent.com/foxthefox/ioBroker.ecoflow-mqtt/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/foxthefox/ioBroker.ecoflow-mqtt/main/admin/ecoflow-mqtt.png",
     "type": "iot-systems",
-    "version": "1.3.2"
+    "version": "1.4.6"
   },
   "ecovacs-deebot": {
     "meta": "https://raw.githubusercontent.com/mrbungle64/ioBroker.ecovacs-deebot/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.ecoflow-mqtt to version 1.4.6.

*This pull request was created by https://www.iobroker.dev 615369f.*