### PR TITLE
Add blackmagic-atem to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -255,6 +255,11 @@
     "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.birthdays/master/admin/birthdays.png",
     "type": "date-and-time"
   },
+  "blackmagic-atem": {
+    "meta": "https://raw.githubusercontent.com/AlanSRU/ioBroker.blackmagic-atem/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/AlanSRU/ioBroker.blackmagic-atem/main/admin/blackmagic-atem.png",
+    "type": "multimedia"
+  },
   "ble": {
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.ble/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.ble/master/admin/ble.png",


### PR DESCRIPTION
## New adapter: iobroker.blackmagic-atem

Adapter for controlling Blackmagic ATEM video mixers over UDP.

- **Repo:** https://github.com/AlanSRU/ioBroker.blackmagic-atem
- **npm:** https://www.npmjs.com/package/iobroker.blackmagic-atem
- **Forum:** https://forum.iobroker.net/topic/84595/new-blackmagic-atem-video-mixers
- **Type:** multimedia
- **Connection:** local (UDP via `atem-connection` library)

### Coverage
Supports 21+ ATEM models from Mini to Constellation 4K+, with capability-based state creation — states only appear for features the connected device actually has.

### Features
- Program/Preview switching per ME block, transitions (mix, dip, wipe, DVE) with rates
- Upstream and downstream keyer control, fade-to-black
- Auxiliary output routing (up to 48 outputs)
- Audio mixer (Classic and Fairlight, unified interface)
- Streaming and recording control
- Media player and macro execution
- Tally, color generators

### Checks
- [x] Published to npm under MIT licence
- [x] `npm install iobroker.blackmagic-atem` works
- [x] CI matrix passing on Node 20/22/24 × Linux/Windows/macOS
- [x] Repochecker passes (errors resolved; remaining items are conventional warnings)
- [x] News entries and translations present in `io-package.json`
- [x] GitHub topics set