### PR TITLE
Update heatingcontrol to 2.12.19

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1027,7 +1027,7 @@
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.heatingcontrol/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.heatingcontrol/master/admin/heatingcontrol.png",
     "type": "climate-control",
-    "version": "2.12.15"
+    "version": "2.12.19"
   },
   "heizoel": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.heizoel/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.heatingcontrol to version 2.12.19.

*This pull request was created by https://www.iobroker.dev 37cf8e2.*