### PR TITLE
Update flexcharts to 0.6.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -793,7 +793,7 @@
     "meta": "https://raw.githubusercontent.com/MyHomeMyData/ioBroker.flexcharts/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/MyHomeMyData/ioBroker.flexcharts/main/admin/flexcharts-icon.png",
     "type": "visualization",
-    "version": "0.5.0"
+    "version": "0.6.1"
   },
   "flot": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.flot/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.flexcharts to version 0.6.1.

*This pull request was created by https://www.iobroker.dev 37cf8e2.*