### PR TITLE
Add solectrus-influxdb 1.8.2 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2757,6 +2757,12 @@
     "type": "energy",
     "version": "0.9.22"
   },
+  "solectrus-influxdb": {
+    "meta": "https://raw.githubusercontent.com/patricknitsch/ioBroker.solectrus-influxdb/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/patricknitsch/ioBroker.solectrus-influxdb/main/admin/solectrus-influxdb.png",
+    "type": "communication",
+    "version": "1.8.2"
+  },
   "soliscloud": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.soliscloud/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.soliscloud/main/admin/solis.png",


### PR DESCRIPTION
Please update my adapter ioBroker.solectrus-influxdb to version 1.8.2.

*This pull request was created by https://www.iobroker.dev 14a3068.*