### PR TITLE
Update weathersense to 5.0.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3499,7 +3499,7 @@
     "meta": "https://raw.githubusercontent.com/ltspicer/ioBroker.weathersense/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ltspicer/ioBroker.weathersense/main/admin/weathersense.png",
     "type": "metering",
-    "version": "4.4.0"
+    "version": "5.0.2"
   },
   "weatherunderground": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.weatherunderground/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.weathersense to version 5.0.2.

*This pull request was created by https://www.iobroker.dev 4292488.*