### PR TITLE
Update nextcloud-monitoring to 2.0.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1887,6 +1887,12 @@
     "type": "climate-control",
     "version": "2.8.0"
   },
+  "nextcloud-monitoring": {
+    "meta": "https://raw.githubusercontent.com/H5N1v2/ioBroker.nextcloud-monitoring/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/H5N1v2/ioBroker.nextcloud-monitoring/main/admin/nextcloud_monitoring.png",
+    "type": "network",
+    "version": "2.0.6"
+  },
   "nina": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.nina/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.nina/master/admin/nina.png",


### PR DESCRIPTION
Please update my adapter ioBroker.nextcloud-monitoring to version 2.0.6.

*This pull request was created by https://www.iobroker.dev e435dad.*