### PR TITLE
feat: add dreame adapter to stable repository

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -555,6 +555,12 @@
     "type": "misc-data",
     "version": "2.6.1"
   },
+  "dreame": {
+    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.dreame/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.dreame/main/admin/dreame.png",
+    "type": "household",
+    "version": "0.3.16"
+  },
   "drops-weather": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.drops-weather/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.drops-weather/main/admin/drops-weather.png",


### PR DESCRIPTION
Adds the ioBroker.dreame adapter to the stable repository.

- npm: https://www.npmjs.com/package/iobroker.dreame
- GitHub: https://github.com/TA2k/ioBroker.dreame
- Type: household
- Version: 0.3.16

### What it does
Connects ioBroker to Dreame and MOVA robotic devices (vacuum cleaners and mowers) via cloud API and MQTT.

### Repochecker status
FINAL status OK - all errors fixed.