### PR TITLE
Add foxesscloud 0.6.3 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -843,6 +843,12 @@
     "type": "vehicle",
     "version": "1.0.4"
   },
+  "foxesscloud": {
+    "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.foxesscloud/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.foxesscloud/main/admin/foxesscloud.png",
+    "type": "energy",
+    "version": "0.6.3"
+  },
   "freeair": {
     "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.freeair/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.freeair/main/admin/freeair.png",


### PR DESCRIPTION
Please update my adapter ioBroker.foxesscloud to version 0.6.3.

*This pull request was created by https://www.iobroker.dev 49ff8b5.*