### PR TITLE
Update ical to 1.19.7

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1195,7 +1195,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ical/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ical/master/admin/ical.png",
     "type": "date-and-time",
-    "version": "1.18.1"
+    "version": "1.19.7"
   },
   "iceroad": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.iceroad/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.ical to version 1.19.7.

*This pull request was created by https://www.iobroker.dev a59a21f.*