### PR TITLE
Add cctvql to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -355,6 +355,11 @@
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.cameras/master/admin/cameras.png",
     "type": "multimedia"
   },
+  "cctvql": {
+    "meta": "https://raw.githubusercontent.com/arunrajiah/ioBroker.cctvql/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/arunrajiah/ioBroker.cctvql/main/admin/cctvql.png",
+    "type": "multimedia"
+  },
   "canbus": {
     "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.canbus/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.canbus/master/admin/canbus.png",


### PR DESCRIPTION
## Summary

Adds `cctvql` to `sources-dist.json` under type `multimedia`.

Adapter repository: https://github.com/arunrajiah/ioBroker.cctvql  
npm package: https://www.npmjs.com/package/iobroker.cctvql

## Checklist

- [x] Standard `test-and-release.yml` workflow from ioBroker.example (uses `ioBroker/testing-action-check@v1`, `ioBroker/testing-action-adapter@v1`, `ioBroker/testing-action-deploy@v1`)
- [x] All 9 CI matrix jobs pass (node 20/22/24 × ubuntu/windows/macos)
- [x] `io-package.json` has all required fields: `titleLang` (11 languages), `desc` (11 languages), `news` (11 languages), `licenseInformation`, `tier: 3`, `extIcon`, `encryptedNative`
- [x] MIT license in README.md with copyright year
- [x] `.gitignore` includes `.commitinfo`
- [x] `dependabot.yml` present
- [x] `package-lock.json` committed
- [x] ESLint flat config (`eslint.config.mjs`) with `@iobroker/eslint-config`
- [x] `test:package` and `test:integration` scripts using `@iobroker/testing`

## About the adapter

cctvQL is a natural-language query layer for CCTV systems — ask questions like "Were there any people at the front door last night?" directly from ioBroker scripts and Blockly. Supports Frigate, Hikvision, Synology Surveillance Station, Dahua, Milestone XProtect, ONVIF, and Scrypted.