### PR TITLE
Update vis-2-widgets-sigenergy to 1.8.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3231,6 +3231,12 @@
     "type": "visualization-widgets",
     "version": "1.2.2"
   },
+  "vis-2-widgets-sigenergy": {
+    "meta": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-sigenergy/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-sigenergy/main/admin/vis-2-widgets-sigenergy.png",
+    "type": "visualization-widgets",
+    "version": "1.8.1"
+  },
   "vis-2-widgets-weather-and-heating": {
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-2-widgets-weather-and-heating/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-2-widgets-weather-and-heating/master/admin/vis-2-widgets-weather-and-heating.png",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-2-widgets-sigenergy to version 1.8.1.

*This pull request was created by https://www.iobroker.dev 49ff8b5.*