### PR TITLE
Update grohe-smarthome to 0.6.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -997,7 +997,7 @@
     "meta": "https://raw.githubusercontent.com/patricknitsch/ioBroker.grohe-smarthome/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/patricknitsch/ioBroker.grohe-smarthome/main/admin/grohe-smarthome.png",
     "type": "metering",
-    "version": "0.3.3"
+    "version": "0.6.0"
   },
   "growatt": {
     "meta": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.grohe-smarthome to version 0.6.0.

*This pull request was created by https://www.iobroker.dev 4292488.*