### PR TITLE
Update vis-weather to 2.5.13

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3217,7 +3217,7 @@
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-weather/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-weather/master/admin/vis-weather.png",
     "type": "visualization-widgets",
-    "version": "2.5.12"
+    "version": "2.5.13"
   },
   "vivitek": {
     "meta": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.vivitek/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-weather to version 2.5.13.

*This pull request was created by https://www.iobroker.dev 37cf8e2.*