### PR TITLE
Add public-holidays to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2255,6 +2255,11 @@
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.proxy/master/admin/proxy.png",
     "type": "network"
   },
+  "public-holidays": {
+    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.public-holidays/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.public-holidays/main/admin/public-holidays.svg",
+    "type": "date-and-time"
+  },
   "public-transport": {
     "meta": "https://raw.githubusercontent.com/tt-tom17/ioBroker.public-transport/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/tt-tom17/ioBroker.public-transport/main/admin/public-transport.png",


### PR DESCRIPTION
## New adapter: ioBroker.public-holidays

Offline public holiday detection for 206 countries with bridge day support. Schedule mode — computes once at startup and daily at midnight, no memory usage between runs.

- **GitHub:** https://github.com/krobipd/ioBroker.public-holidays
- **npm:** [iobroker.public-holidays](https://www.npmjs.com/package/iobroker.public-holidays) (v0.5.1)
- **Type:** date-and-time
- **License:** MIT
- **Engine:** [date-holidays](https://github.com/commenthol/date-holidays) (ISC + CC-BY-SA-3.0, offline, no API calls)
- **193 tests** (136 vitest + 57 package)
- **Node.js:** >= 22
- **js-controller:** >= 7.0.7
- **Admin:** >= 7.8.23

### Features

- 206 countries with state/province/region support
- 5 holiday types (public, bank, school, optional, observance) — individually selectable
- Bridge day detection (Thu→Fri, Tue→Mon)
- Exclude individual holidays via dropdown
- Localized holiday names (system language, English fallback)
- Schedule mode with `allowInit: true`

Repochecker: no errors.