### PR TITLE
Updated air-q to 1.1.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -55,7 +55,7 @@
     "meta": "https://raw.githubusercontent.com/CorantGmbH/ioBroker.air-q/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/CorantGmbH/ioBroker.air-q/main/admin/air-q.png",
     "type": "weather",
-    "version": "1.0.5"
+    "version": "1.1.0"
   },
   "airconwithme": {
     "meta": "https://raw.githubusercontent.com/weggetor/ioBroker.airconwithme/main/io-package.json",


### PR DESCRIPTION
Long overdue update. Stable is at 1.0.5 while 1.1.0 was released on Feb 18.

Skipped releases contain important fixes:
- 1.0.6: night mode support (skip polling when device WiFi is off)
- 1.0.7: fix missing sensor handling, incorrect translations
- 1.1.0: 19 new sensors (mold, refrigerants, gas sensors)