### PR TITLE
Update pirate-weather to 0.7.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2119,7 +2119,7 @@
     "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.pirate-weather/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.pirate-weather/main/admin/pirate-weather.png",
     "type": "weather",
-    "version": "0.4.1"
+    "version": "0.7.0"
   },
   "pixelit": {
     "meta": "https://raw.githubusercontent.com/pixelit-project/ioBroker.pixelit/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.pirate-weather to version 0.7.0.

*This pull request was created by https://www.iobroker.dev 615369f.*