### PR TITLE
Update vis-jsontemplate to 4.4.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3247,7 +3247,7 @@
     "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-jsontemplate/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-jsontemplate/main/admin/vis-jsontemplate.png",
     "type": "visualization-widgets",
-    "version": "4.4.2"
+    "version": "4.4.3"
   },
   "vis-justgage": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-justgage/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-jsontemplate to version 4.4.3.

*This pull request was created by https://www.iobroker.dev a635d25.*