### PR TITLE
Update schlueter-thermostat to 0.5.2 - STABLE

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2487,6 +2487,12 @@
     "type": "logic",
     "version": "1.5.0"
   },
+  "schlueter-thermostat": {
+    "meta": "https://raw.githubusercontent.com/patricknitsch/ioBroker.schlueter-thermostat/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/patricknitsch/ioBroker.schlueter-thermostat/main/admin/schlueter-thermostat.png",
+    "type": "climate-control",
+    "version": "0.5.2"
+  },
   "schoolfree": {
     "meta": "https://raw.githubusercontent.com/simatec/ioBroker.schoolfree/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/simatec/ioBroker.schoolfree/master/admin/schoolfree.png",


### PR DESCRIPTION
Please update my adapter ioBroker.schlueter-thermostat to version 0.5.2.

*This pull request was created by https://www.iobroker.dev e435dad.*