### PR TITLE
Add homewizard 0.12.2 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1179,6 +1179,12 @@
     "type": "iot-systems",
     "version": "1.3.0"
   },
+  "homewizard": {
+    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.homewizard/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.homewizard/main/admin/homewizard.svg",
+    "type": "energy",
+    "version": "0.12.2"
+  },
   "hoymiles-ms": {
     "meta": "https://raw.githubusercontent.com/mcm4iob/ioBroker.hoymiles-ms/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/mcm4iob/ioBroker.hoymiles-ms/main/admin/hoymiles-ms.png",


### PR DESCRIPTION
**Checklist**
- [x] All requirements to bring a new adapter into the stable repository are fulfilled (https://github.com/ioBroker/ioBroker.repositories#requirements-for-adapter-to-get-added-to-the-stable-repository) — in the latest repository since 2026-06-06, no blocking issues.
- [x] Forum testing thread: https://forum.iobroker.net/topic/84709/test-adapter-homewizard-0.11

Adds ioBroker.homewizard 0.12.2 (current latest) to the stable repository.