### PR TITLE
Update myvbus to 0.6.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1849,7 +1849,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.myvbus/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.myvbus/master/admin/myvbus.png",
     "type": "climate-control",
-    "version": "0.6.0"
+    "version": "0.6.1"
   },
   "mywallbox": {
     "meta": "https://raw.githubusercontent.com/SKB-CGN/ioBroker.mywallbox/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.myvbus to version 0.6.1.

*This pull request was created by https://www.iobroker.dev a59a21f.*