### PR TITLE
Add freeair 1.0.5 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -819,6 +819,12 @@
     "type": "vehicle",
     "version": "1.0.4"
   },
+  "freeair": {
+    "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.freeair/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.freeair/main/admin/freeair.png",
+    "type": "hardware",
+    "version": "1.0.5"
+  },
   "frigate": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.frigate/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.frigate/main/admin/frigate.png",


### PR DESCRIPTION
Please update my adapter ioBroker.freeair to version 1.0.5.

*This pull request was created by https://www.iobroker.dev 615369f.*