### PR TITLE
Update ical to 1.18.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1183,7 +1183,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ical/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ical/master/admin/ical.png",
     "type": "date-and-time",
-    "version": "1.17.0"
+    "version": "1.18.1"
   },
   "iceroad": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.iceroad/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.ical to version 1.18.1.

*This pull request was created by https://www.iobroker.dev 615369f.*