### PR TITLE
Update matrix-org to 1.2.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1603,7 +1603,7 @@
     "meta": "https://raw.githubusercontent.com/oelison/ioBroker.matrix-org/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/oelison/ioBroker.matrix-org/main/admin/matrix-logo.png",
     "type": "messaging",
-    "version": "1.2.1"
+    "version": "1.2.2"
   },
   "matter": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.matter/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.matrix-org to version 1.2.2.

*This pull request was created by https://www.iobroker.dev 8bcb699.*