### PR TITLE
Update vis-2-widgets-icontwo to 1.20.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3025,7 +3025,7 @@
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-icontwo/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-icontwo/main/admin/vis-2-widgets-icontwo.png",
     "type": "visualization-icons",
-    "version": "1.18.0"
+    "version": "1.20.0"
   },
   "vis-2-widgets-inventwo": {
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-inventwo/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-2-widgets-icontwo to version 1.20.0.

*This pull request was created by https://www.iobroker.dev 37cf8e2.*