### PR TITLE
dreame: master -> main LATEST

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -556,8 +556,8 @@
     "type": "misc-data"
   },
   "dreame": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.dreame/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.dreame/master/admin/dreame.png",
+    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.dreame/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.dreame/main/admin/dreame.png",
     "type": "household"
   },
   "drops-weather": {


### PR DESCRIPTION
The dreame adapter repository uses 'main' as default branch, not 'master'. This fixes E4005 and E4007 reported by the repochecker.