### PR TITLE
Update daswetter to 4.5.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -451,7 +451,7 @@
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.daswetter/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.daswetter/master/admin/daswettercom.png",
     "type": "weather",
-    "version": "3.2.8"
+    "version": "4.5.3"
   },
   "deconz": {
     "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.deconz/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.daswetter to version 4.5.3.

*This pull request was created by https://www.iobroker.dev eca7354.*