### PR TITLE
Update kecontact to 3.6.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1399,7 +1399,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.kecontact/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.kecontact/master/admin/kecontact.png",
     "type": "hardware",
-    "version": "3.5.0"
+    "version": "3.6.0"
   },
   "kisshome-defender": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.kisshome-defender/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.kecontact to version 3.6.0.

*This pull request was created by https://www.iobroker.dev 8bcb699.*