### PR TITLE
Add vis-jsontemplate 4.1.2 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3111,6 +3111,12 @@
     "type": "visualization-widgets",
     "version": "1.1.1"
   },
+  "vis-jsontemplate": {
+    "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-jsontemplate/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-jsontemplate/main/admin/vis-jsontemplate.png",
+    "type": "visualization-widgets",
+    "version": "4.1.2"
+  },
   "vis-justgage": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-justgage/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-justgage/master/admin/justgage.png",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-jsontemplate to version 4.1.2.

*This pull request was created by https://www.iobroker.dev 615369f.*