### PR TITLE
Update shelly to 10.5.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2509,7 +2509,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.shelly/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.shelly/master/admin/shelly.png",
     "type": "iot-systems",
-    "version": "10.4.1"
+    "version": "10.5.2"
   },
   "shrdzm": {
     "meta": "https://raw.githubusercontent.com/mcm4iob/ioBroker.shrdzm/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.shelly to version 10.5.2.

*This pull request was created by https://www.iobroker.dev c94083c.*