### PR TITLE
hueemu master -> main LATEST

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1146,8 +1146,8 @@
     "type": "lighting"
   },
   "hueemu": {
-    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.hueemu/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.hueemu/master/admin/hue-emu-logo.png",
+    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.hueemu/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.hueemu/main/admin/hue-emu-logo.png",
     "type": "lighting"
   },
   "huum-sauna": {


### PR DESCRIPTION
The hueemu adapter repository uses `main` as its default branch, but the `sources-dist.json` entry still references `/master/` in the meta and icon URLs.

**Changes:**
- `meta`: `/master/` → `/main/`
- `icon`: `/master/` → `/main/`

Fixes repochecker errors E4005 and E4007 for hueemu (krobipd/ioBroker.hueemu#21).