### PR TITLE
Update tesla-motors to 2.0.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2947,7 +2947,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tesla-motors/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tesla-motors/master/admin/tesla-motors.png",
     "type": "vehicle",
-    "version": "1.5.0"
+    "version": "2.0.2"
   },
   "teslafi": {
     "meta": "https://raw.githubusercontent.com/hombach/ioBroker.teslafi/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.tesla-motors to version 2.0.2.

*This pull request was created by https://www.iobroker.dev a635d25.*