### PR TITLE
Add cctvql adapter

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -356,8 +356,8 @@
     "type": "multimedia"
   },
   "cctvql": {
-    "meta": "https://raw.githubusercontent.com/arunrajiah/cctvql/main/integrations/ioBroker.cctvql/io-package.json",
-    "icon": "https://raw.githubusercontent.com/arunrajiah/cctvql/main/integrations/ioBroker.cctvql/admin/cctvql.png",
+    "meta": "https://raw.githubusercontent.com/arunrajiah/ioBroker.cctvql/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/arunrajiah/ioBroker.cctvql/main/admin/cctvql.png",
     "type": "multimedia"
   },
   "canbus": {

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -355,6 +355,11 @@
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.cameras/master/admin/cameras.png",
     "type": "multimedia"
   },
+  "cctvql": {
+    "meta": "https://raw.githubusercontent.com/arunrajiah/cctvql/main/integrations/ioBroker.cctvql/io-package.json",
+    "icon": "https://raw.githubusercontent.com/arunrajiah/cctvql/main/integrations/ioBroker.cctvql/admin/cctvql.png",
+    "type": "multimedia"
+  },
   "canbus": {
     "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.canbus/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.canbus/master/admin/canbus.png",


### PR DESCRIPTION
## Summary

- Adds `cctvql` to `sources-dist.json` under type `multimedia`
- Dedicated adapter repo: https://github.com/arunrajiah/ioBroker.cctvql
- Published to npm as `iobroker.cctvql`

## About the adapter

cctvQL is a natural-language query layer for CCTV systems — ask questions like *"Were there any people at the front door last night?"* directly from ioBroker scripts and Blockly. Supports Frigate, Hikvision, Synology Surveillance Station, Dahua, Milestone XProtect, ONVIF, and Scrypted.

Features:
- Natural-language queries via NLP intent classifier
- Live event polling with per-camera state objects
- PTZ control (pan/tilt/zoom/preset)
- JWT auth and per-user camera permissions on the server side

## Checklist

- [x] Dedicated repository (not a monorepo subdirectory)
- [x] `io-package.json` at repo root with `tier: 3`, `licenseInformation`, `encryptedNative`/`protectedNative` at root level
- [x] `@iobroker/adapter-core ^3.3.2`, `@iobroker/testing ^5.2.2`, `js-controller >=6.0.11`
- [x] `admin >=7.6.20` in `globalDependencies`
- [x] GitHub Actions with `check-and-lint` and `adapter-tests` jobs
- [x] Tag pattern `v[0-9]+.[0-9]+.[0-9]+`
- [x] `jsonConfig.json` with xs/sm/md/lg/xl responsive size attributes
- [x] `## Changelog` section in README
- [x] GitHub topics set: `iobroker`, `iobroker-adapter`, `cctv`, `camera`, `frigate`, `nlp`

(Supersedes #5880 which was closed after checker feedback)