### PR TITLE
Update vis-icontwo to 2.11.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3181,7 +3181,7 @@
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-icontwo/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-icontwo/master/admin/icontwo.png",
     "type": "visualization-icons",
-    "version": "2.9.0"
+    "version": "2.11.1"
   },
   "vis-inventwo": {
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-inventwo/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-icontwo to version 2.11.1.

*This pull request was created by https://www.iobroker.dev 8e10c9b.*