### PR TITLE
Update parcelapp to 0.7.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2179,7 +2179,7 @@
     "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.parcelapp/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.parcelapp/main/admin/parcelapp.svg",
     "type": "infrastructure",
-    "version": "0.5.3"
+    "version": "0.7.2"
   },
   "parser": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.parser/master/io-package.json",


### PR DESCRIPTION
**Checklist**
- [x] Adapter testing is still green for the current version — CI is green and it runs on the maintainer's own installation without regressions.
- [ ] User feedback: ioBroker.parcelapp 0.7.2 has been in the latest repository since 2026-06-12 with no problem reports on the testing thread (https://forum.iobroker.net/topic/84304/test-adapter-parcelapp) or the issue tracker. Niche adapter, so no explicit user confirmations were collected — but no negative reports either.

Updates the stable version of ioBroker.parcelapp from 0.5.3 to 0.7.2 (current latest).