### PR TITLE
Update maxxi-charge to 1.4.48

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1651,7 +1651,7 @@
     "meta": "https://raw.githubusercontent.com/blabond/ioBroker.maxxi-charge/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/blabond/ioBroker.maxxi-charge/main/admin/maxxi-charge.png",
     "type": "energy",
-    "version": "1.4.40"
+    "version": "1.4.48"
   },
   "mbus": {
     "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.mbus/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.maxxi-charge to version 1.4.48.

*This pull request was created by https://www.iobroker.dev 14a3068.*