### PR TITLE
Update unifi-network to 1.4.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3043,7 +3043,7 @@
     "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.unifi-network/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.unifi-network/main/admin/unifi-network.png",
     "type": "network",
-    "version": "1.3.1"
+    "version": "1.4.0"
   },
   "unifi-protect": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.unifi-protect/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.unifi-network to version 1.4.0.

*This pull request was created by https://www.iobroker.dev a635d25.*