### PR TITLE
Add unifi-network 1.1.6 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2901,6 +2901,12 @@
     "type": "network",
     "version": "0.7.0"
   },
+  "unifi-network": {
+    "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.unifi-network/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.unifi-network/main/admin/unifi-network.png",
+    "type": "network",
+    "version": "1.1.6"
+  },
   "unifi-protect": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.unifi-protect/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.unifi-protect/master/admin/unifi-protect.png",


### PR DESCRIPTION
Please update my adapter ioBroker.unifi-network to version 1.1.6.

*This pull request was created by https://www.iobroker.dev 615369f.*