### PR TITLE
Update vis-2-widgets-icontwo to 1.16.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3019,7 +3019,7 @@
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-icontwo/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-icontwo/main/admin/vis-2-widgets-icontwo.png",
     "type": "visualization-icons",
-    "version": "1.14.0"
+    "version": "1.16.0"
   },
   "vis-2-widgets-inventwo": {
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-inventwo/main/io-package.json",
@@ -3345,7 +3345,7 @@
     "type": "lighting",
     "version": "2.0.3"
   },
- "wiobrowser": {
+  "wiobrowser": {
     "meta": "https://raw.githubusercontent.com/Bettman66/ioBroker.wiobrowser/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Bettman66/ioBroker.wiobrowser/master/admin/wiobrowser.png",
     "type": "communication",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-2-widgets-icontwo to version 1.16.0.

*This pull request was created by https://www.iobroker.dev 615369f.*