### PR TITLE
Add beszel 0.7.2 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -255,6 +255,12 @@
     "type": "household",
     "version": "0.0.4"
   },
+  "beszel": {
+    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.beszel/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.beszel/main/admin/beszel.svg",
+    "type": "hardware",
+    "version": "0.7.2"
+  },
   "bidirectional-counter": {
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.bidirectional-counter/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.bidirectional-counter/main/admin/bidirectional-counter.png",


### PR DESCRIPTION
**Checklist**
- [x] All requirements to bring a new adapter into the stable repository are fulfilled (https://github.com/ioBroker/ioBroker.repositories#requirements-for-adapter-to-get-added-to-the-stable-repository) — in the latest repository since 2026-06-06, no blocking issues.
- [x] Forum testing thread: https://forum.iobroker.net/topic/84710/test-adapter-beszel-0.6

Adds ioBroker.beszel 0.7.2 (current latest) to the stable repository.