### PR TITLE
Update envertech-pv to 1.5.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -697,7 +697,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.envertech-pv/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.envertech-pv/master/admin/envertech-pv.png",
     "type": "energy",
-    "version": "1.5.0"
+    "version": "1.5.1"
   },
   "epson_ecotank_et_2750": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.epson_ecotank_et_2750/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.envertech-pv to version 1.5.1.

*This pull request was created by https://www.iobroker.dev 8e10c9b.*