### PR TITLE
Update alarm version to 4.0.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -85,7 +85,7 @@
     "meta": "https://raw.githubusercontent.com/misanorot/ioBroker.alarm/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/misanorot/ioBroker.alarm/master/admin/alarm.png",
     "type": "alarm",
-    "version": "3.7.6"
+    "version": "4.0.5"
   },
   "alexa-shoppinglist": {
     "meta": "https://raw.githubusercontent.com/MiRo1310/ioBroker.alexa-shoppinglist/main/io-package.json",


### PR DESCRIPTION
I've been trying to fix the issues flagged by the adapter checker for weeks now, but new ones keep popping up. I really want to get this into stable, but the adapter checker predicts several issues that prevent this—even though some of them don't even actually exist.

Furthermore, the adapter checker on GitHub flags different errors compared to when I run the check via the ioBroker Developer Portal. The checker there reports errors that are simply incorrect, which is why I can't submit it directly to stable from there either.