### PR TITLE
Update gree-hvac to 2.0.7

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -961,7 +961,7 @@
     "meta": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/admin/air-conditioner.png",
     "type": "climate-control",
-    "version": "2.0.2"
+    "version": "2.0.7"
   },
   "growatt": {
     "meta": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.gree-hvac to version 2.0.7.

*This pull request was created by https://www.iobroker.dev 974ec1c.*