### PR TITLE
Update URLs for cisco-checkpresence adapter

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -386,8 +386,8 @@
     "type": "multimedia"
   },
   "cisco-checkpresence": {
-    "meta": "https://raw.githubusercontent.com/NurPech/ioBroker.cisco-checkpresence/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/NurPech/ioBroker.cisco-checkpresence/master/admin/cisco-checkpresence.png",
+    "meta": "https://raw.githubusercontent.com/NurPech/ioBroker.cisco-checkpresence/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/NurPech/ioBroker.cisco-checkpresence/main/admin/cisco-checkpresence.png",
     "type": "infrastructure"
   },
   "cloud": {


### PR DESCRIPTION
Please merge this correction. I missspelled the URLs.

fix:
❗ [E4005] Icon must be in the following path: https://raw.githubusercontent.com/NurPech/ioBroker.cisco-checkpresence/main/admin/; correct sources-dist.json
❗ [E4007] Meta URL must be equal to https://raw.githubusercontent.com/NurPech/ioBroker.cisco-checkpresence/main/io-package.json; correct sources-dist.json