### PR TITLE
Update lg-thinq to 1.1.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1441,7 +1441,7 @@
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.lg-thinq/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.lg-thinq/master/admin/lg-thinq.png",
     "type": "household",
-    "version": "1.1.2"
+    "version": "1.1.3"
   },
   "lgtv": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.lgtv/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.lg-thinq to version 1.1.3.

*This pull request was created by https://www.iobroker.dev 615369f.*