### PR TITLE
Update meteoswiss to 1.0.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1677,6 +1677,12 @@
     "type": "weather",
     "version": "4.0.1"
   },
+  "meteoswiss": {
+    "meta": "https://raw.githubusercontent.com/deMynchi/ioBroker.meteoswiss/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/deMynchi/ioBroker.meteoswiss/master/admin/meteoswiss.png",
+    "type": "weather",
+    "version": "1.0.2"
+  },
   "mhi-wfrac": {
     "meta": "https://raw.githubusercontent.com/hacki11/ioBroker.mhi-wfrac/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/hacki11/ioBroker.mhi-wfrac/main/admin/mhi-wfrac.png",


### PR DESCRIPTION
Please update my adapter ioBroker.meteoswiss to version 1.0.2.

*This pull request was created by https://www.iobroker.dev 5c5f5d4.*