### PR TITLE
Update tinymqttbroker to 0.1.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2941,7 +2941,7 @@
     "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.tinymqttbroker/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/HGlab01/ioBroker.tinymqttbroker/main/admin/tinymqttbroker.png",
     "type": "protocols",
-    "version": "0.1.5"
+    "version": "0.1.6"
   },
   "tr-064": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tr-064/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.tinymqttbroker to version 0.1.6.

*This pull request was created by https://www.iobroker.dev e435dad.*