### PR TITLE
Update tesla-motors to 3.2.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2971,7 +2971,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tesla-motors/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tesla-motors/master/admin/tesla-motors.png",
     "type": "vehicle",
-    "version": "2.0.2"
+    "version": "3.2.0"
   },
   "teslafi": {
     "meta": "https://raw.githubusercontent.com/hombach/ioBroker.teslafi/master/io-package.json",

--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2971,7 +2971,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tesla-motors/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tesla-motors/master/admin/tesla-motors.png",
     "type": "vehicle",
-    "version": "3.2.0"
+    "version": "3.2.1"
   },
   "teslafi": {
     "meta": "https://raw.githubusercontent.com/hombach/ioBroker.teslafi/master/io-package.json",


### PR DESCRIPTION
## Zusammenfassung

Aktualisiert den Stable-Eintrag für `tesla-motors` von `2.0.2` auf `3.2.1`.

## Hintergrund

`3.2.1` ist ein Patch-Release nach `3.2.0`, das die Release-Tooling-Abhängigkeit auf die vom ioBroker Repository Checker geforderte Mindestversion hebt. Die eigentlichen Adapter-Änderungen für die Stable-Promotion stammen aus `3.2.0`.

## Prüfung

- `iobroker.tesla-motors@3.2.1` ist auf npm veröffentlicht.
- GitHub Actions für den Tag `v3.2.1` sind erfolgreich durchgelaufen.
- Der Adapter-Checker meldete für den vorherigen Stand bereits keine Fehler; dieser PR zielt nun auf die Checker-konforme Patch-Version.
