### PR TITLE
Remove zwave2 adapter

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3573,12 +3573,6 @@
     "type": "climate-control",
     "version": "0.5.4"
   },
-  "zwave2": {
-    "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/admin/zwave2.svg?sanitize=true",
-    "type": "hardware",
-    "version": "3.1.0"
-  },
   "zwavews": {
     "meta": "https://raw.githubusercontent.com/arteck/ioBroker.zwavews/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/arteck/ioBroker.zwavews/main/admin/zwavews.png?sanitize=true",

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -3470,11 +3470,6 @@
     "icon": "https://raw.githubusercontent.com/kirovilya/ioBroker.zont/master/admin/zont.png",
     "type": "climate-control"
   },
-  "zwave2": {
-    "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.zwave2/master/admin/zwave2.svg?sanitize=true",
-    "type": "hardware"
-  },
   "zwavews": {
     "meta": "https://raw.githubusercontent.com/arteck/ioBroker.zwavews/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/arteck/ioBroker.zwavews/main/admin/zwavews.png?sanitize=true",


### PR DESCRIPTION
The adapter is no longer maintained and has a more up to date successor in the `zwavews` adapter.