### PR TITLE
Update seplos-v3-sniffer to 1.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2539,7 +2539,7 @@
     "meta": "https://raw.githubusercontent.com/DpunktS/ioBroker.seplos-v3-sniffer/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/DpunktS/ioBroker.seplos-v3-sniffer/main/admin/seplos-v3-sniffer.jpg",
     "type": "iot-systems",
-    "version": "0.1.1"
+    "version": "1.0.0"
   },
   "seq": {
     "meta": "https://raw.githubusercontent.com/arteck/ioBroker.seq/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.seplos-v3-sniffer to version 1.0.0.

*This pull request was created by https://www.iobroker.dev 2902794.*