### PR TITLE
Update vis-2-widgets-inventwo to 1.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3181,7 +3181,7 @@
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-inventwo/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-inventwo/main/admin/vis-2-widgets-inventwo.png",
     "type": "visualization-widgets",
-    "version": "0.7.2"
+    "version": "1.0.0"
   },
   "vis-2-widgets-jaeger-design": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-jaeger-design/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-2-widgets-inventwo to version 1.0.0.

*This pull request was created by https://www.iobroker.dev 49ff8b5.*