### PR TITLE
Add sigenergy 1.9.17 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2649,6 +2649,12 @@
     "type": "climate-control",
     "version": "1.2.1"
   },
+  "sigenergy": {
+    "meta": "https://raw.githubusercontent.com/ssbingo/ioBroker.sigenergy/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/ssbingo/ioBroker.sigenergy/main/admin/sigenergy.png",
+    "type": "energy",
+    "version": "1.9.17"
+  },
   "signal-cmb": {
     "meta": "https://raw.githubusercontent.com/derAlff/ioBroker.signal-cmb/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/derAlff/ioBroker.signal-cmb/master/admin/signal-cmb.png",


### PR DESCRIPTION
Please update my adapter ioBroker.sigenergy to version 1.9.17.

*This pull request was created by https://www.iobroker.dev 49ff8b5.*