### PR TITLE
Add nextcloudtalk 1.0.3 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1917,6 +1917,12 @@
     "type": "network",
     "version": "2.0.6"
   },
+  "nextcloudtalk": {
+    "meta": "https://raw.githubusercontent.com/Rello/ioBroker.nextcloudtalk/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Rello/ioBroker.nextcloudtalk/main/admin/nextcloud.png",
+    "type": "messaging",
+    "version": "1.0.3"
+  },
   "nina": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.nina/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.nina/master/admin/nina.png",


### PR DESCRIPTION
Please update my adapter ioBroker.nextcloudtalk to version 1.0.3.

*This pull request was created by https://www.iobroker.dev a635d25.*