### PR TITLE
Update mihome-cloud to 1.0.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1747,7 +1747,7 @@
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.mihome-cloud/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.mihome-cloud/main/admin/mihome-cloud.png",
     "type": "iot-systems",
-    "version": "1.0.4"
+    "version": "1.0.6"
   },
   "mihome-plug": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mihome-plug/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.mihome-cloud to version 1.0.6.

*This pull request was created by https://www.iobroker.dev 14a3068.*