### PR TITLE
Add hueemu adapter to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1135,6 +1135,11 @@
     "icon": "https://raw.githubusercontent.com/xXBJXx/ioBroker.hue-sync-box/main/admin/hueSyncBox.png",
     "type": "lighting"
   },
+  "hueemu": {
+    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.hueemu/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.hueemu/master/admin/hue-emu-logo.png",
+    "type": "lighting"
+  },
   "huum-sauna": {
     "meta": "https://raw.githubusercontent.com/Chris-656/ioBroker.huum-sauna/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Chris-656/ioBroker.huum-sauna/main/admin/huum-sauna.png",


### PR DESCRIPTION
## New Adapter: hueemu

Emulates a Philips Hue Bridge (v2, BSB002) to allow controlling ioBroker devices via Alexa, Google Home and other Hue-compatible smart home systems.

- **npm:** https://www.npmjs.com/package/iobroker.hueemu
- **GitHub:** https://github.com/krobipd/ioBroker.hueemu
- **Version:** 1.0.4
- **Type:** lighting
- **License:** MIT

### What it does
- Emulates Hue API v1 endpoints
- UPnP/SSDP discovery for automatic detection
- Supports On/Off, Dimmable, Color Temperature and RGB lights
- Maps ioBroker states to Hue light properties
- Pairing-mode with 50s timeout

### Original
Fork and complete rewrite of [ioBroker.hueemu](https://github.com/holomekc/ioBroker.hueemu) by Christopher Holomek (original 2020, inactive since 2022). Modernized in 2026 with Fastify, TypeScript strict mode, Admin 7 jsonConfig UI, js-controller 7 support.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)