### PR TITLE
Update tado to 0.8.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2749,7 +2749,7 @@
     "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.tado/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.tado/main/admin/tado.png",
     "type": "climate-control",
-    "version": "0.7.10"
+    "version": "0.8.0"
   },
   "tagesschau": {
     "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.tagesschau/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.tado to version 0.8.0.

*This pull request was created by https://www.iobroker.dev 615369f.*