### PR TITLE
Update fb-checkpresence to 1.4.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -751,7 +751,7 @@
     "meta": "https://raw.githubusercontent.com/afuerhoff/ioBroker.fb-checkpresence/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/afuerhoff/ioBroker.fb-checkpresence/master/admin/fb-checkpresence.png",
     "type": "infrastructure",
-    "version": "1.4.0"
+    "version": "1.4.1"
   },
   "feiertage": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.feiertage/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.fb-checkpresence to version 1.4.1.

*This pull request was created by https://www.iobroker.dev 615369f.*