### PR TITLE
Update foobar2000 to 2.3.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -817,7 +817,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.foobar2000/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.foobar2000/master/admin/foobar2000.png",
     "type": "multimedia",
-    "version": "2.2.0"
+    "version": "2.3.0"
   },
   "ford": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.ford/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.foobar2000 to version 2.3.0.

*This pull request was created by https://www.iobroker.dev e435dad.*