### PR TITLE
Add al-ko 0.3.11 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -75,6 +75,12 @@
     "type": "climate-control",
     "version": "2.0.3"
   },
+  "al-ko": {
+    "meta": "https://raw.githubusercontent.com/zechnerhubert/ioBroker.al-ko/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/zechnerhubert/ioBroker.al-ko/master/admin/al-ko-128.png",
+    "type": "garden",
+    "version": "0.3.11"
+  },
   "alarm": {
     "meta": "https://raw.githubusercontent.com/misanorot/ioBroker.alarm/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/misanorot/ioBroker.alarm/master/admin/alarm.png",


### PR DESCRIPTION
This PR adds the AL-KO adapter to the stable repository.

The adapter has been tested in the latest repository and is considered stable.
Several versions have been released and feedback has been collected.

Node.js >= 22.13.0 is required.

Forum thread for testing:
https://forum.iobroker.net/topic/84404/test-adapter-al-ko-0.3.5