### PR TITLE
Add openmeteo to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1976,6 +1976,11 @@
     "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.openmediavault/main/admin/openmediavault.png",
     "type": "infrastructure"
   },
+  "openmeteo": {
+    "meta": "https://raw.githubusercontent.com/ipod86/ioBroker.openmeteo/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/ipod86/ioBroker.openmeteo/main/admin/openmeteo.png",
+    "type": "weather"
+  },
   "opensmartcity": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.opensmartcity/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.opensmartcity/main/admin/opensmartcity.png",


### PR DESCRIPTION
## Add ioBroker.openmeteo to Latest Repository

This PR adds the `openmeteo` adapter to the Latest repository (`sources-dist.json`).

**Note:** There is already an existing adapter `open-meteo-weather` in the repository. The addition of this adapter was discussed with and approved by @Apollon77.

## Adapter details

- GitHub: https://github.com/ipod86/ioBroker.openmeteo
- npm: https://www.npmjs.com/package/iobroker.openmeteo
- Type: `weather`
