### PR TITLE
Update heizoel24-mex to 1.6.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1045,7 +1045,7 @@
     "meta": "https://raw.githubusercontent.com/ltspicer/ioBroker.heizoel24-mex/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ltspicer/ioBroker.heizoel24-mex/main/admin/heizoel24-mex.png",
     "type": "metering",
-    "version": "1.5.0"
+    "version": "1.6.0"
   },
   "heizungssteuerung": {
     "meta": "https://raw.githubusercontent.com/jbeenenga/ioBroker.heizungssteuerung/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.heizoel24-mex to version 1.6.0.

*This pull request was created by https://www.iobroker.dev dfc76cf.*