### PR TITLE
Update smartm to 0.0.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2619,6 +2619,12 @@
     "type": "logic",
     "version": "0.1.0"
   },
+  "smartm": {
+    "meta": "https://raw.githubusercontent.com/strulli85/ioBroker.smartm/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/strulli85/ioBroker.smartm/main/admin/smartm.svg",
+    "type": "energy",
+    "version": "0.0.5"
+  },
   "smartmeter": {
     "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.smartmeter/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.smartmeter/master/admin/smartmeter.png",


### PR DESCRIPTION
Please update my adapter ioBroker.smartm to version 0.0.5.

*This pull request was created by https://www.iobroker.dev 8e10c9b.*