### PR TITLE
Update vis-inventwo to 4.1.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3301,7 +3301,7 @@
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-inventwo/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-inventwo/master/admin/inventwo.png",
     "type": "visualization-widgets",
-    "version": "4.1.0"
+    "version": "4.1.1"
   },
   "vis-jqui-mfd": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-jqui-mfd/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-inventwo to version 4.1.1.

*This pull request was created by https://www.iobroker.dev 49ff8b5.*