### PR TITLE
Add hoymiles to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1090,6 +1090,11 @@
     "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.homee/master/admin/homee.png",
     "type": "iot-systems"
   },
+  "hoymiles": {
+    "meta": "https://raw.githubusercontent.com/Eistee82/ioBroker.hoymiles/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Eistee82/ioBroker.hoymiles/main/admin/hoymiles.png",
+    "type": "energy"
+  },
   "homekit-controller": {
     "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.homekit-controller/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.homekit-controller/main/admin/homekit-controller.png",


### PR DESCRIPTION
## Add ioBroker.hoymiles adapter

Hoymiles HMS microinverter adapter with integrated WiFi DTU (DTUBI) support.

- **npm**: https://www.npmjs.com/package/iobroker.hoymiles
- **GitHub**: https://github.com/Eistee82/ioBroker.hoymiles
- **Type**: energy
- **Tested**: HMS-800W-2T with local TCP + S-Miles Cloud

### Features
- Direct TCP/Protobuf communication (persistent connection with heartbeat)
- Cloud Relay: forwards data to Hoymiles Cloud on behalf of DTU
- Configurable data interval (0 = fastest, ~1s)
- AES-128-CBC encryption for newer firmware
- 75 unit tests, 0 lint errors