### PR TITLE
Add life360ng 1.1.0 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1497,6 +1497,12 @@
     "type": "multimedia",
     "version": "1.0.5"
   },
+  "life360ng": {
+    "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.life360ng/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.life360ng/main/admin/Life360_s.svg",
+    "type": "geoposition",
+    "version": "1.1.0"
+  },
   "lifx": {
     "meta": "https://raw.githubusercontent.com/foxthefox/ioBroker.lifx/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/foxthefox/ioBroker.lifx/master/admin/lifx_logo.png",


### PR DESCRIPTION
Please update my adapter ioBroker.life360ng to version 1.1.0.

*This pull request was created by https://www.iobroker.dev a635d25.*