### PR TITLE
Update fritzbox to 0.7.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -841,7 +841,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fritzbox/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fritzbox/master/admin/fritzbox.png",
     "type": "infrastructure",
-    "version": "0.6.0"
+    "version": "0.7.0"
   },
   "fritzdect": {
     "meta": "https://raw.githubusercontent.com/foxthefox/ioBroker.fritzdect/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.fritzbox to version 0.7.0.

*This pull request was created by https://www.iobroker.dev e435dad.*