### PR TITLE
Update harmony to 2.0.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1015,7 +1015,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.harmony/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.harmony/master/admin/harmony.png",
     "type": "multimedia",
-    "version": "1.5.0"
+    "version": "2.0.5"
   },
   "hass": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.hass/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.harmony to version 2.0.5.

*This pull request was created by https://www.iobroker.dev 5c5f5d4.*