### PR TITLE
Update alias-manager to 2.1.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -103,7 +103,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.alias-manager/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.alias-manager/master/admin/alias-manager.png",
     "type": "general",
-    "version": "2.0.0"
+    "version": "2.1.0"
   },
   "alpha-ess": {
     "meta": "https://raw.githubusercontent.com/Gaspode69/ioBroker.alpha-ess/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.alias-manager to version 2.1.0.

*This pull request was created by https://www.iobroker.dev 8e10c9b.*