### PR TITLE
Update brunner-eas3 to 1.1.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -333,6 +333,12 @@
     "type": "iot-systems",
     "version": "2.3.0"
   },
+  "brunner-eas3": {
+    "meta": "https://raw.githubusercontent.com/JR-Home/ioBroker.brunner-eas3/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/JR-Home/ioBroker.brunner-eas3/main/admin/brunner-eas3.png",
+    "type": "iot-systems",
+    "version": "1.1.4"
+  },
   "bsblan": {
     "meta": "https://raw.githubusercontent.com/hacki11/ioBroker.bsblan/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/hacki11/ioBroker.bsblan/master/admin/bsblan.png",


### PR DESCRIPTION
Please update my adapter ioBroker.brunner-eas3 to version 1.1.4.

*This pull request was created by https://www.iobroker.dev 8bcb699.*