### PR TITLE
Update ical to 1.20.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1231,7 +1231,7 @@
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ical/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ical/master/admin/ical.png",
     "type": "date-and-time",
-    "version": "1.20.0"
+    "version": "1.20.1"
   },
   "iceroad": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.iceroad/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.ical to version 1.20.1.

*This pull request was created by https://www.iobroker.dev 49ff8b5.*