### PR TITLE
Update stiebel-isg to 2.0.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2743,7 +2743,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.stiebel-isg/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.stiebel-isg/master/admin/stiebel-isg.png",
     "type": "climate-control",
-    "version": "1.7.7"
+    "version": "2.0.2"
   },
   "sun2000": {
     "meta": "https://raw.githubusercontent.com/bolliy/ioBroker.sun2000/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.stiebel-isg to version 2.0.2.

*This pull request was created by https://www.iobroker.dev 974ec1c.*