### PR TITLE
Update epson_ecotank_et_2750 to 1.1.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -703,7 +703,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.epson_ecotank_et_2750/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.epson_ecotank_et_2750/master/admin/epson_ecotank_et_2750.png",
     "type": "infrastructure",
-    "version": "1.0.1"
+    "version": "1.1.0"
   },
   "epson_stylus_px830": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.epson_stylus_px830/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.epson_ecotank_et_2750 to version 1.1.0.

*This pull request was created by https://www.iobroker.dev a59a21f.*