### PR TITLE
Update drag-indicator to 2.5.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -529,7 +529,7 @@
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.drag-indicator/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.drag-indicator/main/admin/drag-indicator.png",
     "type": "misc-data",
-    "version": "2.4.0"
+    "version": "2.5.0"
   },
   "drops-weather": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.drops-weather/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.drag-indicator to version 2.5.0.

*This pull request was created by https://www.iobroker.dev 615369f.*