### PR TITLE
Add smartloadmanager 0.1.0 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2583,6 +2583,12 @@
     "type": "garden",
     "version": "2.0.1"
   },
+  "smartloadmanager": {
+    "meta": "https://raw.githubusercontent.com/quorle/ioBroker.smartloadmanager/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/quorle/ioBroker.smartloadmanager/main/admin/smartloadmanager.png",
+    "type": "logic",
+    "version": "0.1.0"
+  },
   "smartmeter": {
     "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.smartmeter/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.smartmeter/master/admin/smartmeter.png",


### PR DESCRIPTION
Please update my adapter ioBroker.smartloadmanager to version 0.1.0.

*This pull request was created by https://www.iobroker.dev 974ec1c.*