### PR TITLE
Add beszel to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -240,6 +240,11 @@
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.bestway/master/admin/bestway.png",
     "type": "household"
   },
+  "beszel": {
+    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.beszel/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.beszel/main/admin/beszel.svg",
+    "type": "hardware"
+  },
   "bidirectional-counter": {
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.bidirectional-counter/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.bidirectional-counter/main/admin/bidirectional-counter.png",


### PR DESCRIPTION
## New Adapter: ioBroker.beszel

**Repository:** https://github.com/krobipd/ioBroker.beszel  
**npm:** https://www.npmjs.com/package/iobroker.beszel  
**Version:** 0.1.4  
**Type:** hardware

### Description

Connects to a [Beszel](https://github.com/henrygd/beszel) Hub and exposes server monitoring metrics for all registered systems as ioBroker states.

### Features
- Fetches metrics from all systems registered in the Beszel Hub
- Per-system states: CPU, memory, disk, network, temperature, load average
- Optional: GPU metrics, Docker/Podman containers, battery, extra filesystems, CPU breakdown, systemd services
- Configurable poll interval (10–300 seconds)
- Automatic token refresh and re-authentication on 401
- Connection test button in admin UI

### Repochecker
Only remaining issue: E2001 (bluefox npm collaborator — invitation already sent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)