### PR TITLE
Add apsystem-ez1-solar to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -140,6 +140,11 @@
     "icon": "https://raw.githubusercontent.com/HGlab01/ioBroker.apg-info/main/admin/apg-info.png",
     "type": "general"
   },
+  "apsystem-ez1-solar": {
+    "meta": "https://raw.githubusercontent.com/d3vc0-de/ioBroker.apsystem-ez1-solar/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/d3vc0-de/ioBroker.apsystem-ez1-solar/main/admin/apsystem-ez1-solar.png",
+    "type": "energy"
+  },
   "apsystems-ez1": {
     "meta": "https://raw.githubusercontent.com/zhihaining/ioBroker.apsystems-ez1/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/zhihaining/ioBroker.apsystems-ez1/master/admin/apsystems-ez1.png",


### PR DESCRIPTION
## New adapter: apsystem-ez1-solar

This PR adds the **APsystems EZ1 Solar microinverter** adapter to the ioBroker latest repository.

### Adapter details

- **Name:** apsystem-ez1-solar
- **npm:** https://www.npmjs.com/package/iobroker.apsystem-ez1-solar
- **GitHub:** https://github.com/d3vc0-de/ioBroker.apsystem-ez1-solar
- **Type:** energy
- **License:** MIT

### Description

Integrates the APsystems EZ1 microinverter into ioBroker via its local HTTP API (port 8050). Reads real-time power output, energy totals and alarm states. Supports controlling the inverter (on/off, max power limit).

### Why a new adapter?

The existing adapter [`apsystems-ez1`](https://github.com/zhihaining/ioBroker.apsystems-ez1) referenced in the repository is no longer functional and has been abandoned:

- The adapter is **no longer actively maintained** — the repository has had no meaningful updates and issues remain unaddressed.
- It **does not work** with current ioBroker installations due to outdated dependencies and broken API handling.
- It contains **structural deficiencies** in both the code and ioBroker adapter structure (missing `info.connection` state, invalid state roles, improper error handling, non-compliant `io-package.json`).

This new adapter was written from scratch with a clean implementation following current ioBroker development best practices and adapter checker requirements.

### Checklist

- [x] Published on npm
- [x] `io-package.json` valid and adapter-checker compliant
- [x] `README.md` with description and configuration
- [x] MIT License
- [x] GitHub Actions CI/CD configured
- [x] `info.connection` state implemented
- [x] Valid state roles used throughout