### PR TITLE
Add hueemu 1.2.8 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1185,6 +1185,12 @@
     "type": "lighting",
     "version": "3.16.2"
   },
+  "hueemu": {
+    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.hueemu/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.hueemu/main/admin/hue-emu-logo.png",
+    "type": "lighting",
+    "version": "1.2.8"
+  },
   "huum-sauna": {
     "meta": "https://raw.githubusercontent.com/Chris-656/ioBroker.huum-sauna/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Chris-656/ioBroker.huum-sauna/main/admin/huum-sauna.png",


### PR DESCRIPTION
Promotes ioBroker.hueemu from latest to stable.

## Status
- **Latest-Repo merged:** 2026-04-11 (PR #5634)
- **Current npm version:** 1.2.8 (released 2026-04-26)
- **Installations (iobroker.live):** ~23
- **Tests:** 283 (226 unit + 57 package + integration)
- **Repochecker auto-check on issue tracker:** clean
- **No known regressions in 1.2.8**

## Changes since latest-merge
- 1.2.5 → 1.2.6: API-Boundary hardening (type-guards, NaN/Infinity coercion for bri/hue/sat/ct/xy)
- 1.2.6 → 1.2.7: build-test separation, async-handler `.catch()` wrappers, instanceObjects for clients folder
- 1.2.7 → 1.2.8: process-level unhandled-rejection/uncaughtException handlers, js-controller minimum corrected to repochecker-recommended `>=6.0.11`, admin minimum on `>=7.6.20`, manual-review release-script plugin removed

The stack of patches has been live in latest for two weeks; the most recent (1.2.8) is the consistency wave applied across all 6 krobi adapters today and contains no hueemu-specific runtime changes.