### PR TITLE
Update rpi2 to 3.0.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2419,7 +2419,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.rpi2/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.rpi2/master/admin/rpi2.png",
     "type": "hardware",
-    "version": "2.4.0"
+    "version": "3.0.2"
   },
   "rssfeed": {
     "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.rssfeed/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.rpi2 to version 3.0.2.

*This pull request was created by https://www.iobroker.dev e435dad.*