### PR TITLE
Update paperless-ngx to 0.5.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2053,7 +2053,7 @@
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.paperless-ngx/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.paperless-ngx/main/admin/paperless-ngx.png",
     "type": "storage",
-    "version": "0.4.4"
+    "version": "0.5.0"
   },
   "parser": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.parser/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.paperless-ngx to version 0.5.0.

*This pull request was created by https://www.iobroker.dev 615369f.*