### PR TITLE
Add parcelnet to latest repository

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -20,6 +20,11 @@
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.accuweather/master/admin/accuweather.png",
     "type": "weather"
   },
+  "parcelnet": {
+  "meta": "https://raw.githubusercontent.com/radebold/ioBroker.parcelnet/master/io-package.json",
+  "icon": "https://raw.githubusercontent.com/radebold/ioBroker.parcelnet/master/admin/parcelnet.png",
+  "type": "communication"
+},
   "acme": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.acme/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.acme/main/admin/acme.png",


### PR DESCRIPTION
Added new adapter parcelnet to latest repository.

GitHub: https://github.com/radebold/ioBroker.parcelnet
npm: iobroker.parcelnet
Type: communication