### PR TITLE
Update pvoutputorg to 1.9.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2245,7 +2245,7 @@
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.pvoutputorg/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.pvoutputorg/master/admin/pvoutputorg.png",
     "type": "energy",
-    "version": "1.9.3"
+    "version": "1.9.6"
   },
   "pylontech": {
     "meta": "https://raw.githubusercontent.com/PLCHome/ioBroker.pylontech/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.pvoutputorg to version 1.9.6.

*This pull request was created by https://www.iobroker.dev 37cf8e2.*