### PR TITLE
Add ntfy-client to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1891,6 +1891,11 @@
     "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.nspanel-lovelace-ui/main/admin/nspanel-lovelace-ui.png",
     "type": "hardware"
   },
+  "ntfy-client": {
+    "meta": "https://raw.githubusercontent.com/lubepi/ioBroker.ntfy-client/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/lubepi/ioBroker.ntfy-client/main/admin/ntfy-client.png",
+    "type": "messaging"
+  },
   "nuki": {
     "meta": "https://raw.githubusercontent.com/smaragdschlange/ioBroker.nuki/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/smaragdschlange/ioBroker.nuki/master/admin/nuki-logo.png",


### PR DESCRIPTION
## Add new adapter: ntfy-client
**Type:** messaging
**Description:** Unofficial ntfy.sh client adapter for ioBroker. This adapter allows receiving and sending notifications via ntfy.sh (including self-hosted instances) with support for SSE, account statistics, and rich publishing options.
**Links:**
- Repository: https://github.com/lubepi/ioBroker.ntfy-client
- npm: https://www.npmjs.com/package/iobroker.ntfy-client
**Checklist:**
- [x] The adapter has a unique name
- [x] Published on npm (v0.1.2)
- [x] Uses @iobroker/adapter-core
- [x] Has io-package.json with all required fields (titleLang, desc, licenseInformation, tier: 3, connectionType: cloud, etc.)
- [x] Has README.md with link to manufacturer/service (ntfy.sh) and changelog
- [x] bluefox added as npm collaborator
- [x] Adapter checker passed (https://adapter-check.iobroker.in)