### PR TITLE
Update synochat to 1.4.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2743,7 +2743,7 @@
     "meta": "https://raw.githubusercontent.com/phoeluga/ioBroker.synochat/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/phoeluga/ioBroker.synochat/master/admin/synochat.png",
     "type": "messaging",
-    "version": "1.3.3"
+    "version": "1.4.2"
   },
   "synology": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.synology/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.synochat to version 1.4.2.

*This pull request was created by https://www.iobroker.dev 615369f.*