### PR TITLE
Add miner to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1681,6 +1681,11 @@
     "icon": "https://raw.githubusercontent.com/Steiger04/ioBroker.milight-smart-light/master/admin/milight-smart-light.png",
     "type": "lighting"
   },
+  "miner": {
+    "meta": "https://raw.githubusercontent.com/SimonFischer04/ioBroker.miner/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/SimonFischer04/ioBroker.miner/main/admin/miner.png",
+    "type": "hardware"
+  },
   "minuaru": {
     "meta": "https://raw.githubusercontent.com/minukodu/ioBroker.minuaru/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/minukodu/ioBroker.minuaru/main/admin/minuaru.png",


### PR DESCRIPTION
Created manually (and not through dev-portal) because checker blocks with issues I can't fix:

- [E4033] Dependency 'admin':'>=7.8.20' not available at stable repository -> available in latest and required to get devicemanager to work, which is required in this adapter to configure devices. (current stable 7.7.22 does not work)
- [E5027] Plugin "license" missing at .releaseconfig.json. Please add. -> complains about 2007 - but this is part of GPL license text
See: https://github.com/AlCalzone/release-script/issues/130

Links:
- repo https://github.com/SimonFischer04/ioBroker.miner
- feature request: https://github.com/ioBroker/AdapterRequests/issues/786