### PR TITLE
Update drops-weather to 1.2.10

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -541,7 +541,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.drops-weather/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.drops-weather/main/admin/drops-weather.png",
     "type": "weather",
-    "version": "1.2.7"
+    "version": "1.2.10"
   },
   "ds18b20": {
     "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.ds18b20/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.drops-weather to version 1.2.10.

*This pull request was created by https://www.iobroker.dev dfc76cf.*