### PR TITLE
Add hueemu 1.5.1 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1197,6 +1197,12 @@
     "type": "lighting",
     "version": "3.16.2"
   },
+  "hueemu": {
+    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.hueemu/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.hueemu/main/admin/hue-emu-logo.svg",
+    "type": "lighting",
+    "version": "1.5.1"
+  },
   "huum-sauna": {
     "meta": "https://raw.githubusercontent.com/Chris-656/ioBroker.huum-sauna/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Chris-656/ioBroker.huum-sauna/main/admin/huum-sauna.png",


### PR DESCRIPTION
**Checklist**
- [x] All requirements to bring a new adapter into Stable repository are fulfilled (see https://github.com/ioBroker/ioBroker.repositories#requirements-for-adapter-to-get-added-to-the-stable-repository)
- [x] Forum testing thread: https://forum.iobroker.net/topic/84300/test-adapter-hueemu

ioBroker.hueemu has been in the latest repository since 2026-04-11. repochecker (5.17.3) reports no errors. The forum tester thread is active.
