### PR TITLE
Update operating-hours to 1.5.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2077,7 +2077,7 @@
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.operating-hours/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.operating-hours/main/admin/operating-hours.png",
     "type": "metering",
-    "version": "1.4.1"
+    "version": "1.5.1"
   },
   "opi": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.opi/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.operating-hours to version 1.5.1.

*This pull request was created by https://www.iobroker.dev a635d25.*