### PR TITLE
Add heishamon to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1055,6 +1055,11 @@
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.heatingcontrol/master/admin/heatingcontrol.png",
     "type": "climate-control"
   },
+  "heishamon": {
+    "meta": "https://raw.githubusercontent.com/TobiasHanss/ioBroker.heishamon/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/TobiasHanss/ioBroker.heishamon/main/admin/heishamon.png",
+    "type": "climate-control"
+  },
   "heizoel": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.heizoel/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.heizoel/master/admin/heizoel.png",


### PR DESCRIPTION
### Add ioBroker.heishamon

A direct-serial adapter for **Panasonic Aquarea** air-to-water heat pumps
(H/J/K/L series). It speaks the CN-CNT protocol directly over a serial line —
no HeishaMon module or MQTT broker required.

Running stable on a **real heat pump for 4+ weeks**.
npm: https://www.npmjs.com/package/iobroker.heishamon · type: climate-control

Thanks for reviewing!