### PR TITLE
Update onlycat to 0.5.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1957,7 +1957,7 @@
     "meta": "https://raw.githubusercontent.com/Sickboy78/ioBroker.onlycat/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Sickboy78/ioBroker.onlycat/main/admin/onlycat.png",
     "type": "iot-systems",
-    "version": "0.5.1"
+    "version": "0.5.2"
   },
   "onvif": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.onvif/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.onlycat to version 0.5.2.

*This pull request was created by https://www.iobroker.dev 615369f.*