### PR TITLE
Update google-spreadsheet to 0.6.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -937,7 +937,7 @@
     "meta": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.google-spreadsheet/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.google-spreadsheet/main/admin/google-spreadsheet.png",
     "type": "storage",
-    "version": "0.5.0"
+    "version": "0.6.0"
   },
   "gotify": {
     "meta": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.gotify/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.google-spreadsheet to version 0.6.0.

*This pull request was created by https://www.iobroker.dev 974ec1c.*