### PR TITLE
Update bosesoundtouch to 0.12.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -307,7 +307,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.bosesoundtouch/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.bosesoundtouch/master/admin/bosesoundtouch.png",
     "type": "multimedia",
-    "version": "0.11.1"
+    "version": "0.12.0"
   },
   "botslab360": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.botslab360/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.bosesoundtouch to version 0.12.0.

*This pull request was created by https://www.iobroker.dev 49ff8b5.*