### PR TITLE
Update tinker to 1.3.11

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2869,7 +2869,7 @@
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.tinker/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/simatec/ioBroker.tinker/master/admin/tinker.png",
     "type": "hardware",
-    "version": "1.3.9"
+    "version": "1.3.11"
   },
   "tinymqttbroker": {
     "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.tinyMQTTbroker/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.tinker to version 1.3.11.

*This pull request was created by https://www.iobroker.dev 974ec1c.*