### PR TITLE
Add grohe-smarthome to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -915,6 +915,11 @@
     "icon": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/admin/air-conditioner.png",
     "type": "climate-control"
   },
+  "grohe-smarthome": {
+    "meta": "https://raw.githubusercontent.com/patricknitsch/ioBroker.grohe-smarthome/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/patricknitsch/ioBroker.grohe-smarthome/main/admin/grohe-smarthome.png",
+    "type": "metering"
+  },
   "growatt": {
     "meta": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/admin/growatt.png",


### PR DESCRIPTION
Please add my adapter ioBroker.grohe-smarthome to latest.

*This pull request was created by https://www.iobroker.dev 5c5f5d4.*