### PR TITLE
Add apsystem-ez1-solar adapter

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -4,15 +4,15 @@
     "name": {
       "en": "Latest (beta) repository",
       "de": "Latest (Beta) Repository",
-      "ru": "Latest (бета) репозиторий",
-      "pt": "Latest repositório (beta)",
-      "nl": "Latest (bèta) repository",
-      "fr": "Latest dépôt (bêta)",
+      "ru": "Latest (\u0431\u0435\u0442\u0430) \u0440\u0435\u043f\u043e\u0437\u0438\u0442\u043e\u0440\u0438\u0439",
+      "pt": "Latest reposit\u00f3rio (beta)",
+      "nl": "Latest (b\u00e8ta) repository",
+      "fr": "Latest d\u00e9p\u00f4t (b\u00eata)",
       "it": "Latest repository (beta)",
       "es": "Latest repositorio (beta)",
       "pl": "Latest repozytorium (beta)",
-      "uk": "Latest (бета) репозиторій",
-      "zh-cn": "Latest（测试版）存储库"
+      "uk": "Latest (\u0431\u0435\u0442\u0430) \u0440\u0435\u043f\u043e\u0437\u0438\u0442\u043e\u0440\u0456\u0439",
+      "zh-cn": "Latest\uff08\u6d4b\u8bd5\u7248\uff09\u5b58\u50a8\u5e93"
     }
   },
   "accuweather": {
@@ -139,6 +139,11 @@
     "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.apg-info/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/HGlab01/ioBroker.apg-info/main/admin/apg-info.png",
     "type": "general"
+  },
+  "apsystem-ez1-solar": {
+    "meta": "https://raw.githubusercontent.com/d3vc0-de/ioBroker.apsystem-ez1-solar/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/d3vc0-de/ioBroker.apsystem-ez1-solar/main/admin/apsystem-ez1-solar.png",
+    "type": "energy"
   },
   "apsystems-ez1": {
     "meta": "https://raw.githubusercontent.com/zhihaining/ioBroker.apsystems-ez1/master/io-package.json",


### PR DESCRIPTION
## New adapter: apsystem-ez1-solar

This PR adds the **APsystems EZ1 microinverter** adapter to the ioBroker repository.

### Adapter details

- **Name:** apsystem-ez1-solar
- **npm:** https://www.npmjs.com/package/iobroker.apsystem-ez1-solar
- **GitHub:** https://github.com/d3vc0-de/ioBroker.apsystem-ez1-solar
- **Type:** energy
- **License:** MIT

### Description

Integrates the APsystems EZ1 microinverter into ioBroker via its local HTTP API (port 8050). Reads real-time power output, energy totals and alarm states. Supports controlling the inverter (on/off, max power limit).

### Checklist

- [x] Published on npm
- [x] io-package.json valid
- [x] README.md with description and configuration
- [x] MIT License
- [x] Adapter Checker reviewed