### PR TITLE
Update lametric to 5.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1411,7 +1411,7 @@
     "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.lametric/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.lametric/master/admin/lametric.png",
     "type": "hardware",
-    "version": "4.1.0"
+    "version": "5.0.0"
   },
   "lcn": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.lcn/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.lametric to version 5.0.0.

*This pull request was created by https://www.iobroker.dev 37cf8e2.*