### PR TITLE
Update bshb to 0.6.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -349,7 +349,7 @@
     "meta": "https://raw.githubusercontent.com/holomekc/ioBroker.bshb/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/holomekc/ioBroker.bshb/master/admin/bshb-logo.jpg",
     "type": "iot-systems",
-    "version": "0.5.0"
+    "version": "0.6.3"
   },
   "bwt": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.bwt/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.bshb to version 0.6.3.

*This pull request was created by https://www.iobroker.dev 14a3068.*