### PR TITLE
Update vbus-gw to 0.3.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3019,7 +3019,7 @@
     "meta": "https://raw.githubusercontent.com/pdbjjens/ioBroker.vbus-gw/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/pdbjjens/ioBroker.vbus-gw/main/admin/vbus-gw.png",
     "type": "network",
-    "version": "0.3.0"
+    "version": "0.3.2"
   },
   "vds2465-server": {
     "meta": "https://raw.githubusercontent.com/Hirsch-DE/ioBroker.vds2465-server/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vbus-gw to version 0.3.2.

*This pull request was created by https://www.iobroker.dev a59a21f.*