### PR TITLE
Update hagelschutz-vkf to 1.0.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -993,6 +993,12 @@
     "type": "visualization",
     "version": "0.5.0"
   },
+  "hagelschutz-vkf": {
+    "meta": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.hagelschutz-vkf/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.hagelschutz-vkf/main/admin/hagelschutz-vkf.jpg",
+    "type": "weather",
+    "version": "1.0.1"
+  },
   "haier": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.haier/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.haier/master/admin/haier.png",


### PR DESCRIPTION
Please update my adapter ioBroker.hagelschutz-vkf to version 1.0.1.

*This pull request was created by https://www.iobroker.dev 5c5f5d4.*