### PR TITLE
Update steam to 0.5.7

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2739,6 +2739,12 @@
     "type": "misc-data",
     "version": "2.4.0"
   },
+  "steam": {
+    "meta": "https://raw.githubusercontent.com/bloop16/ioBroker.steam/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/bloop16/ioBroker.steam/main/admin/steam.png",
+    "type": "multimedia",
+    "version": "0.5.7"
+  },
   "stiebel-isg": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.stiebel-isg/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.stiebel-isg/master/admin/stiebel-isg.png",


### PR DESCRIPTION
Please update my adapter ioBroker.steam to version 0.5.7.

*This pull request was created by https://www.iobroker.dev c94083c.*