### PR TITLE
Update feiertage to 1.3.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -769,7 +769,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.feiertage/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.feiertage/master/admin/feiertage.png",
     "type": "date-and-time",
-    "version": "1.2.1"
+    "version": "1.3.0"
   },
   "fenecon": {
     "meta": "https://raw.githubusercontent.com/sg-app/ioBroker.fenecon/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.feiertage to version 1.3.0.

*This pull request was created by https://www.iobroker.dev 8e10c9b.*