### PR TITLE
Update open-meteo-weather to 3.1.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2059,7 +2059,7 @@
     "meta": "https://raw.githubusercontent.com/H5N1v2/ioBroker.open-meteo-weather/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/H5N1v2/ioBroker.open-meteo-weather/main/admin/open-meteo.png",
     "type": "weather",
-    "version": "2.6.4"
+    "version": "3.1.0"
   },
   "opendtu": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.opendtu/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.open-meteo-weather to version 3.1.0.

*This pull request was created by https://www.iobroker.dev 14a3068.*