### PR TITLE
Update matrix-org to 1.2.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1585,7 +1585,7 @@
     "meta": "https://raw.githubusercontent.com/oelison/ioBroker.matrix-org/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/oelison/ioBroker.matrix-org/main/admin/matrix-logo.png",
     "type": "messaging",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "matter": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.matter/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.matrix-org to version 1.2.0.

*This pull request was created by https://www.iobroker.dev 974ec1c.*