### PR TITLE
Update bidirectional-counter to 2.5.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -253,7 +253,7 @@
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.bidirectional-counter/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.bidirectional-counter/main/admin/bidirectional-counter.png",
     "type": "misc-data",
-    "version": "2.5.4"
+    "version": "2.5.5"
   },
   "birthdays": {
     "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.birthdays/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.bidirectional-counter to version 2.5.5.

*This pull request was created by https://www.iobroker.dev 5c5f5d4.*