### PR TITLE
Update PR comment workflow to exclude github-actions

### DIFF
--- a/.github/workflows/newPrComment.yml
+++ b/.github/workflows/newPrComment.yml
@@ -9,7 +9,8 @@ jobs:
     if: |
       github.repository == 'ioBroker/ioBroker.repositories' &&
       github.event.issue.pull_request &&
-      github.event.comment.user.login != 'mcm1957'
+      github.event.comment.user.login != 'mcm1957' &&
+      github.event.comment.user.login != 'github-actions'
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Prevent PR comments from being processed if the user is 'github-actions'.