### PR TITLE
Update solarprognose to 2.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2619,6 +2619,12 @@
     "type": "energy",
     "version": "0.7.1"
   },
+  "solarprognose": {
+    "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.solarprognose/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.solarprognose/main/admin/solarprognose.png",
+    "type": "weather",
+    "version": "2.0.0"
+  },
   "solarviewdatareader": {
     "meta": "https://raw.githubusercontent.com/afuerhoff/ioBroker.solarviewdatareader/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/afuerhoff/ioBroker.solarviewdatareader/master/admin/solarviewdatareader.png",


### PR DESCRIPTION
Please update my adapter ioBroker.solarprognose to version 2.0.0.

*This pull request was created by https://www.iobroker.dev 37cf8e2.*