### PR TITLE
Update weathersense to 4.2.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3337,7 +3337,7 @@
     "meta": "https://raw.githubusercontent.com/ltspicer/ioBroker.weathersense/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ltspicer/ioBroker.weathersense/main/admin/weathersense.png",
     "type": "metering",
-    "version": "3.0.3"
+    "version": "4.2.1"
   },
   "weatherunderground": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.weatherunderground/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.weathersense to version 4.2.1.

*This pull request was created by https://www.iobroker.dev 5c5f5d4.*