### PR TITLE
Update pjlink to 0.1.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2181,6 +2181,12 @@
     "type": "hardware",
     "version": "1.1.4"
   },
+  "pjlink": {
+    "meta": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.pjlink/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.pjlink/main/admin/pjlink.png",
+    "type": "multimedia",
+    "version": "0.1.2"
+  },
   "places": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.places/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.places/master/admin/places.png",


### PR DESCRIPTION
Please update my adapter ioBroker.pjlink to version 0.1.2.

*This pull request was created by https://www.iobroker.dev e435dad.*