### PR TITLE
Update vis-jsontemplate to 4.2.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3157,7 +3157,7 @@
     "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-jsontemplate/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-jsontemplate/main/admin/vis-jsontemplate.png",
     "type": "visualization-widgets",
-    "version": "4.1.2"
+    "version": "4.2.0"
   },
   "vis-justgage": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-justgage/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-jsontemplate to version 4.2.0.

*This pull request was created by https://www.iobroker.dev f132faf.*