### PR TITLE
Add ultrahuman adapter

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2910,6 +2910,11 @@
     "icon": "https://raw.githubusercontent.com/patrickbs96/ioBroker.twinkly/master/admin/twinkly.png",
     "type": "lighting"
   },
+  "ultrahuman": {
+    "meta": "https://raw.githubusercontent.com/SmarterPapa/ioBroker.ultrahuman/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/SmarterPapa/ioBroker.ultrahuman/main/admin/ultrahuman.png",
+    "type": "health"
+  },
   "unifi": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.unifi/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.unifi/master/admin/unifi.png",


### PR DESCRIPTION
## Add ioBroker.ultrahuman adapter

Adds the Ultrahuman Ring adapter to the ioBroker repository.

### Adapter Information
- **Name:** ultrahuman
- **Description:** Reads health metrics from Ultrahuman Ring via Partner API
- **Type:** health
- **npm:** https://www.npmjs.com/package/iobroker.ultrahuman
- **GitHub:** https://github.com/SmarterPapa/ioBroker.ultrahuman

### Features
- Sleep data (efficiency, duration, stages, score, cycles)
- Heart rate (resting, night, average, min/max, trend)
- HRV (average, sleep, min/max, trend)
- SpO2 (if supported by ring)
- Skin temperature
- Activity (steps, active minutes, movement/recovery index, VO2 max)

### Checklist
- [x] Adapter published on npm
- [x] GitHub repository public
- [x] MIT License
- [x] io-package.json valid
- [x] README with documentation