### PR TITLE
Add openmeteo-notify to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1991,6 +1991,11 @@
     "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.openmediavault/main/admin/openmediavault.png",
     "type": "infrastructure"
   },
+  "openmeteo-notify": {
+    "meta": "https://raw.githubusercontent.com/ipod86/ioBroker.openmeteo-notify/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/ipod86/ioBroker.openmeteo-notify/main/admin/openmeteo-notify.png",
+    "type": "weather"
+  },
   "opensmartcity": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.opensmartcity/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.opensmartcity/main/admin/opensmartcity.png",


### PR DESCRIPTION
## Add ioBroker.openmeteo-notify to Latest Repository

This PR adds the `openmeteo-notify` adapter to the Latest repository (`sources-dist.json`).

**Note:** There is already an existing adapter `open-meteo-weather` in the repository. The addition of this adapter was previously discussed with and approved by @Apollon77 (see closed PR #5776, adapter was renamed from `openmeteo` to `openmeteo-notify`).