### PR TITLE
Add google-sharedlocations2 0.3.6 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -963,6 +963,12 @@
     "type": "vehicle",
     "version": "1.0.41"
   },
+  "google-sharedlocations2": {
+    "meta": "https://raw.githubusercontent.com/Garfonso/ioBroker.google-sharedlocations2/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Garfonso/ioBroker.google-sharedlocations2/main/admin/google-sharedlocations2.png",
+    "type": "geoposition",
+    "version": "0.3.6"
+  },
   "google-spreadsheet": {
     "meta": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.google-spreadsheet/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.google-spreadsheet/main/admin/google-spreadsheet.png",


### PR DESCRIPTION
Please update my adapter ioBroker.google-sharedlocations2 to version 0.3.6.

*This pull request was created by https://www.iobroker.dev 4292488.*