### PR TITLE
Update vis-icontwo to 2.9.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3175,7 +3175,7 @@
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-icontwo/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-icontwo/master/admin/icontwo.png",
     "type": "visualization-icons",
-    "version": "2.1.1"
+    "version": "2.9.0"
   },
   "vis-inventwo": {
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-inventwo/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-icontwo to version 2.9.0.

*This pull request was created by https://www.iobroker.dev 5c5f5d4.*