### PR TITLE
Update residents to 1.1.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2359,7 +2359,7 @@
     "meta": "https://raw.githubusercontent.com/jpawlowski/ioBroker.residents/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/jpawlowski/ioBroker.residents/main/admin/residents.svg",
     "type": "logic",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "resol": {
     "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.resol/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.residents to version 1.1.0.

*This pull request was created by https://www.iobroker.dev 8bcb699.*