### PR TITLE
Update solarprognose to 2.0.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2677,7 +2677,7 @@
     "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.solarprognose/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.solarprognose/main/admin/solarprognose.png",
     "type": "weather",
-    "version": "2.0.0"
+    "version": "2.0.1"
   },
   "solarviewdatareader": {
     "meta": "https://raw.githubusercontent.com/afuerhoff/ioBroker.solarviewdatareader/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.solarprognose to version 2.0.1.

*This pull request was created by https://www.iobroker.dev eca7354.*