### PR TITLE
Update backitup to 3.3.13

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -205,7 +205,7 @@
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.backitup/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/simatec/ioBroker.backitup/master/admin/backitup.png",
     "type": "general",
-    "version": "3.3.10"
+    "version": "3.3.13"
   },
   "batrium-bms": {
     "meta": "https://raw.githubusercontent.com/bembelstemmer/ioBroker.batrium-bms/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.backitup to version 3.3.13.

*This pull request was created by https://www.iobroker.dev 974ec1c.*