### PR TITLE
Add govee-smart 2.16.2 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -987,6 +987,12 @@
     "type": "lighting",
     "version": "0.4.7"
   },
+  "govee-smart": {
+    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.govee-smart/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.govee-smart/main/admin/govee-smart.svg",
+    "type": "lighting",
+    "version": "2.16.2"
+  },
   "gree-hvac": {
     "meta": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/admin/air-conditioner.png",


### PR DESCRIPTION
**Checklist**
- [x] All requirements to bring a new adapter into the stable repository are fulfilled (https://github.com/ioBroker/ioBroker.repositories#requirements-for-adapter-to-get-added-to-the-stable-repository) — in the latest repository since 2026-06-06, no blocking issues.
- [x] Forum testing thread: https://forum.iobroker.net/topic/84712/test-adapter-govee-smart-2.14.1

Adds ioBroker.govee-smart 2.16.2 (current latest) to the stable repository.