### PR TITLE
Add anker-solix to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -130,6 +130,11 @@
     "icon": "https://raw.githubusercontent.com/dan1-de/ioBroker.anelhut/main/admin/anelhut.png",
     "type": "iot-systems"
   },
+  "anker-solix": {
+    "meta": "https://raw.githubusercontent.com/MatthiasUlrich1/ioBroker.anker-solix/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/MatthiasUlrich1/ioBroker.anker-solix/main/admin/anker-solix.png",
+    "type": "energy"
+  },
   "ankersolix2": {
     "meta": "https://raw.githubusercontent.com/ronny130286/ioBroker.ankersolix2/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ronny130286/ioBroker.ankersolix2/main/admin/ankersolix2.png",


### PR DESCRIPTION
## Summary
- Add **anker-solix** (MatthiasUlrich1/ioBroker.anker-solix) to `sources-dist.json` (latest)
- Type: `energy`
- Based on ha-anker-solix / solixapi (Solarbank, Smart Meter, PPS, EV charger, …)

## Adapter
- GitHub: https://github.com/MatthiasUlrich1/ioBroker.anker-solix
- npm: https://www.npmjs.com/package/iobroker.anker-solix (currently **0.9.8**)
- Adapter check: https://adaptercheck.iobroker.in/?url=https://github.com/MatthiasUlrich1/ioBroker.anker-solix — **successful**
- CI: GitHub Actions deploy green (trusted publishing)

## Notes
- Unofficial Anker cloud API; user must accept terms in instance config
- Requires Python 3.12+ on ioBroker host
- Maintainer `iobroker` on npm can be added on request (per ioBroker wiki)

## Test plan
- [ ] `iobroker update available` lists anker-solix after merge
- [ ] `iobroker install anker-solix` works from npm

Reopens #6014 (branch refreshed on current master; npm publish + adapter-check now complete).