### PR TITLE
Update pi-hole to 2.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2137,7 +2137,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pi-hole/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pi-hole/master/admin/pi-hole.png",
     "type": "network",
-    "version": "1.3.6"
+    "version": "2.0.0"
   },
   "pi-hole2": {
     "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.pi-hole2/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.pi-hole to version 2.0.0.

*This pull request was created by https://www.iobroker.dev e435dad.*