### PR TITLE
Update google-spreadsheet to 1.0.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -937,7 +937,7 @@
     "meta": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.google-spreadsheet/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.google-spreadsheet/main/admin/google-spreadsheet.png",
     "type": "storage",
-    "version": "0.6.0"
+    "version": "1.0.1"
   },
   "gotify": {
     "meta": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.gotify/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.google-spreadsheet to version 1.0.1.

*This pull request was created by https://www.iobroker.dev 8e10c9b.*