### PR TITLE
Add aurora-nowcast 2.1.4 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -183,6 +183,12 @@
     "type": "hardware",
     "version": "2.3.0"
   },
+  "aurora-nowcast": {
+    "meta": "https://raw.githubusercontent.com/chrmenne/ioBroker.aurora-nowcast/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/chrmenne/ioBroker.aurora-nowcast/main/admin/aurora-nowcast.png",
+    "type": "weather",
+    "version": "2.1.4"
+  },
   "autodarts": {
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.autodarts/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.autodarts/main/admin/autodarts.svg",


### PR DESCRIPTION
Please update my adapter ioBroker.aurora-nowcast to version 2.1.4.

*This pull request was created by https://www.iobroker.dev eca7354.*