### PR TITLE
Add mitsubishi-local-control to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1651,6 +1651,11 @@
     "icon": "https://raw.githubusercontent.com/minukodu/ioBroker.minuvis/master/admin/minuvis.png",
     "type": "visualization"
   },
+  "mitsubishi-local-control": {
+    "meta": "https://raw.githubusercontent.com/Black-Thunder/ioBroker.mitsubishi-local-control/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Black-Thunder/ioBroker.mitsubishi-local-control/main/admin/mitsubishi-local-control.png",
+    "type": "climate-control"
+  },
   "mobile": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.mobile/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.mobile/master/admin/mobile.png",


### PR DESCRIPTION
@Black-Thunder

This PR replaces PR #5414.

Original PR was based on a damaged sources-dist.json file. This fact confused checker.
Please watch this PR for further information / feddback.

Sorry for the inconvinience.

object-dump see original PR #5414