### PR TITLE
Add weatherflow-tempest-api 1.1.2 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3237,6 +3237,12 @@
     "type": "weather",
     "version": "0.7.4"
   },
+  "weatherflow-tempest-api": {
+    "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.weatherflow-tempest-api/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.weatherflow-tempest-api/main/admin/weatherflow-tempest-api.png",
+    "type": "weather",
+    "version": "1.1.2"
+  },
   "weatherflow_udp": {
     "meta": "https://raw.githubusercontent.com/woessmich/ioBroker.weatherflow_udp/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/woessmich/ioBroker.weatherflow_udp/master/admin/weatherflow_udp.png",


### PR DESCRIPTION
Please update my adapter ioBroker.weatherflow-tempest-api to version 1.1.2.

*This pull request was created by https://www.iobroker.dev 615369f.*