### PR TITLE
Update open-meteo-weather to 2.6.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2007,6 +2007,12 @@
     "type": "protocols",
     "version": "1.2.1"
   },
+  "open-meteo-weather": {
+    "meta": "https://raw.githubusercontent.com/H5N1v2/ioBroker.open-meteo-weather/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/H5N1v2/ioBroker.open-meteo-weather/main/admin/open-meteo.png",
+    "type": "weather",
+    "version": "2.6.4"
+  },
   "opendtu": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.opendtu/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.opendtu/main/admin/opendtu.png",


### PR DESCRIPTION
Please update my adapter ioBroker.open-meteo-weather to version 2.6.4.

*This pull request was created by https://www.iobroker.dev e435dad.*