### PR TITLE
Update squeezeboxrpc to 1.6.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2797,7 +2797,7 @@
     "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.squeezeboxrpc/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.squeezeboxrpc/main/admin/squeezeboxrpc.png",
     "type": "multimedia",
-    "version": "1.6.2"
+    "version": "1.6.4"
   },
   "srm": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.srm/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.squeezeboxrpc to version 1.6.4.

*This pull request was created by https://www.iobroker.dev 8bcb699.*