### PR TITLE
Add fairland adapter to latest

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -771,6 +771,12 @@
     "type": "date-and-time",
     "version": "1.4.1"
   },
+  "fairland": {
+    "meta": "https://raw.githubusercontent.com/dude2k/ioBroker.fairland/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/dude2k/ioBroker.fairland/main/admin/fairland.png",
+    "type": "iot-systems",
+    "version": "0.2.3"
+  },
   "fakeroku": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fakeroku/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fakeroku/master/admin/fakeroku.png",


### PR DESCRIPTION
Adds ioBroker.fairland to the latest repository.

npm: https://www.npmjs.com/package/iobroker.fairland
GitHub: https://github.com/dude2k/ioBroker.fairland