### PR TITLE
Update uv-protect to 0.6.11

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2971,7 +2971,7 @@
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.uv-protect/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/simatec/ioBroker.uv-protect/master/admin/uv-protect.png",
     "type": "weather",
-    "version": "0.6.9"
+    "version": "0.6.11"
   },
   "valloxmv": {
     "meta": "https://raw.githubusercontent.com/hacki11/ioBroker.valloxmv/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.uv-protect to version 0.6.11.

*This pull request was created by https://www.iobroker.dev 974ec1c.*