### PR TITLE
Update lorawan to 1.20.51

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1537,7 +1537,7 @@
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lorawan/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lorawan/main/admin/lorawan.png",
     "type": "protocols",
-    "version": "1.18.0"
+    "version": "1.20.51"
   },
   "lovelace": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.lovelace/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.lorawan to version 1.20.51.

*This pull request was created by https://www.iobroker.dev 5c5f5d4.*