### PR TITLE
Update nextcloud-monitoring to 2.1.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1927,7 +1927,7 @@
     "meta": "https://raw.githubusercontent.com/H5N1v2/ioBroker.nextcloud-monitoring/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/H5N1v2/ioBroker.nextcloud-monitoring/main/admin/nextcloud_monitoring.png",
     "type": "network",
-    "version": "2.0.6"
+    "version": "2.1.0"
   },
   "nextcloudtalk": {
     "meta": "https://raw.githubusercontent.com/Rello/ioBroker.nextcloudtalk/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.nextcloud-monitoring to version 2.1.0.

*This pull request was created by https://www.iobroker.dev 14a3068.*