### PR TITLE
Add dreo to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -555,6 +555,11 @@
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.dreame/master/admin/dreame.png",
     "type": "household"
   },
+  "dreo": {
+    "meta": "https://raw.githubusercontent.com/alexandertartler-web/ioBroker.dreo/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/alexandertartler-web/ioBroker.dreo/main/admin/dreo.png",
+    "type": "climate-control"
+  },
   "drops-weather": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.drops-weather/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.drops-weather/main/admin/drops-weather.png",


### PR DESCRIPTION
Adds the Dreo adapter to the latest repository.\n\nAdapter repository: https://github.com/alexandertartler-web/ioBroker.dreo\nNPM package: https://www.npmjs.com/package/iobroker.dreo\nType: climate-control\n\nNotes:\n- npm package is published as iobroker.dreo@0.0.11\n- bluefox has been invited as npm package maintainer\n- local JSON validation and git diff checks passed