### PR TITLE
Update matter to 0.5.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1573,7 +1573,7 @@
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.matter/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.matter/main/admin/matter.png",
     "type": "iot-systems",
-    "version": "0.5.2"
+    "version": "0.5.5"
   },
   "maveo": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.maveo/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.matter to version 0.5.5.

Was widely tested by community and enhances things a lot

*This pull request was created by https://www.iobroker.dev 615369f.*