### PR TITLE
Add homeassistant-bridge adapter

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1140,11 +1140,6 @@
     "icon": "https://raw.githubusercontent.com/xXBJXx/ioBroker.hue-sync-box/main/admin/hueSyncBox.png",
     "type": "lighting"
   },
-  "hueemu": {
-    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.hueemu/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.hueemu/master/admin/hue-emu-logo.png",
-    "type": "lighting"
-  },
   "huum-sauna": {
     "meta": "https://raw.githubusercontent.com/Chris-656/ioBroker.huum-sauna/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Chris-656/ioBroker.huum-sauna/main/admin/huum-sauna.png",

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1140,6 +1140,11 @@
     "icon": "https://raw.githubusercontent.com/xXBJXx/ioBroker.hue-sync-box/main/admin/hueSyncBox.png",
     "type": "lighting"
   },
+  "hueemu": {
+    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.hueemu/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.hueemu/master/admin/hue-emu-logo.png",
+    "type": "lighting"
+  },
   "huum-sauna": {
     "meta": "https://raw.githubusercontent.com/Chris-656/ioBroker.huum-sauna/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Chris-656/ioBroker.huum-sauna/main/admin/huum-sauna.png",

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1090,6 +1090,11 @@
     "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.homee/master/admin/homee.png",
     "type": "iot-systems"
   },
+  "homeassistant-bridge": {
+    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.homeassistant-bridge/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.homeassistant-bridge/main/admin/homeassistant-bridge.svg",
+    "type": "infrastructure"
+  },
   "homekit-controller": {
     "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.homekit-controller/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.homekit-controller/main/admin/homekit-controller.png",


### PR DESCRIPTION
## New Adapter: homeassistant-bridge

**npm:** https://www.npmjs.com/package/iobroker.homeassistant-bridge
**GitHub:** https://github.com/krobipd/ioBroker.homeassistant-bridge

### Description

Emulates a minimal Home Assistant server so devices expecting a Home Assistant dashboard (e.g. Shelly Wall Display XL) can display any custom web URL — without running a real Home Assistant Core.

### Features

- Emulates relevant Home Assistant API endpoints
- Provides `_home-assistant._tcp` mDNS service discovery via Avahi
- Implements minimal OAuth2-like auth flow
- Redirects to any configured target URL after authentication

### Technical

- Written in TypeScript (strict mode)
- Express 5
- js-controller >= 7.0.0, Admin >= 7.6.20
- Node.js >= 20
- 111 tests passing
- Official ioBroker testing actions (check, adapter, deploy)

### Repochecker

FINAL status 'OK' — only remaining issue is E2001 (bluefox collaborator, pending acceptance).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)