### PR TITLE
Update reolink to 1.4.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2353,7 +2353,7 @@
     "meta": "https://raw.githubusercontent.com/aendue/ioBroker.reolink/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/aendue/ioBroker.reolink/main/admin/reolink.png",
     "type": "alarm",
-    "version": "1.2.3"
+    "version": "1.4.2"
   },
   "residents": {
     "meta": "https://raw.githubusercontent.com/jpawlowski/ioBroker.residents/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.reolink to version 1.4.2.

*This pull request was created by https://www.iobroker.dev e435dad.*