### PR TITLE
Update gree-hvac to 3.0.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -973,7 +973,7 @@
     "meta": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/admin/air-conditioner.png",
     "type": "climate-control",
-    "version": "2.0.8"
+    "version": "3.0.3"
   },
   "grohe-smarthome": {
     "meta": "https://raw.githubusercontent.com/patricknitsch/ioBroker.grohe-smarthome/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.gree-hvac to version 3.0.3.

*This pull request was created by https://www.iobroker.dev 49ff8b5.*