### PR TITLE
Add liquid-check to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1436,6 +1436,11 @@
     "icon": "https://raw.githubusercontent.com/foxthefox/ioBroker.lifx/master/admin/lifx_logo.png",
     "type": "lighting"
   },
+  "liquid-check": {
+    "meta": "https://raw.githubusercontent.com/matz694/ioBroker.liquid-check/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/matz694/ioBroker.liquid-check/main/admin/liquid-check.png",
+    "type": "metering"
+  },
   "lightcontrol": {
     "meta": "https://raw.githubusercontent.com/Schmakus/ioBroker.lightcontrol/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Schmakus/ioBroker.lightcontrol/main/admin/lightcontrol.png",


### PR DESCRIPTION
## Adapter submission: liquid-check

- **GitHub:** https://github.com/matz694/ioBroker.liquid-check
- **npm:** https://www.npmjs.com/package/iobroker.liquid-check
- **Type:** metering
- **License:** MIT
- **Tier:** 3

This adapter reads data from a [Liquid-Check](https://www.si-elektronik.de/produkte/fuellstandsmessung/liquid-check/) sensor device (by SI Elektronik GmbH) and makes it available as states in ioBroker. The sensor measures liquid levels via a JSON HTTP API.

> **Note:** This is an independent private open-source project. It is not affiliated with or supported by SI Elektronik GmbH.

### Repochecker
Verified with `@iobroker/repochecker` — no errors.