### PR TITLE
Update plenticore-g3 to 1.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2263,7 +2263,7 @@
     "meta": "https://raw.githubusercontent.com/FernetMenta/ioBroker.plenticore-g3/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/FernetMenta/ioBroker.plenticore-g3/main/admin/plenticore-g3.png",
     "type": "energy",
-    "version": "0.5.3"
+    "version": "1.0.0"
   },
   "plex": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.plex/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.plenticore-g3 to version 1.0.0.

*This pull request was created by https://www.iobroker.dev 49ff8b5.*