### PR TITLE
Add adapter anker-solix to latest repository

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -130,6 +130,11 @@
     "icon": "https://raw.githubusercontent.com/dan1-de/ioBroker.anelhut/main/admin/anelhut.png",
     "type": "iot-systems"
   },
+  "anker-solix": {
+    "meta": "https://raw.githubusercontent.com/MatthiasUlrich1/ioBroker.anker-solix/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/MatthiasUlrich1/ioBroker.anker-solix/main/admin/anker-solix.png",
+    "type": "energy"
+  },
   "ankersolix2": {
     "meta": "https://raw.githubusercontent.com/ronny130286/ioBroker.ankersolix2/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ronny130286/ioBroker.ankersolix2/main/admin/ankersolix2.png",


### PR DESCRIPTION
## Summary
- Add **anker-solix** (MatthiasUlrich1/ioBroker.anker-solix) to `sources-dist.json` (latest)
- Type: `energy`
- Based on ha-anker-solix / solixapi (Solarbank, Smart Meter, PPS, EV charger, …)

## Adapter
- GitHub: https://github.com/MatthiasUlrich1/ioBroker.anker-solix
- npm: `iobroker.anker-solix` (publish via tag v0.9.5 / trusted publishing)
- Adapter check: https://adaptercheck.iobroker.in/?url=https://github.com/MatthiasUlrich1/ioBroker.anker-solix
- CI: GitHub Actions (lint, build, package tests)

## Notes
- Unofficial Anker cloud API; user must accept terms in instance config
- Requires Python 3.12+ on ioBroker host
- npm package owner `iobroker` will be requested after first publish (per ioBroker wiki)

## Test plan
- [ ] PR merged after npm package is available
- [ ] `iobroker update available` lists anker-solix
- [ ] `iobroker install anker-solix` works