### PR TITLE
Add otlp to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1951,6 +1951,11 @@
     "icon": "https://raw.githubusercontent.com/volkerrichert/ioBroker.oppoplayer/master/admin/oppoplayer.png",
     "type": "multimedia"
   },
+  "otlp": {
+    "meta": "https://raw.githubusercontent.com/OlliMartin/ioBroker.otlp/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/OlliMartin/ioBroker.otlp/main/admin/otlp.png",
+    "type": "storage"
+  },
   "owfs": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.owfs/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.owfs/master/admin/owfs.png",


### PR DESCRIPTION
Please add my adapter ioBroker.otlp to latest.

## Description

This adapter allows pushing historical data into an OTLP-compatible gateway.

_Retrieval_ of historical data is - by design - __not__ possible.
Since data points/states are published as metrics, _only numerical values_ can be written.

## Links 

[Repository](https://github.com/OlliMartin/ioBroker.otlp)
[Open Telemetry](https://opentelemetry.io/)
[OTLP](https://opentelemetry.io/docs/specs/otlp/)

_This pull request was created by a human_