### PR TITLE
Add ioBroker.script-restore

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2493,6 +2493,12 @@
     "type": "climate-control",
     "version": "1.4.2"
   },
+  "script-restore": {
+    "meta": "https://raw.githubusercontent.com/ipod86/ioBroker.script-restore/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/ipod86/ioBroker.script-restore/main/admin/script-restore.svg",
+    "type": "tools",
+    "version": "0.0.3"
+  },
   "seko": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.seko/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.seko/main/admin/seko.png",

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2421,6 +2421,11 @@
     "icon": "https://raw.githubusercontent.com/Excodibur/ioBroker.schwoerer-ventcube/master/admin/schwoerer-ventcube.png",
     "type": "climate-control"
   },
+  "script-restore": {
+    "meta": "https://raw.githubusercontent.com/ipod86/ioBroker.script-restore/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/ipod86/ioBroker.script-restore/main/admin/script-restore.svg",
+    "type": "tools"
+  },
   "seko": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.seko/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.seko/main/admin/seko.png",


### PR DESCRIPTION
## Add ioBroker.script-restore

Adds the `script-restore` adapter to both `sources-dist.json` (latest) and `sources-dist-stable.json` (stable v0.0.3).

- **Repository:** https://github.com/ipod86/ioBroker.script-restore
- **Type:** tools
- **Version (stable):** 0.0.3

The adapter allows restoring ioBroker scripts from backup files.