### PR TITLE
Update bluesound to 1.2.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -277,7 +277,7 @@
     "meta": "https://raw.githubusercontent.com/Uwe1958/ioBroker.bluesound/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Uwe1958/ioBroker.bluesound/main/admin/bluesound.png",
     "type": "multimedia",
-    "version": "1.2.0"
+    "version": "1.2.1"
   },
   "boschindego": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.boschindego/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.bluesound to version 1.2.1.

*This pull request was created by https://www.iobroker.dev 615369f.*