### PR TITLE
Update vis-2-widgets-ovarious to 2.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3043,7 +3043,7 @@
     "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-2-widgets-ovarious/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-2-widgets-ovarious/main/admin/vis-2-widgets-ovarious.png",
     "type": "visualization-widgets",
-    "version": "0.1.9"
+    "version": "2.0.0"
   },
   "vis-2-widgets-radar-trap": {
     "meta": "https://raw.githubusercontent.com/Steiger04/ioBroker.vis-2-widgets-radar-trap/main/io-package.json",
@@ -3441,7 +3441,7 @@
     "type": "iot-systems",
     "version": "1.0.2"
   },
-   "xsense": {
+  "xsense": {
     "meta": "https://raw.githubusercontent.com/arteck/ioBroker.xsense/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/arteck/ioBroker.xsense/main/admin/xsense.png",
     "type": "utility",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-2-widgets-ovarious to version 2.0.0.

*This pull request was created by https://www.iobroker.dev 615369f.*