### PR TITLE
feat: add victron-gx adapter

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -3090,6 +3090,11 @@
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.victron-cerbo/main/admin/victron-cerbo.svg",
     "type": "energy"
   },
+  "victron-gx": {
+    "meta": "https://raw.githubusercontent.com/Sefina-DS/ioBroker.victron-gx/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Sefina-DS/ioBroker.victron-gx/main/admin/victron-gx.png",
+    "type": "energy"
+  },
   "viessmann": {
     "meta": "https://raw.githubusercontent.com/misanorot/ioBroker.viessmann/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/misanorot/ioBroker.viessmann/master/admin/viessmann.png",


### PR DESCRIPTION
## victron-gx adapter

Adds the ioBroker.victron-gx adapter to the repository.

- **npm**: https://www.npmjs.com/package/iobroker.victron-gx
- **GitHub**: https://github.com/Sefina-DS/ioBroker.victron-gx
- **Type**: energy
- **Connection**: local MQTT + Modbus TCP
- **Tier**: 3

### What it does
Connects ioBroker directly to Victron GX devices (Cerbo GX, Venus GX, Ekrano GX) via local MQTT and Modbus TCP – without VRM Cloud or Home Assistant.

Supports reading all device data (battery, inverter, grid, PV, loads) and full ESS control via Modbus TCP.

### Fixes applied since first PR (#6049)
- Node.js >= 22 in package.json and workflows
- Admin dependency >= 7.6.20
- English-only README
- jsonConfig removed from io-package.json common
- mqttPassword added to protectedNative and encryptedNative
- news entries with all languages
- dependabot config updated (cooldown, ignore, limits)
- auto-merge workflow migrated to iobroker-bot/action-automerge-dependabot@v1
- GitHub topics added
- bluefox invited as npm maintainer