### PR TITLE
Update frontier_silicon to 0.5.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -877,7 +877,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.frontier_silicon/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.frontier_silicon/master/admin/radio.png",
     "type": "multimedia",
-    "version": "0.5.0"
+    "version": "0.5.1"
   },
   "fuelpricemonitor": {
     "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.fuelpricemonitor/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.frontier_silicon to version 0.5.1.

*This pull request was created by https://www.iobroker.dev e435dad.*