### PR TITLE
Update adguard to 1.2.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -37,7 +37,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.adguard/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.adguard/main/admin/adguard.png",
     "type": "network",
-    "version": "1.1.1"
+    "version": "1.2.0"
   },
   "admin": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.admin/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.adguard to version 1.2.0.

*This pull request was created by https://www.iobroker.dev 14a3068.*