### PR TITLE
Update weatherflow-tempest-api to 1.1.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3265,7 +3265,7 @@
     "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.weatherflow-tempest-api/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.weatherflow-tempest-api/main/admin/weatherflow-tempest-api.png",
     "type": "weather",
-    "version": "1.1.2"
+    "version": "1.1.3"
   },
   "weatherflow_udp": {
     "meta": "https://raw.githubusercontent.com/woessmich/ioBroker.weatherflow_udp/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.weatherflow-tempest-api to version 1.1.3.

*This pull request was created by https://www.iobroker.dev 37cf8e2.*