### PR TITLE
Update mitsubishi-local-control to 1.0.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1777,7 +1777,7 @@
     "meta": "https://raw.githubusercontent.com/Black-Thunder/ioBroker.mitsubishi-local-control/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Black-Thunder/ioBroker.mitsubishi-local-control/main/admin/mitsubishi-local-control.png",
     "type": "climate-control",
-    "version": "1.0.5"
+    "version": "1.0.6"
   },
   "mobile": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.mobile/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.mitsubishi-local-control to version 1.0.6.

*This pull request was created by https://www.iobroker.dev 8bcb699.*