### PR TITLE
Update ems-esp to 6.0.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -643,7 +643,7 @@
     "meta": "https://raw.githubusercontent.com/tp1de/ioBroker.ems-esp/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/tp1de/ioBroker.ems-esp/main/admin/ems-esp.png",
     "type": "climate-control",
-    "version": "6.0.0"
+    "version": "6.0.1"
   },
   "energiefluss": {
     "meta": "https://raw.githubusercontent.com/SKB-CGN/ioBroker.energiefluss/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.ems-esp to version 6.0.1.

*This pull request was created by https://www.iobroker.dev 615369f.*