### PR TITLE
Update openknx to 1.1.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2023,7 +2023,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.openknx/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.openknx/master/admin/openknx.png",
     "type": "iot-systems",
-    "version": "0.9.0"
+    "version": "1.1.4"
   },
   "openligadb": {
     "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.openligadb/main/io-package.json",


### PR DESCRIPTION
Update openknx stable version from 0.9.0 to 1.1.4.

## Changes since 0.9.0

**Breaking:**
- KNX communication switched to KNXUltimate library
- DPT21 property names changed to camelCase (outofservice → outOfService, inalarm → inAlarm, alarmeunack → alarmUnAck), values must be boolean
- DPT237 property names changed to camelCase
- Adapter requires node.js >= 20 and js-controller >= 6

**Features:**
- KNX Secure support (Tunnel TCP + Multicast)
- Native .knxproj import (ETS4/5/6, password-protected) with CO flags, DPT inference, room assignment
- Extended DPT coverage (9 additional DPTs: DPT-22, 213, 222, 235, 242, 249, 251)
- Direct Link: connect any ioBroker state to a KNX group address (1:1, trigger, toggle modes)
- GA-Tools: all GA properties editable (DPT, type, role, read/write flags) with compact layout
- Role dropdown filtered by read/write state
- Improved role detection (switch, level, value, text, date) based on DPT type
- Reconnect with exponential backoff (7 attempts: 10s-120s)
- KNX gateway auto-detection with manufacturer lookup

**Fixes:**
- Unhandled promise rejection when Disconnect() called without socket
- Uncaught exceptions in read()/write() during reconnect
- GA tree filter not finding items inside collapsed folders
- BigInt DPT29 decode (ioBroker cannot store BigInt)
- Socket leak during reconnect
- DPT5.000 write error for unresolvable subtypes
