### PR TITLE
Update device-watcher to 2.15.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -475,7 +475,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.device-watcher/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.device-watcher/main/admin/device-watcher.png",
     "type": "misc-data",
-    "version": "2.13.1"
+    "version": "2.15.5"
   },
   "devices": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.devices/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.device-watcher to version 2.15.5.

*This pull request was created by https://www.iobroker.dev 5c5f5d4.*