### PR TITLE
Bumb TibberLink stable to 6.0.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2815,7 +2815,7 @@
     "meta": "https://raw.githubusercontent.com/hombach/ioBroker.tibberlink/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/hombach/ioBroker.tibberlink/master/admin/tibberlink.png",
     "type": "energy",
-    "version": "5.0.2"
+    "version": "6.0.1"
   },
   "tinker": {
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.tinker/master/io-package.json",


### PR DESCRIPTION
Bumb TibberLink stable to 6.0.1 for support of 15 minutes prices.
6.0.0 is used about one week now - 6.0.1 just fixes a wrong number constant. 
And as this should be usable for all quite soon ..... ;)