### PR TITLE
Add fujitsu-airstage to LATEST

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -875,15 +875,15 @@
     "icon": "https://raw.githubusercontent.com/tim2zg/ioBroker.fronius-wattpilot/main/admin/fronius-wattpilot.png",
     "type": "vehicle"
   },
-  "fujitsu-airstage": {
-    "meta": "https://raw.githubusercontent.com/stefan5232/ioBroker.fujitsu-airstage/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/stefan5232/ioBroker.fujitsu-airstage/main/admin/fujitsu.png",
-    "type": "climate-control"
-  },
   "frontier_silicon": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.frontier_silicon/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.frontier_silicon/master/admin/radio.png",
     "type": "multimedia"
+  },
+  "fujitsu-airstage": {
+    "meta": "https://raw.githubusercontent.com/stefan5232/ioBroker.fujitsu-airstage/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/stefan5232/ioBroker.fujitsu-airstage/main/admin/fujitsu.png",
+    "type": "climate-control"
   },
   "fuelpricemonitor": {
     "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.fuelpricemonitor/main/io-package.json",

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -875,6 +875,11 @@
     "icon": "https://raw.githubusercontent.com/tim2zg/ioBroker.fronius-wattpilot/main/admin/fronius-wattpilot.png",
     "type": "vehicle"
   },
+  "fujitsu-airstage": {
+    "meta": "https://raw.githubusercontent.com/stefan5232/ioBroker.fujitsu-airstage/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/stefan5232/ioBroker.fujitsu-airstage/main/admin/fujitsu.png",
+    "type": "climate-control"
+  },
   "frontier_silicon": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.frontier_silicon/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.frontier_silicon/master/admin/radio.png",

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -880,15 +880,15 @@
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.frontier_silicon/master/admin/radio.png",
     "type": "multimedia"
   },
-  "fujitsu-airstage": {
-    "meta": "https://raw.githubusercontent.com/stefan5232/ioBroker.fujitsu-airstage/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/stefan5232/ioBroker.fujitsu-airstage/main/admin/fujitsu.png",
-    "type": "climate-control"
-  },
   "fuelpricemonitor": {
     "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.fuelpricemonitor/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/HGlab01/ioBroker.fuelpricemonitor/main/admin/fuelpricemonitor.png",
     "type": "vehicle"
+  },
+  "fujitsu-airstage": {
+    "meta": "https://raw.githubusercontent.com/stefan5232/ioBroker.fujitsu-airstage/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/stefan5232/ioBroker.fujitsu-airstage/main/admin/fujitsu.png",
+    "type": "climate-control"
   },
   "fullcalendar": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.fullcalendar/master/io-package.json",


### PR DESCRIPTION
## Add new adapter: fujitsu-airstage

### Adapter Information
- **Name**: Fujitsu Airstage Air Conditioner
- **Type**: climate-control
- **Description**: Controls Fujitsu Airstage air conditioners via local WiFi connection
- **Repository**: https://github.com/stefan5232/ioBroker.fujitsu-airstage
- **npm Package**: https://www.npmjs.com/package/iobroker.fujitsu-airstage (v0.1.3)
- **Forum Thread**: https://forum.iobroker.net/topic/83426/test-adapter-iobroker.fujitsu-airstage
- **License**: MIT

### Requirements Checklist
- [x] Adapter is published on npm
- [x] bluefox added as npm owner
- [x] GitHub Actions with tests (check-and-lint, adapter-tests on Ubuntu/Windows/macOS with Node 22.x & 24.x)
- [x] README with English description, details, and changelog
- [x] Valid license (MIT)
- [x] jsonConfig admin interface with i18n
- [x] All states have proper roles (no generic 'state' roles)
- [x] Type defined: climate-control
- [x] All repository checker errors, warnings, and suggestions resolved (Issue #84)
- [x] Node.js >= 22 requirement
- [x] Dependabot configured with 7-day cooldown

### Latest Version
- **Current Version**: 0.1.3
- **Release Date**: 2026-06-02

### Repository Checker Status
All errors, warnings and suggestions from the repository checker have been resolved:
- ✅ 23 Errors fixed
- ✅ 17 Warnings fixed  
- ✅ 4 Suggestions implemented

See: https://github.com/stefan5232/ioBroker.fujitsu-airstage/issues/84

### Additional Information
This adapter enables local control of Fujitsu Airstage air conditioners with WiFi modules. It supports:
- Full control (power, temperature, modes, fan speed)
- Monitoring (indoor/outdoor temperature, power consumption, status)
- Multiple devices
- Advanced features (powerful mode, economy mode, swing control, low-noise mode)

Relates to adapter request: https://github.com/ioBroker/AdapterRequests/issues/763