### PR TITLE
Update freeair to 1.0.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -823,7 +823,7 @@
     "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.freeair/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.freeair/main/admin/freeair.png",
     "type": "hardware",
-    "version": "1.0.5"
+    "version": "1.0.6"
   },
   "frigate": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.frigate/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.freeair to version 1.0.6.

*This pull request was created by https://www.iobroker.dev 37cf8e2.*