### PR TITLE
Update mihome-cloud to 1.0.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1723,7 +1723,7 @@
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.mihome-cloud/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.mihome-cloud/main/admin/mihome-cloud.png",
     "type": "iot-systems",
-    "version": "0.1.0"
+    "version": "1.0.4"
   },
   "mihome-plug": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mihome-plug/master/io-package.json",


### PR DESCRIPTION
The old stable version 0.1.0 is broken due to Xiaomi cloud API changes. Version 1.0.4 is a major update/rewrite that restores functionality and has been tested in latest.