### PR TITLE
Add blustream-mfp to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -275,6 +275,11 @@
     "icon": "https://raw.githubusercontent.com/Uwe1958/ioBroker.bluesound/main/admin/bluesound.png",
     "type": "multimedia"
   },
+  "blustream-mfp": {
+    "meta": "https://raw.githubusercontent.com/AlanSRU/ioBroker.blustream-mfp/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/AlanSRU/ioBroker.blustream-mfp/main/admin/blustream.png",
+    "type": "multimedia"
+  },
   "bmw": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.bmw/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.bmw/master/admin/bmw.png",


### PR DESCRIPTION
**Checklist**
- [x] The adapter is published to NPM (iobroker.blustream-mfp@0.3.3)
- [x] Developer Best practices are known and considered
- [x] All requirements to bring a new adapter into Latest repository are fulfilled
- [x] The adapter was checked by https://adapter-check.iobroker.in/ — clean
      (one known false-positive E0063 for chai/mocha, which are required because npm doesn't hoist @iobroker/testing's nested mocha into node_modules/.bin)
- [x] Forum testing thread: https://forum.iobroker.net/topic/84590/new-blustream-mfp-av-presentation-switcher-adapter

This PR adds the Blustream MFP adapter to the latest repository.

**About the adapter**
- Controls Blustream AMF/MFP/WMF series AV presentation switchers
- Supports IP/Telnet and RS232 serial connections (with optional RS232-to-IP converter for older models)
- Dynamic state tree based on the selected device model (AMF42AU, MFP62, MFP72, MFP112, WMF51, WMF72)
- Built on @iobroker/adapter-core 3.3.x, requires js-controller 6.0.11+, admin 7.6.20+
- Admin UI uses jsonConfig
- Published via npm trusted publishing (OIDC) from GitHub Actions

**Links**
- GitHub: https://github.com/AlanSRU/ioBroker.blustream-mfp
- npm: https://www.npmjs.com/package/iobroker.blustream-mfp
- Forum thread: https://forum.iobroker.net/topic/84590/new-blustream-mfp-av-presentation-switcher-adapter

The adapter has been running in production with 2 instances for several months and was verified again with the 0.3.3 release on js-controller 7.0.7.