### PR TITLE
Add ioBroker.simple-proxy-manager to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2466,6 +2466,11 @@
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.simple-api/master/admin/simple-api.png",
     "type": "communication"
   },
+  "simple-proxy-manager": {
+    "meta": "https://raw.githubusercontent.com/lubepi/ioBroker.simple-proxy-manager/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/lubepi/ioBroker.simple-proxy-manager/main/admin/simple-proxy-manager.png",
+    "type": "network"
+  },
   "skiinfo": {
     "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.skiinfo/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.skiinfo/main/admin/skiinfo.png",


### PR DESCRIPTION
## Add new adapter: simple-proxy-manager

**Type:** network

**Description:** Simple HTTPS reverse proxy manager with virtual hosts, IP filtering and automatic certificate reload

**Links:**
- Repository: https://github.com/lubepi/ioBroker.simple-proxy-manager
- npm: https://www.npmjs.com/package/iobroker.simple-proxy-manager

**Checklist:**
- [x] The adapter has a unique name
- [x] Published on npm (v0.1.1)
- [x] Uses @iobroker/adapter-core
- [x] Has io-package.json with all required fields (titleLang, desc, licenseInformation, tier, etc.)
- [x] Has README.md
- [x] bluefox added as npm collaborator
- [x] Adapter checker passed (https://adapter-check.iobroker.in)