### PR TITLE
Update zwavews to 0.2.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3673,6 +3673,6 @@
     "meta": "https://raw.githubusercontent.com/arteck/ioBroker.zwavews/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/arteck/ioBroker.zwavews/main/admin/zwavews.png?sanitize=true",
     "type": "hardware",
-    "version": "0.1.3"
+    "version": "0.2.1"
   }
 }


### PR DESCRIPTION
Please update my adapter ioBroker.zwavews to version 0.2.1.

*This pull request was created by https://www.iobroker.dev 49ff8b5.*