### PR TITLE
Update deconz to 1.7.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -457,7 +457,7 @@
     "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.deconz/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.deconz/master/admin/deconz.png",
     "type": "hardware",
-    "version": "1.6.4"
+    "version": "1.7.4"
   },
   "denon": {
     "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.denon/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.deconz to version 1.7.4.

*This pull request was created by https://www.iobroker.dev e435dad.*

@mcm1957 wäre gut wenn du das release Zeitnah ins Stable Übernimmst, da es einen Bug in der 1.6.4 gibt der den Adapter seit der Zeitumstellung unbrauchbar macht. -> https://forum.iobroker.net/topic/84157/deconz-startet-nicht-mehr?_=1774821111489