### PR TITLE
Add siku to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2511,6 +2511,11 @@
     "icon": "https://raw.githubusercontent.com/disaster123/ioBroker.signifylights/main/admin/signifylights.png",
     "type": "lighting"
   },
+  "siku": {
+    "meta": "https://raw.githubusercontent.com/ChrMaass/ioBroker.siku/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/ChrMaass/ioBroker.siku/main/admin/siku.svg",
+    "type": "climate-control"
+  },
   "simple-api": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.simple-api/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.simple-api/master/admin/simple-api.png",


### PR DESCRIPTION
## Zusammenfassung

Ich möchte `siku` in das **latest**-Repository aufnehmen.

Der Adapter verwaltet SIKU-RV-V2- und Oxxify-smart-Lüftungsgeräte lokal per UDP, unterstützt mehrere Geräte pro Instanz sowie Broadcast-Erkennung und kommt ohne Cloud-Dienst aus.

## Nachweise / Voraussetzungen

- Repository: https://github.com/ChrMaass/ioBroker.siku
- npm-Paket: https://www.npmjs.com/package/iobroker.siku
- veröffentlichte Version: `0.2.2`
- GitHub-Release: https://github.com/ChrMaass/ioBroker.siku/releases/tag/v0.2.2
- AdapterRequests-Issue: https://github.com/ioBroker/AdapterRequests/issues/1021

## Erfüllte Punkte

- Repo-Name folgt `ioBroker.<adaptername>` und die Repository-Topics sind gesetzt
- englisches README mit Hersteller- und Gerätelinks vorhanden
- Admin-JSON-Config mit allen von ioBroker geforderten Übersetzungen vorhanden
- vollständige Test-and-Release-Matrix für Linux, macOS und Windows sowie Node.js 22 und 24
- automatische Releases über GitHub Actions und npm Trusted Publishing
- `type` und `connectionType` gesetzt; ausschließlich lokale LAN-Kommunikation
- Gerätepasswörter liegen getrennt in `native.devicePasswords` und werden über `encryptedNative`/`protectedNative` geschützt; Legacy-Konfigurationen werden automatisch migriert
- Paket ist auf npm veröffentlicht; `bluefox` ist als npm-Owner eingetragen
- aktuelle lokale Adapter- und Objektstrukturprüfungen sind sauber

## Änderung in diesem PR

- `sources-dist.json` um den Eintrag für `siku` ergänzt
