### PR TITLE
Update jeelink to 1.2.8

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1369,7 +1369,7 @@
     "meta": "https://raw.githubusercontent.com/foxthefox/ioBroker.jeelink/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/foxthefox/ioBroker.jeelink/master/admin/jeelab_logo.png",
     "type": "hardware",
-    "version": "1.2.5"
+    "version": "1.2.8"
   },
   "js-controller": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.js-controller/master/packages/controller/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.jeelink to version 1.2.8.

*This pull request was created by https://www.iobroker.dev e435dad.*