### PR TITLE
Update residents to 1.1.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2377,7 +2377,7 @@
     "meta": "https://raw.githubusercontent.com/jpawlowski/ioBroker.residents/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/jpawlowski/ioBroker.residents/main/admin/residents.svg",
     "type": "logic",
-    "version": "1.1.0"
+    "version": "1.1.1"
   },
   "resol": {
     "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.resol/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.residents to version 1.1.1.

NOTE: THIS IS AN EMERGENCY PATCH UPDATE! Admin GUI is not loading in `v1.1.0`and this is fixing it.

*This pull request was created by https://www.iobroker.dev a635d25.*