### PR TITLE
Update shelly to 10.4.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2485,7 +2485,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.shelly/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.shelly/master/admin/shelly.png",
     "type": "iot-systems",
-    "version": "10.4.0"
+    "version": "10.4.1"
   },
   "shrdzm": {
     "meta": "https://raw.githubusercontent.com/mcm4iob/ioBroker.shrdzm/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.shelly to version 10.4.1.

*This pull request was created by https://www.iobroker.dev 509607d.*