### PR TITLE
Add pwned-check to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2246,6 +2246,11 @@
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.pvoutputorg/master/admin/pvoutputorg.png",
     "type": "energy"
   },
+  "pwned-check": {
+    "meta": "https://raw.githubusercontent.com/ipod86/ioBroker.pwned-check/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/ipod86/ioBroker.pwned-check/main/admin/pwned-check.svg",
+    "type": "alarm"
+  },
   "pylontech": {
     "meta": "https://raw.githubusercontent.com/PLCHome/ioBroker.pylontech/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/PLCHome/ioBroker.pylontech/master/admin/pylontech.png",


### PR DESCRIPTION
## Add ioBroker.pwned-check to Latest Repository

Adds the \`pwned-check\` adapter to \`sources-dist.json\` (latest repository only).

- **Repository:** https://github.com/ipod86/ioBroker.pwned-check
- **Type:** alarm
- **npm:** https://www.npmjs.com/package/iobroker.pwned-check

The adapter checks whether email addresses or passwords have been compromised in known data breaches using the Have I Been Pwned (HIBP) API.