### PR TITLE
Add blustream-acm to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -295,9 +295,9 @@
     "icon": "https://raw.githubusercontent.com/Uwe1958/ioBroker.bluesound/main/admin/bluesound.png",
     "type": "multimedia"
   },
-  "blustream-acm200": {
-    "meta": "https://raw.githubusercontent.com/AlanSRU/ioBroker.blustream-acm200/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/AlanSRU/ioBroker.blustream-acm200/main/admin/blustream-acm200.png",
+  "blustream-acm": {
+    "meta": "https://raw.githubusercontent.com/AlanSRU/ioBroker.blustream-acm/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/AlanSRU/ioBroker.blustream-acm/main/admin/blustream-acm.png",
     "type": "multimedia"
   },
   "blustream-mfp": {

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -298,6 +298,7 @@
   "blustream-acm200": {
     "meta": "https://raw.githubusercontent.com/AlanSRU/ioBroker.blustream-acm200/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlanSRU/ioBroker.blustream-acm200/main/admin/blustream-acm200.png",
+    "type": "multimedia"
   },
   "blustream-mfp": {
     "meta": "https://raw.githubusercontent.com/AlanSRU/ioBroker.blustream-mfp/main/io-package.json",

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -275,6 +275,11 @@
     "icon": "https://raw.githubusercontent.com/Uwe1958/ioBroker.bluesound/main/admin/bluesound.png",
     "type": "multimedia"
   },
+  "blustream-acm200": {
+    "meta": "https://raw.githubusercontent.com/AlanSRU/ioBroker.blustream-acm200/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/AlanSRU/ioBroker.blustream-acm200/main/admin/blustream-acm200.png",
+    "type": "multimedia"
+  },
   "bmw": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.bmw/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.bmw/master/admin/bmw.png",


### PR DESCRIPTION
**Checklist**
- [x] The adapter is published to NPM (iobroker.blustream-acm200@0.2.1)
- [x] Developer Best practices are known and considered
- [x] All requirements to bring a new adapter into Latest repository are fulfilled
- [x] The adapter was checked by https://adapter-check.iobroker.in/ — clean
      (one known false-positive E0063 for chai/mocha, which are required because npm doesn't hoist @iobroker/testing's nested mocha into node_modules/.bin)
- [x] Forum testing thread: https://forum.iobroker.net/topic/84592/new-blustream-acm200-hdmi-matrix-controller-adapter

This PR adds the Blustream ACM200 adapter to the latest repository.

**About the adapter**
- Controls the Blustream ACM200 HDMI matrix controller for AV-over-IP distribution
- Discovers connected transmitters and receivers via the ACM200's telnet interface
- Supports video/audio routing — combined and independent per stream — and route-to-all-displays bulk commands
- Transmitter audio source selection (AUTO/HDMI/ANA)
- Built on @iobroker/adapter-core 3.3.x, requires js-controller 6.0.11+, admin 7.6.20+
- Admin UI uses jsonConfig; password stored encrypted (protectedNative + encryptedNative)
- CI uses ioBroker/testing-action-* and **npm trusted publishing (OIDC)** — verified working on the 0.2.1 release

**Links**
- GitHub: https://github.com/AlanSRU/ioBroker.blustream-acm200
- npm: https://www.npmjs.com/package/iobroker.blustream-acm200
- Forum thread: https://forum.iobroker.net/topic/84592/new-blustream-acm200-hdmi-matrix-controller-adapter

The ACM200 is part of the Blustream AV control family; same author also maintains iobroker.blustream-mfp (PR #6001).