### PR TITLE
Add govee-smart adapter

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -930,6 +930,11 @@
     "icon": "https://raw.githubusercontent.com/boergegrunicke/ioBroker.govee-local/main/admin/govee-local.png",
     "type": "lighting"
   },
+  "govee-smart": {
+    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.govee-smart/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.govee-smart/main/admin/govee-smart.svg",
+    "type": "lighting"
+  },
   "gree-hvac": {
     "meta": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/admin/air-conditioner.png",


### PR DESCRIPTION
## Description

Add **ioBroker.govee-smart** to the latest repository.

Control Govee smart lights via three seamless channels: LAN (fastest, primary), AWS IoT MQTT (real-time status push), and Cloud API v2 (scenes, segments, capabilities).

**GitHub:** https://github.com/krobipd/ioBroker.govee-smart
**npm:** https://www.npmjs.com/package/iobroker.govee-smart
**Version:** 1.0.0

### Key Features

- **LAN First** — UDP multicast discovery and control for lowest latency (~100ms)
- **BLE-over-LAN Scenes** — 78-237 scenes per device activated locally via ptReal protocol
- **Music Mode** — Local BLE-over-LAN music reactive effects
- **Local Snapshots** — Save/restore device state via LAN without Cloud
- **SKU Cache** — Zero Cloud calls after first start
- **Graceful Degradation** — Works LAN-only without any credentials
- **291 tests**, CI on 3 Node versions × 3 OS

### Checklist

- [x] Repochecker passes (0 errors, 0 warnings)
- [x] npm published with OIDC
- [x] Bluefox added as npm collaborator
- [x] GitHub Actions green (test-and-release.yml)
- [x] build/ committed
- [x] README in English with changelog
- [x] MIT license
- [x] jsonConfig with responsive breakpoints
- [x] dependabot.yml (npm + github-actions)
- [x] automerge-dependabot.yml