### PR TITLE
Update trashschedule to 5.3.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3025,7 +3025,7 @@
     "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.trashschedule/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.trashschedule/master/admin/trashschedule.png",
     "type": "date-and-time",
-    "version": "3.3.0"
+    "version": "5.3.0"
   },
   "trivum": {
     "meta": "https://raw.githubusercontent.com/TheBam1990/ioBroker.trivum/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.trashschedule to version 5.3.0.

*This pull request was created by https://www.iobroker.dev 14a3068.*