### PR TITLE
Update tesla-motors to 3.2.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2989,7 +2989,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tesla-motors/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tesla-motors/master/admin/tesla-motors.png",
     "type": "vehicle",
-    "version": "2.0.2"
+    "version": "3.2.1"
   },
   "teslafi": {
     "meta": "https://raw.githubusercontent.com/hombach/ioBroker.teslafi/master/io-package.json",


### PR DESCRIPTION
## Zusammenfassung

Aktualisiert den Stable-Eintrag für `tesla-motors` von `2.0.2` auf `3.2.1`.

## Hintergrund

Dies ist der erneute Versuch nach dem geschlossenen PR #6098. `3.2.1` ist gegenüber `3.2.0` nur ein technischer Patch für die vom ioBroker Repository Checker geforderte Release-Tooling-Abhängigkeit (`@alcalzone/release-script`). Die fachlich relevanten Adapter-Änderungen stammen aus `3.2.0` und laufen bereits stabil.

## Prüfung

- `iobroker.tesla-motors@3.2.1` ist auf npm veröffentlicht und als `latest` gesetzt.
- GitHub Release `v3.2.1` ist veröffentlicht und enthält Release Notes.
- GitHub Actions für `v3.2.1` waren erfolgreich, inklusive npm-Deploy.
- Der vorherige Checker-Lauf im PR #6098 meldete für den Adapter keine Fehler; der PR wurde nur wegen der 0-Day-/Latest-Wartezeit geschlossen.
