### PR TITLE
Add homeassistant-bridge adapter

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1080,6 +1080,11 @@
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.hmip/master/admin/homematic.png",
     "type": "hardware"
   },
+  "homeassistant-bridge": {
+    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.homeassistant-bridge/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.homeassistant-bridge/main/admin/icon.svg",
+    "type": "infrastructure"
+  },
   "homeconnect": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.homeconnect/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.homeconnect/master/admin/homeconnect.png",


### PR DESCRIPTION
## New Adapter: homeassistant-bridge

**npm:** https://www.npmjs.com/package/iobroker.homeassistant-bridge
**GitHub:** https://github.com/krobipd/ioBroker.homeassistant-bridge

### Description

Emulates a minimal Home Assistant server so devices expecting a Home Assistant dashboard (e.g. Shelly Wall Display XL) can display any custom web URL — without running a real Home Assistant Core.

### Features

- Emulates relevant Home Assistant API endpoints
- Provides `_home-assistant._tcp` mDNS service discovery via Avahi
- Implements minimal OAuth2-like auth flow
- Redirects to any configured target URL after authentication

### Technical

- Written in TypeScript (strict mode)
- Express 5
- js-controller >= 7.0.0, Admin >= 7.6.20
- Node.js >= 20
- 111 tests passing
- Official ioBroker testing actions (check, adapter, deploy)

### Repochecker

FINAL status 'OK' — only remaining issue is E2001 (bluefox collaborator, pending acceptance).