### PR TITLE
Add parcelapp 0.5.3 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2157,6 +2157,12 @@
     "type": "storage",
     "version": "1.0.0"
   },
+  "parcelapp": {
+    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.parcelapp/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.parcelapp/main/admin/parcelapp.svg",
+    "type": "infrastructure",
+    "version": "0.5.3"
+  },
   "parser": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.parser/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.parser/master/admin/parser.png",


### PR DESCRIPTION
**Checklist**
- [x] All requirements to bring a new adapter into Stable repository are fulfilled (see https://github.com/ioBroker/ioBroker.repositories#requirements-for-adapter-to-get-added-to-the-stable-repository)
- [x] Forum testing thread: https://forum.iobroker.net/topic/84304/test-adapter-parcelapp

ioBroker.parcelapp has been in the latest repository since 2026-05-10. repochecker (5.17.3) reports no errors and no warnings. The forum tester thread is active.
