### PR TITLE
Add grohe-smarthome 0.3.3 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -957,6 +957,12 @@
     "type": "climate-control",
     "version": "2.0.8"
   },
+  "grohe-smarthome": {
+    "meta": "https://raw.githubusercontent.com/patricknitsch/ioBroker.grohe-smarthome/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/patricknitsch/ioBroker.grohe-smarthome/main/admin/grohe-smarthome.png",
+    "type": "metering",
+    "version": "0.3.3"
+  },
   "growatt": {
     "meta": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/admin/growatt.png",


### PR DESCRIPTION
Please update my adapter ioBroker.grohe-smarthome to version 0.3.3.

*This pull request was created by https://www.iobroker.dev e435dad.*