### PR TITLE
Update pvforecast to 6.1.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2317,7 +2317,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pvforecast/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pvforecast/main/admin/pvforecast.png",
     "type": "energy",
-    "version": "5.1.0"
+    "version": "6.1.0"
   },
   "pvoutputorg": {
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.pvoutputorg/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.pvforecast to version 6.1.0.

*This pull request was created by https://www.iobroker.dev 14a3068.*