### PR TITLE
Add agent-dvr to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1,3718 +1,3723 @@
 {
-  "_repoInfo": {
-    "stable": false,
-    "name": {
-      "en": "Latest (beta) repository",
-      "de": "Latest (Beta) Repository",
-      "ru": "Latest (бета) репозиторий",
-      "pt": "Latest repositório (beta)",
-      "nl": "Latest (bèta) repository",
-      "fr": "Latest dépôt (bêta)",
-      "it": "Latest repository (beta)",
-      "es": "Latest repositorio (beta)",
-      "pl": "Latest repozytorium (beta)",
-      "uk": "Latest (бета) репозиторій",
-      "zh-cn": "Latest（测试版）存储库"
+    "_repoInfo": {
+        "name": {
+            "de": "Latest (Beta) Repository",
+            "en": "Latest (beta) repository",
+            "es": "Latest repositorio (beta)",
+            "fr": "Latest dépôt (bêta)",
+            "it": "Latest repository (beta)",
+            "nl": "Latest (bèta) repository",
+            "pl": "Latest repozytorium (beta)",
+            "pt": "Latest repositório (beta)",
+            "ru": "Latest (бета) репозиторий",
+            "uk": "Latest (бета) репозиторій",
+            "zh-cn": "Latest（测试版）存储库"
+        },
+        "stable": false
+    },
+    "accuweather": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.accuweather/master/admin/accuweather.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.accuweather/master/io-package.json",
+        "type": "weather"
+    },
+    "acme": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.acme/main/admin/acme.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.acme/main/io-package.json",
+        "type": "general"
+    },
+    "adb": {
+        "icon": "https://raw.githubusercontent.com/om2804/ioBroker.adb/master/admin/adb.png",
+        "meta": "https://raw.githubusercontent.com/om2804/ioBroker.adb/master/io-package.json",
+        "type": "hardware"
+    },
+    "adguard": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.adguard/main/admin/adguard.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.adguard/main/io-package.json",
+        "type": "network"
+    },
+    "admin": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.admin/master/admin/admin.svg",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.admin/master/io-package.json",
+        "type": "general"
+    },
+    "agent-dvr": {
+        "icon": "https://raw.githubusercontent.com/ipod86/ioBroker.agent-dvr/main/admin/agent-dvr.png",
+        "meta": "https://raw.githubusercontent.com/ipod86/ioBroker.agent-dvr/main/io-package.json",
+        "type": "alarm"
+    },
+    "ai-assistant": {
+        "icon": "https://raw.githubusercontent.com/ToGe3688/ioBroker.ai-assistant/main/admin/ai-assistant.png",
+        "meta": "https://raw.githubusercontent.com/ToGe3688/ioBroker.ai-assistant/main/io-package.json",
+        "type": "messaging"
+    },
+    "ai-toolbox": {
+        "icon": "https://raw.githubusercontent.com/ToGe3688/ioBroker.ai-toolbox/main/admin/ai-toolbox.png",
+        "meta": "https://raw.githubusercontent.com/ToGe3688/ioBroker.ai-toolbox/main/io-package.json",
+        "type": "logic"
+    },
+    "aio": {
+        "icon": "https://raw.githubusercontent.com/Newan/ioBroker.aio/master/admin/aio.png",
+        "meta": "https://raw.githubusercontent.com/Newan/ioBroker.aio/master/io-package.json",
+        "type": "energy"
+    },
+    "air-q": {
+        "icon": "https://raw.githubusercontent.com/CorantGmbH/ioBroker.air-q/main/admin/air-q.png",
+        "meta": "https://raw.githubusercontent.com/CorantGmbH/ioBroker.air-q/main/io-package.json",
+        "type": "weather"
+    },
+    "airconwithme": {
+        "icon": "https://raw.githubusercontent.com/weggetor/ioBroker.airconwithme/main/admin/airconwithme.png",
+        "meta": "https://raw.githubusercontent.com/weggetor/ioBroker.airconwithme/main/io-package.json",
+        "type": "climate-control"
+    },
+    "airquality": {
+        "icon": "https://raw.githubusercontent.com/raschy/ioBroker.airquality/main/admin/airquality.png",
+        "meta": "https://raw.githubusercontent.com/raschy/ioBroker.airquality/main/io-package.json",
+        "type": "weather"
+    },
+    "airzone": {
+        "icon": "https://raw.githubusercontent.com/SilentPhoenix11/ioBroker.airzone/master/admin/Airzone.png",
+        "meta": "https://raw.githubusercontent.com/SilentPhoenix11/ioBroker.airzone/master/io-package.json",
+        "type": "climate-control"
+    },
+    "al-ko": {
+        "icon": "https://raw.githubusercontent.com/zechnerhubert/ioBroker.al-ko/master/admin/al-ko-128.png",
+        "meta": "https://raw.githubusercontent.com/zechnerhubert/ioBroker.al-ko/master/io-package.json",
+        "type": "garden"
+    },
+    "alarm": {
+        "icon": "https://raw.githubusercontent.com/misanorot/ioBroker.alarm/master/admin/alarm.png",
+        "meta": "https://raw.githubusercontent.com/misanorot/ioBroker.alarm/master/io-package.json",
+        "type": "alarm"
+    },
+    "alexa-shoppinglist": {
+        "icon": "https://raw.githubusercontent.com/MiRo1310/ioBroker.alexa-shoppinglist/main/admin/alexa-shoppinglist.png",
+        "meta": "https://raw.githubusercontent.com/MiRo1310/ioBroker.alexa-shoppinglist/main/io-package.json",
+        "type": "logic"
+    },
+    "alexa-timer-vis": {
+        "icon": "https://raw.githubusercontent.com/MiRo1310/ioBroker.alexa-timer-vis/main/admin/alexa-timer-vis.png",
+        "meta": "https://raw.githubusercontent.com/MiRo1310/ioBroker.alexa-timer-vis/main/io-package.json",
+        "type": "logic"
+    },
+    "alexa2": {
+        "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.alexa2/master/admin/alexa.png",
+        "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.alexa2/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "alias-manager": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.alias-manager/master/admin/alias-manager.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.alias-manager/master/io-package.json",
+        "type": "general"
+    },
+    "alpha-ess": {
+        "icon": "https://raw.githubusercontent.com/Gaspode69/ioBroker.alpha-ess/main/admin/alpha-ess.png",
+        "meta": "https://raw.githubusercontent.com/Gaspode69/ioBroker.alpha-ess/main/io-package.json",
+        "type": "energy"
+    },
+    "alpha2": {
+        "icon": "https://raw.githubusercontent.com/Eisbaeeer/ioBroker.alpha2/master/admin/mh-logo.png",
+        "meta": "https://raw.githubusercontent.com/Eisbaeeer/ioBroker.alpha2/master/io-package.json",
+        "type": "climate-control"
+    },
+    "amazon-dash": {
+        "icon": "https://raw.githubusercontent.com/PArns/ioBroker.amazon-dash/master/admin/amazon-dash.png",
+        "meta": "https://raw.githubusercontent.com/PArns/ioBroker.amazon-dash/master/io-package.json",
+        "type": "hardware"
+    },
+    "amtronwallbox": {
+        "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.amtronwallbox/master/admin/amtronwallbox.png",
+        "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.amtronwallbox/master/io-package.json",
+        "type": "energy"
+    },
+    "anelhut": {
+        "icon": "https://raw.githubusercontent.com/dan1-de/ioBroker.anelhut/main/admin/anelhut.png",
+        "meta": "https://raw.githubusercontent.com/dan1-de/ioBroker.anelhut/main/io-package.json",
+        "type": "iot-systems"
+    },
+    "ankersolix2": {
+        "icon": "https://raw.githubusercontent.com/ronny130286/ioBroker.ankersolix2/main/admin/ankersolix2.png",
+        "meta": "https://raw.githubusercontent.com/ronny130286/ioBroker.ankersolix2/main/io-package.json",
+        "type": "iot-systems"
+    },
+    "apcups": {
+        "icon": "https://raw.githubusercontent.com/XHunter74/ioBroker.apcups/master/admin/ups.png",
+        "meta": "https://raw.githubusercontent.com/XHunter74/ioBroker.apcups/master/io-package.json",
+        "type": "hardware"
+    },
+    "apg-info": {
+        "icon": "https://raw.githubusercontent.com/HGlab01/ioBroker.apg-info/main/admin/apg-info.png",
+        "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.apg-info/main/io-package.json",
+        "type": "general"
+    },
+    "apsystems-ez1": {
+        "icon": "https://raw.githubusercontent.com/zhihaining/ioBroker.apsystems-ez1/master/admin/apsystems-ez1.png",
+        "meta": "https://raw.githubusercontent.com/zhihaining/ioBroker.apsystems-ez1/master/io-package.json",
+        "type": "energy"
+    },
+    "artnet": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.artnet/master/admin/artnet.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.artnet/master/io-package.json",
+        "type": "lighting"
+    },
+    "artnet-recorder": {
+        "icon": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.artnet-recorder/master/admin/artnet-recorder.png",
+        "meta": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.artnet-recorder/master/io-package.json",
+        "type": "lighting"
+    },
+    "asterisk": {
+        "icon": "https://raw.githubusercontent.com/schmupu/ioBroker.asterisk/master/admin/asterisk.png",
+        "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.asterisk/master/io-package.json",
+        "type": "communication"
+    },
+    "asuswrt": {
+        "icon": "https://raw.githubusercontent.com/mcdhrts/ioBroker.asuswrt/master/admin/asuswrt.png",
+        "meta": "https://raw.githubusercontent.com/mcdhrts/ioBroker.asuswrt/master/io-package.json",
+        "type": "hardware"
+    },
+    "atlas-scientific-ezo-i2c": {
+        "icon": "https://raw.githubusercontent.com/Buzze11/ioBroker.atlas-scientific-ezo-i2c/master/admin/atlas-scientific-ezo-i2c.png",
+        "meta": "https://raw.githubusercontent.com/Buzze11/ioBroker.atlas-scientific-ezo-i2c/master/io-package.json",
+        "type": "hardware"
+    },
+    "aura": {
+        "icon": "https://raw.githubusercontent.com/hdering/ioBroker.aura/master/admin/aura.png",
+        "meta": "https://raw.githubusercontent.com/hdering/ioBroker.aura/main/io-package.json",
+        "type": "visualization"
+    },
+    "aurora-nowcast": {
+        "icon": "https://raw.githubusercontent.com/chrmenne/ioBroker.aurora-nowcast/main/admin/aurora-nowcast.png",
+        "meta": "https://raw.githubusercontent.com/chrmenne/ioBroker.aurora-nowcast/main/io-package.json",
+        "type": "weather"
+    },
+    "autodarts": {
+        "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.autodarts/main/admin/autodarts.svg",
+        "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.autodarts/main/io-package.json",
+        "type": "protocols"
+    },
+    "awattar": {
+        "icon": "https://raw.githubusercontent.com/sirjojo69/ioBroker.awattar/master/admin/awattar.png",
+        "meta": "https://raw.githubusercontent.com/sirjojo69/ioBroker.awattar/master/io-package.json",
+        "type": "utility"
+    },
+    "awtrix-light": {
+        "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.awtrix-light/master/admin/awtrix-light.png",
+        "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.awtrix-light/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "b-control-em": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.b-control-em/master/admin/bcontrol.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.b-control-em/master/io-package.json",
+        "type": "energy"
+    },
+    "backitup": {
+        "icon": "https://raw.githubusercontent.com/simatec/ioBroker.backitup/master/admin/backitup.png",
+        "meta": "https://raw.githubusercontent.com/simatec/ioBroker.backitup/master/io-package.json",
+        "type": "general"
+    },
+    "bambulab": {
+        "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.bambulab/main/admin/bambulab.png",
+        "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.bambulab/main/io-package.json",
+        "type": "hardware"
+    },
+    "bascloud": {
+        "icon": "https://raw.githubusercontent.com/bascloud/ioBroker.bascloud/main/admin/bascloud.png",
+        "meta": "https://raw.githubusercontent.com/bascloud/ioBroker.bascloud/main/io-package.json",
+        "type": "communication"
+    },
+    "batrium-bms": {
+        "icon": "https://raw.githubusercontent.com/bembelstemmer/ioBroker.batrium-bms/main/admin/batrium-bms.png",
+        "meta": "https://raw.githubusercontent.com/bembelstemmer/ioBroker.batrium-bms/main/io-package.json",
+        "type": "energy"
+    },
+    "bayernluft": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.bayernluft/main/admin/bayernluft.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.bayernluft/main/io-package.json",
+        "type": "climate-control"
+    },
+    "beckhoff": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.beckhoff/master/admin/beckhoff.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.beckhoff/master/io-package.json",
+        "type": "hardware"
+    },
+    "benchmark": {
+        "icon": "https://raw.githubusercontent.com/foxriver76/ioBroker.benchmark/main/admin/benchmark.png",
+        "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.benchmark/main/io-package.json",
+        "type": "utility"
+    },
+    "benq": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.benq/master/admin/benq.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.benq/master/io-package.json",
+        "type": "multimedia"
+    },
+    "bestway": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.bestway/master/admin/bestway.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.bestway/master/io-package.json",
+        "type": "household"
+    },
+    "beszel": {
+        "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.beszel/main/admin/beszel.svg",
+        "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.beszel/main/io-package.json",
+        "type": "hardware"
+    },
+    "bidirectional-counter": {
+        "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.bidirectional-counter/main/admin/bidirectional-counter.png",
+        "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.bidirectional-counter/main/io-package.json",
+        "type": "misc-data"
+    },
+    "birthdays": {
+        "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.birthdays/master/admin/birthdays.png",
+        "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.birthdays/master/io-package.json",
+        "type": "date-and-time"
+    },
+    "ble": {
+        "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.ble/master/admin/ble.png",
+        "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.ble/master/io-package.json",
+        "type": "hardware"
+    },
+    "blebox": {
+        "icon": "https://raw.githubusercontent.com/ka-vaNu/ioBroker.blebox/master/admin/blebox.png",
+        "meta": "https://raw.githubusercontent.com/ka-vaNu/ioBroker.blebox/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "bluelink": {
+        "icon": "https://raw.githubusercontent.com/Newan/ioBroker.bluelink/master/admin/bluelink.png",
+        "meta": "https://raw.githubusercontent.com/Newan/ioBroker.bluelink/master/io-package.json",
+        "type": "vehicle"
+    },
+    "bluesound": {
+        "icon": "https://raw.githubusercontent.com/Uwe1958/ioBroker.bluesound/main/admin/bluesound.png",
+        "meta": "https://raw.githubusercontent.com/Uwe1958/ioBroker.bluesound/main/io-package.json",
+        "type": "multimedia"
+    },
+    "bmw": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.bmw/master/admin/bmw.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.bmw/master/io-package.json",
+        "type": "vehicle"
+    },
+    "bosch-ebike": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.bosch-ebike/main/admin/bosch-ebike.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.bosch-ebike/main/io-package.json",
+        "type": "vehicle"
+    },
+    "boschindego": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.boschindego/main/admin/boschindego.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.boschindego/main/io-package.json",
+        "type": "garden"
+    },
+    "bosesoundtouch": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.bosesoundtouch/master/admin/bosesoundtouch.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.bosesoundtouch/master/io-package.json",
+        "type": "multimedia"
+    },
+    "botslab360": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.botslab360/main/admin/botslab360.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.botslab360/main/io-package.json",
+        "type": "household"
+    },
+    "botvac": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.botvac/master/admin/botvac.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.botvac/master/io-package.json",
+        "type": "household"
+    },
+    "brightsky": {
+        "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.brightsky/main/admin/brightsky.png",
+        "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.brightsky/main/io-package.json",
+        "type": "weather"
+    },
+    "bring": {
+        "icon": "https://raw.githubusercontent.com/foxriver76/ioBroker.bring/master/admin/bring.png",
+        "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.bring/master/io-package.json",
+        "type": "household"
+    },
+    "broadlink2": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.broadlink2/master/admin/broadlink.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.broadlink2/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "brunner-eas3": {
+        "icon": "https://raw.githubusercontent.com/JR-Home/ioBroker.brunner-eas3/main/admin/brunner-eas3.png",
+        "meta": "https://raw.githubusercontent.com/JR-Home/ioBroker.brunner-eas3/main/io-package.json",
+        "type": "iot-systems"
+    },
+    "bsblan": {
+        "icon": "https://raw.githubusercontent.com/hacki11/ioBroker.bsblan/master/admin/bsblan.png",
+        "meta": "https://raw.githubusercontent.com/hacki11/ioBroker.bsblan/master/io-package.json",
+        "type": "climate-control"
+    },
+    "bshb": {
+        "icon": "https://raw.githubusercontent.com/holomekc/ioBroker.bshb/master/admin/bshb-logo.jpg",
+        "meta": "https://raw.githubusercontent.com/holomekc/ioBroker.bshb/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "bwt": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.bwt/master/admin/bwt.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.bwt/master/io-package.json",
+        "type": "household"
+    },
+    "bydbatt": {
+        "icon": "https://raw.githubusercontent.com/arteck/ioBroker.bydbatt/master/admin/byd-batterybox.png",
+        "meta": "https://raw.githubusercontent.com/arteck/ioBroker.bydbatt/master/io-package.json",
+        "type": "household"
+    },
+    "bydhvs": {
+        "icon": "https://raw.githubusercontent.com/christianh17/ioBroker.bydhvs/master/admin/bydhvs.png",
+        "meta": "https://raw.githubusercontent.com/christianh17/ioBroker.bydhvs/master/io-package.json",
+        "type": "energy"
+    },
+    "calendar": {
+        "icon": "https://raw.githubusercontent.com/maxblome/ioBroker.calendar/master/admin/calendar.png",
+        "meta": "https://raw.githubusercontent.com/maxblome/ioBroker.calendar/master/io-package.json",
+        "type": "date-and-time"
+    },
+    "cameras": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.cameras/master/admin/cameras.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.cameras/master/io-package.json",
+        "type": "multimedia"
+    },
+    "canbus": {
+        "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.canbus/master/admin/canbus.png",
+        "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.canbus/master/io-package.json",
+        "type": "hardware"
+    },
+    "cec2": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.cec2/master/admin/cec2.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.cec2/master/io-package.json",
+        "type": "multimedia"
+    },
+    "chargemaster": {
+        "icon": "https://raw.githubusercontent.com/hombach/ioBroker.chargemaster/master/admin/chargemaster.png",
+        "meta": "https://raw.githubusercontent.com/hombach/ioBroker.chargemaster/master/io-package.json",
+        "type": "energy"
+    },
+    "chromecast": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.chromecast/master/admin/chromecast.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.chromecast/master/io-package.json",
+        "type": "multimedia"
+    },
+    "cisco-checkpresence": {
+        "icon": "https://raw.githubusercontent.com/NurPech/ioBroker.cisco-checkpresence/main/admin/cisco-checkpresence.png",
+        "meta": "https://raw.githubusercontent.com/NurPech/ioBroker.cisco-checkpresence/main/io-package.json",
+        "type": "infrastructure"
+    },
+    "cloud": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.cloud/master/admin/cloud.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.cloud/master/io-package.json",
+        "type": "communication"
+    },
+    "cloudflare": {
+        "icon": "https://raw.githubusercontent.com/Marco15453/ioBroker.cloudflare/main/admin/cloudflare.png",
+        "meta": "https://raw.githubusercontent.com/Marco15453/ioBroker.cloudflare/main/io-package.json",
+        "type": "infrastructure"
+    },
+    "cloudless-homeconnect": {
+        "icon": "https://raw.githubusercontent.com/eifel-tech/ioBroker.cloudless-homeconnect/master/admin/cloudless-homeconnect.png",
+        "meta": "https://raw.githubusercontent.com/eifel-tech/ioBroker.cloudless-homeconnect/master/io-package.json",
+        "type": "household"
+    },
+    "cmicoe": {
+        "icon": "https://raw.githubusercontent.com/FreDeko06/ioBroker.cmicoe/main/admin/cmicoe.png",
+        "meta": "https://raw.githubusercontent.com/FreDeko06/ioBroker.cmicoe/main/io-package.json",
+        "type": "iot-systems"
+    },
+    "comfoair": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.comfoair/master/admin/comfoair.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.comfoair/master/io-package.json",
+        "type": "climate-control"
+    },
+    "comfoairq": {
+        "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.comfoairq/master/admin/comfoairq.png",
+        "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.comfoairq/master/io-package.json",
+        "type": "climate-control"
+    },
+    "consumption": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.consumption/master/admin/consumption.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.consumption/master/io-package.json",
+        "type": "logic"
+    },
+    "contact": {
+        "icon": "https://raw.githubusercontent.com/maxblome/ioBroker.contact/master/admin/contact.png",
+        "meta": "https://raw.githubusercontent.com/maxblome/ioBroker.contact/master/io-package.json",
+        "type": "misc-data"
+    },
+    "contactid": {
+        "icon": "https://raw.githubusercontent.com/schmupu/ioBroker.contactid/master/admin/contactid.png",
+        "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.contactid/master/io-package.json",
+        "type": "network"
+    },
+    "controme": {
+        "icon": "https://raw.githubusercontent.com/MadErstam/ioBroker.controme/main/admin/controme.png",
+        "meta": "https://raw.githubusercontent.com/MadErstam/ioBroker.controme/main/io-package.json",
+        "type": "climate-control"
+    },
+    "coronavirus-statistics": {
+        "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.coronavirus-statistics/main/admin/coronavirus-statistics.png",
+        "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.coronavirus-statistics/main/io-package.json",
+        "type": "health"
+    },
+    "corrently": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.corrently/master/admin/corrently.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.corrently/master/io-package.json",
+        "type": "misc-data"
+    },
+    "countdown": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.countdown/master/admin/countdown.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.countdown/master/io-package.json",
+        "type": "misc-data"
+    },
+    "cul": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.cul/master/admin/busware.jpg",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.cul/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "daikin": {
+        "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.daikin/master/admin/daikin.jpg",
+        "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.daikin/master/io-package.json",
+        "type": "climate-control"
+    },
+    "daikin-cloud": {
+        "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.daikin-cloud/master/admin/daikin-cloud.jpg",
+        "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.daikin-cloud/master/io-package.json",
+        "type": "climate-control"
+    },
+    "danfoss-ally": {
+        "icon": "https://raw.githubusercontent.com/Stefan8485/ioBroker.danfoss-ally/main/admin/danfoss.png",
+        "meta": "https://raw.githubusercontent.com/Stefan8485/ioBroker.danfoss-ally/main/io-package.json",
+        "type": "climate-control"
+    },
+    "daswetter": {
+        "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.daswetter/master/admin/daswettercom.png",
+        "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.daswetter/master/io-package.json",
+        "type": "weather"
+    },
+    "deconz": {
+        "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.deconz/master/admin/deconz.png",
+        "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.deconz/master/io-package.json",
+        "type": "hardware"
+    },
+    "denon": {
+        "icon": "https://raw.githubusercontent.com/foxriver76/ioBroker.denon/master/admin/denon.png",
+        "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.denon/master/io-package.json",
+        "type": "multimedia"
+    },
+    "device-reminder": {
+        "icon": "https://raw.githubusercontent.com/Xenon-s/ioBroker.device-reminder/master/admin/device-reminder.png",
+        "meta": "https://raw.githubusercontent.com/Xenon-s/ioBroker.device-reminder/master/io-package.json",
+        "type": "logic"
+    },
+    "device-watcher": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.device-watcher/main/admin/device-watcher.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.device-watcher/main/io-package.json",
+        "type": "misc-data"
+    },
+    "devices": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.devices/master/admin/devices.svg",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.devices/master/io-package.json",
+        "type": "general"
+    },
+    "deyeidc": {
+        "icon": "https://raw.githubusercontent.com/raschy/ioBroker.deyeidc/main/admin/deyeidc.png",
+        "meta": "https://raw.githubusercontent.com/raschy/ioBroker.deyeidc/main/io-package.json",
+        "type": "energy"
+    },
+    "digitalstrom": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.digitalstrom/master/admin/digitalstrom.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.digitalstrom/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "discord": {
+        "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.discord/main/admin/discord.png",
+        "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.discord/main/io-package.json",
+        "type": "messaging"
+    },
+    "discovergy": {
+        "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.discovergy/main/admin/discovergy.png",
+        "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.discovergy/main/io-package.json",
+        "type": "energy"
+    },
+    "discovery": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.discovery/master/admin/discovery.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.discovery/master/io-package.json",
+        "type": "general"
+    },
+    "divera247": {
+        "icon": "https://raw.githubusercontent.com/TKnpl/ioBroker.divera247/main/admin/divera247.png",
+        "meta": "https://raw.githubusercontent.com/TKnpl/ioBroker.divera247/main/io-package.json",
+        "type": "alarm"
+    },
+    "dnscope": {
+        "icon": "https://raw.githubusercontent.com/simatec/ioBroker.dnscope/main/admin/dnscope.png",
+        "meta": "https://raw.githubusercontent.com/simatec/ioBroker.dnscope/main/io-package.json",
+        "type": "network"
+    },
+    "docker-manager": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.docker-manager/main/admin/docker-manager.svg",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.docker-manager/main/io-package.json",
+        "type": "iot-systems"
+    },
+    "doorbird": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.doorbird/master/admin/doorbird.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.doorbird/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "doorio": {
+        "icon": "https://raw.githubusercontent.com/Bettman66/ioBroker.doorio/master/admin/doorio.png",
+        "meta": "https://raw.githubusercontent.com/Bettman66/ioBroker.doorio/master/io-package.json",
+        "type": "communication"
+    },
+    "drag-indicator": {
+        "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.drag-indicator/main/admin/drag-indicator.png",
+        "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.drag-indicator/main/io-package.json",
+        "type": "misc-data"
+    },
+    "dreame": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.dreame/main/admin/dreame.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.dreame/main/io-package.json",
+        "type": "household"
+    },
+    "drops-weather": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.drops-weather/main/admin/drops-weather.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.drops-weather/main/io-package.json",
+        "type": "weather"
+    },
+    "ds18b20": {
+        "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.ds18b20/master/admin/ds18b20.png",
+        "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.ds18b20/master/io-package.json",
+        "type": "hardware"
+    },
+    "dune-hd-remote": {
+        "icon": "https://raw.githubusercontent.com/sadam6752-tech/ioBroker.dune-hd-remote/main/admin/dune-hd-remote.png",
+        "meta": "https://raw.githubusercontent.com/sadam6752-tech/ioBroker.dune-hd-remote/main/io-package.json",
+        "type": "multimedia"
+    },
+    "dwd": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.dwd/master/admin/dwd.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.dwd/master/io-package.json",
+        "type": "weather"
+    },
+    "dysonairpurifier": {
+        "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.dysonairpurifier/main/admin/dyson_logo.svg",
+        "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.dysonairpurifier/main/io-package.json",
+        "type": "climate-control"
+    },
+    "e3dc-rscp": {
+        "icon": "https://raw.githubusercontent.com/git-kick/ioBroker.e3dc-rscp/master/admin/e3dc-rscp.png",
+        "meta": "https://raw.githubusercontent.com/git-kick/ioBroker.e3dc-rscp/master/io-package.json",
+        "type": "energy"
+    },
+    "e3oncan": {
+        "icon": "https://raw.githubusercontent.com/MyHomeMyData/ioBroker.e3oncan/main/admin/e3oncan_small.png",
+        "meta": "https://raw.githubusercontent.com/MyHomeMyData/ioBroker.e3oncan/main/io-package.json",
+        "type": "iot-systems"
+    },
+    "easee": {
+        "icon": "https://raw.githubusercontent.com/Newan/ioBroker.easee/master/admin/easee.png",
+        "meta": "https://raw.githubusercontent.com/Newan/ioBroker.easee/master/io-package.json",
+        "type": "vehicle"
+    },
+    "ebus": {
+        "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.ebus/master/admin/ebus.png",
+        "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.ebus/master/io-package.json",
+        "type": "hardware"
+    },
+    "echarts": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.echarts/master/admin/echarts.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.echarts/master/io-package.json",
+        "type": "visualization"
+    },
+    "ecoflow": {
+        "icon": "https://raw.githubusercontent.com/Newan/ioBroker.ecoflow/main/admin/ecoflow.png",
+        "meta": "https://raw.githubusercontent.com/Newan/ioBroker.ecoflow/main/io-package.json",
+        "type": "energy"
+    },
+    "ecoflow-mqtt": {
+        "icon": "https://raw.githubusercontent.com/foxthefox/ioBroker.ecoflow-mqtt/main/admin/ecoflow-mqtt.png",
+        "meta": "https://raw.githubusercontent.com/foxthefox/ioBroker.ecoflow-mqtt/main/io-package.json",
+        "type": "iot-systems"
+    },
+    "ecovacs-deebot": {
+        "icon": "https://raw.githubusercontent.com/mrbungle64/ioBroker.ecovacs-deebot/master/admin/ecovacs-deebot.png",
+        "meta": "https://raw.githubusercontent.com/mrbungle64/ioBroker.ecovacs-deebot/master/io-package.json",
+        "type": "household"
+    },
+    "egigeozone2": {
+        "icon": "https://raw.githubusercontent.com/obakuhl/ioBroker.egigeozone2/master/admin/egigeozone.png",
+        "meta": "https://raw.githubusercontent.com/obakuhl/ioBroker.egigeozone2/master/io-package.json",
+        "type": "geoposition"
+    },
+    "ekey": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.ekey/master/admin/ekey.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.ekey/master/io-package.json",
+        "type": "hardware"
+    },
+    "elero-usb-transmitter": {
+        "icon": "https://raw.githubusercontent.com/marc2016/ioBroker.elero-usb-transmitter/master/admin/elero-usb-transmitter.png",
+        "meta": "https://raw.githubusercontent.com/marc2016/ioBroker.elero-usb-transmitter/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "elgato-key-light": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.elgato-key-light/main/admin/elgato-key-light.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.elgato-key-light/main/io-package.json",
+        "type": "lighting"
+    },
+    "elv-sup2": {
+        "icon": "https://raw.githubusercontent.com/pdbjjens/ioBroker.elv-sup2/master/admin/elv-sup2.png",
+        "meta": "https://raw.githubusercontent.com/pdbjjens/ioBroker.elv-sup2/master/io-package.json",
+        "type": "multimedia"
+    },
+    "email": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.email/master/admin/email.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.email/master/io-package.json",
+        "type": "messaging"
+    },
+    "emby": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.emby/master/admin/emby.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.emby/master/io-package.json",
+        "type": "multimedia"
+    },
+    "emporia": {
+        "icon": "https://raw.githubusercontent.com/Chris-656/ioBroker.emporia/main/admin/emporia.png",
+        "meta": "https://raw.githubusercontent.com/Chris-656/ioBroker.emporia/main/io-package.json",
+        "type": "energy"
+    },
+    "ems-esp": {
+        "icon": "https://raw.githubusercontent.com/tp1de/ioBroker.ems-esp/main/admin/ems-esp.png",
+        "meta": "https://raw.githubusercontent.com/tp1de/ioBroker.ems-esp/main/io-package.json",
+        "type": "climate-control"
+    },
+    "energiefluss": {
+        "icon": "https://raw.githubusercontent.com/SKB-CGN/ioBroker.energiefluss/main/admin/energiefluss.png",
+        "meta": "https://raw.githubusercontent.com/SKB-CGN/ioBroker.energiefluss/main/io-package.json",
+        "type": "visualization"
+    },
+    "energiefluss-erweitert": {
+        "icon": "https://raw.githubusercontent.com/SKB-CGN/ioBroker.energiefluss-erweitert/main/admin/energiefluss-erweitert.png",
+        "meta": "https://raw.githubusercontent.com/SKB-CGN/ioBroker.energiefluss-erweitert/main/io-package.json",
+        "type": "visualization"
+    },
+    "energy-tracker": {
+        "icon": "https://raw.githubusercontent.com/energy-tracker/ioBroker.energy-tracker/main/admin/energy-tracker.png",
+        "meta": "https://raw.githubusercontent.com/energy-tracker/ioBroker.energy-tracker/main/io-package.json",
+        "type": "iot-systems"
+    },
+    "energymanager": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.energymanager/master/admin/energymanager.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.energymanager/master/io-package.json",
+        "type": "energy"
+    },
+    "enet": {
+        "icon": "https://raw.githubusercontent.com/stoffel7/ioBroker.enet/master/admin/enet.png",
+        "meta": "https://raw.githubusercontent.com/stoffel7/ioBroker.enet/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "enigma2": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.enigma2/master/admin/enigma2.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.enigma2/master/io-package.json",
+        "type": "multimedia"
+    },
+    "enocean": {
+        "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.enocean/master/admin/enocean.png",
+        "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.enocean/master/io-package.json",
+        "type": "hardware"
+    },
+    "enpal": {
+        "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.enpal/main/admin/enpal.svg",
+        "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.enpal/main/io-package.json",
+        "type": "energy"
+    },
+    "envertech-pv": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.envertech-pv/master/admin/envertech-pv.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.envertech-pv/master/io-package.json",
+        "type": "energy"
+    },
+    "epson_ecotank_et_2750": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.epson_ecotank_et_2750/master/admin/epson_ecotank_et_2750.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.epson_ecotank_et_2750/master/io-package.json",
+        "type": "infrastructure"
+    },
+    "epson_stylus_px830": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.epson_stylus_px830/master/admin/epson_stylus_px830.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.epson_stylus_px830/master/io-package.json",
+        "type": "infrastructure"
+    },
+    "esphome": {
+        "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.esphome/main/admin/esphome.png",
+        "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.esphome/main/io-package.json",
+        "type": "hardware"
+    },
+    "espresense": {
+        "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.espresense/main/admin/espresense.png",
+        "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.espresense/main/io-package.json",
+        "type": "geoposition"
+    },
+    "eusec": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.eusec/master/admin/eusec.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.eusec/master/io-package.json",
+        "type": "alarm"
+    },
+    "evcc": {
+        "icon": "https://raw.githubusercontent.com/Newan/ioBroker.evcc/main/admin/evcc.png",
+        "meta": "https://raw.githubusercontent.com/Newan/ioBroker.evcc/main/io-package.json",
+        "type": "energy"
+    },
+    "eventlist": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.eventlist/master/admin/eventlist.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.eventlist/master/io-package.json",
+        "type": "visualization"
+    },
+    "exchangerates": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.exchangerates/master/admin/exchangerates.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.exchangerates/master/io-package.json",
+        "type": "misc-data"
+    },
+    "extron": {
+        "icon": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.extron/master/admin/extron.png",
+        "meta": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.extron/master/io-package.json",
+        "type": "hardware"
+    },
+    "f1": {
+        "icon": "https://raw.githubusercontent.com/bloop16/ioBroker.f1/main/admin/f1.png",
+        "meta": "https://raw.githubusercontent.com/bloop16/ioBroker.f1/main/io-package.json",
+        "type": "misc-data"
+    },
+    "fahrplan": {
+        "icon": "https://raw.githubusercontent.com/gaudes/ioBroker.fahrplan/master/admin/fahrplan.png",
+        "meta": "https://raw.githubusercontent.com/gaudes/ioBroker.fahrplan/master/io-package.json",
+        "type": "date-and-time"
+    },
+    "fakeroku": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fakeroku/master/admin/fakeroku.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fakeroku/master/io-package.json",
+        "type": "multimedia"
+    },
+    "fb-checkpresence": {
+        "icon": "https://raw.githubusercontent.com/afuerhoff/ioBroker.fb-checkpresence/master/admin/fb-checkpresence.png",
+        "meta": "https://raw.githubusercontent.com/afuerhoff/ioBroker.fb-checkpresence/master/io-package.json",
+        "type": "infrastructure"
+    },
+    "feiertage": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.feiertage/master/admin/feiertage.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.feiertage/master/io-package.json",
+        "type": "date-and-time"
+    },
+    "fenecon": {
+        "icon": "https://raw.githubusercontent.com/sg-app/ioBroker.fenecon/main/admin/fenecon.png",
+        "meta": "https://raw.githubusercontent.com/sg-app/ioBroker.fenecon/main/io-package.json",
+        "type": "energy"
+    },
+    "fhem": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fhem/master/admin/fhem.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fhem/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "fiat": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.fiat/master/admin/fiat.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.fiat/master/io-package.json",
+        "type": "vehicle"
+    },
+    "firetv": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.firetv/master/admin/firetv.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.firetv/master/io-package.json",
+        "type": "multimedia"
+    },
+    "fitbit-fitness": {
+        "icon": "https://raw.githubusercontent.com/Chris-656/ioBroker.fitbit-fitness/main/admin/fitbit-fitness.png",
+        "meta": "https://raw.githubusercontent.com/Chris-656/ioBroker.fitbit-fitness/main/io-package.json",
+        "type": "health"
+    },
+    "flexcharts": {
+        "icon": "https://raw.githubusercontent.com/MyHomeMyData/ioBroker.flexcharts/main/admin/flexcharts-icon.png",
+        "meta": "https://raw.githubusercontent.com/MyHomeMyData/ioBroker.flexcharts/main/io-package.json",
+        "type": "visualization"
+    },
+    "flot": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.flot/master/admin/flot.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.flot/master/io-package.json",
+        "type": "visualization"
+    },
+    "flowers": {
+        "icon": "https://raw.githubusercontent.com/sadam6752-tech/ioBroker.flowers/main/admin/flowers.png",
+        "meta": "https://raw.githubusercontent.com/sadam6752-tech/ioBroker.flowers/main/io-package.json",
+        "type": "climate-control"
+    },
+    "followthesun": {
+        "icon": "https://raw.githubusercontent.com/HGlab01/ioBroker.followthesun/main/admin/followthesun.png",
+        "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.followthesun/main/io-package.json",
+        "type": "geoposition"
+    },
+    "foobar2000": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.foobar2000/master/admin/foobar2000.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.foobar2000/master/io-package.json",
+        "type": "multimedia"
+    },
+    "ford": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.ford/master/admin/ford.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.ford/master/io-package.json",
+        "type": "vehicle"
+    },
+    "foxesscloud": {
+        "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.foxesscloud/main/admin/foxesscloud.png",
+        "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.foxesscloud/main/io-package.json",
+        "type": "energy"
+    },
+    "freeair": {
+        "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.freeair/main/admin/freeair.png",
+        "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.freeair/main/io-package.json",
+        "type": "hardware"
+    },
+    "frigate": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.frigate/main/admin/frigate.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.frigate/main/io-package.json",
+        "type": "alarm"
+    },
+    "fritzbox": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fritzbox/master/admin/fritzbox.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fritzbox/master/io-package.json",
+        "type": "infrastructure"
+    },
+    "fritzdect": {
+        "icon": "https://raw.githubusercontent.com/foxthefox/ioBroker.fritzdect/master/admin/fritzdect_logo.png",
+        "meta": "https://raw.githubusercontent.com/foxthefox/ioBroker.fritzdect/master/io-package.json",
+        "type": "hardware"
+    },
+    "froeling": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.froeling/master/admin/froeling.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.froeling/master/io-package.json",
+        "type": "climate-control"
+    },
+    "fronius": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fronius/master/admin/fronius.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fronius/master/io-package.json",
+        "type": "energy"
+    },
+    "fronius-solarweb": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.fronius-solarweb/master/admin/fronius-solarweb.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.fronius-solarweb/master/io-package.json",
+        "type": "energy"
+    },
+    "fronius-wattpilot": {
+        "icon": "https://raw.githubusercontent.com/tim2zg/ioBroker.fronius-wattpilot/main/admin/fronius-wattpilot.png",
+        "meta": "https://raw.githubusercontent.com/tim2zg/ioBroker.fronius-wattpilot/main/io-package.json",
+        "type": "vehicle"
+    },
+    "frontier_silicon": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.frontier_silicon/master/admin/radio.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.frontier_silicon/master/io-package.json",
+        "type": "multimedia"
+    },
+    "fuelpricemonitor": {
+        "icon": "https://raw.githubusercontent.com/HGlab01/ioBroker.fuelpricemonitor/main/admin/fuelpricemonitor.png",
+        "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.fuelpricemonitor/main/io-package.json",
+        "type": "vehicle"
+    },
+    "fullcalendar": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.fullcalendar/master/admin/fullcalendar.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.fullcalendar/master/io-package.json",
+        "type": "date-and-time"
+    },
+    "fullybrowser": {
+        "icon": "https://raw.githubusercontent.com/arteck/ioBroker.fullybrowser/master/admin/fully.png",
+        "meta": "https://raw.githubusercontent.com/arteck/ioBroker.fullybrowser/master/io-package.json",
+        "type": "utility"
+    },
+    "fyta": {
+        "icon": "https://raw.githubusercontent.com/muffin142/ioBroker.fyta/main/admin/fyta.png",
+        "meta": "https://raw.githubusercontent.com/muffin142/ioBroker.fyta/main/io-package.json",
+        "type": "garden"
+    },
+    "g-homa": {
+        "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.g-homa/master/admin/g-homa.png",
+        "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.g-homa/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "garmin": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.garmin/main/admin/garmin.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.garmin/main/io-package.json",
+        "type": "health"
+    },
+    "geofency": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.geofency/master/admin/geofency.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.geofency/master/io-package.json",
+        "type": "geoposition"
+    },
+    "gira-iot": {
+        "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.gira-iot/master/admin/gira-iot.png",
+        "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.gira-iot/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "go-e": {
+        "icon": "https://raw.githubusercontent.com/MK-2001/ioBroker.go-e/main/admin/go-echarger.png",
+        "meta": "https://raw.githubusercontent.com/MK-2001/ioBroker.go-e/main/io-package.json",
+        "type": "vehicle"
+    },
+    "google-sharedlocations2": {
+        "icon": "https://raw.githubusercontent.com/Garfonso/ioBroker.google-sharedlocations2/main/admin/google-sharedlocations2.png",
+        "meta": "https://raw.githubusercontent.com/Garfonso/ioBroker.google-sharedlocations2/main/io-package.json",
+        "type": "geoposition"
+    },
+    "google-spreadsheet": {
+        "icon": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.google-spreadsheet/main/admin/google-spreadsheet.png",
+        "meta": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.google-spreadsheet/main/io-package.json",
+        "type": "storage"
+    },
+    "googleauth": {
+        "icon": "https://raw.githubusercontent.com/Vertumnus/ioBroker.googleauth/master/admin/logo-google.svg",
+        "meta": "https://raw.githubusercontent.com/Vertumnus/ioBroker.googleauth/master/io-package.json",
+        "type": "utility"
+    },
+    "gotify": {
+        "icon": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.gotify/main/admin/gotify.png",
+        "meta": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.gotify/main/io-package.json",
+        "type": "messaging"
+    },
+    "gotify-ws": {
+        "icon": "https://raw.githubusercontent.com/simatec/ioBroker.gotify-ws/master/admin/gotify-ws.png",
+        "meta": "https://raw.githubusercontent.com/simatec/ioBroker.gotify-ws/master/io-package.json",
+        "type": "messaging"
+    },
+    "govee-local": {
+        "icon": "https://raw.githubusercontent.com/boergegrunicke/ioBroker.govee-local/main/admin/govee-local.png",
+        "meta": "https://raw.githubusercontent.com/boergegrunicke/ioBroker.govee-local/main/io-package.json",
+        "type": "lighting"
+    },
+    "govee-smart": {
+        "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.govee-smart/main/admin/govee-smart.svg",
+        "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.govee-smart/main/io-package.json",
+        "type": "lighting"
+    },
+    "gree-hvac": {
+        "icon": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/admin/air-conditioner.png",
+        "meta": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/io-package.json",
+        "type": "climate-control"
+    },
+    "grohe-smarthome": {
+        "icon": "https://raw.githubusercontent.com/patricknitsch/ioBroker.grohe-smarthome/main/admin/grohe-smarthome.png",
+        "meta": "https://raw.githubusercontent.com/patricknitsch/ioBroker.grohe-smarthome/main/io-package.json",
+        "type": "metering"
+    },
+    "growatt": {
+        "icon": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/admin/growatt.png",
+        "meta": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/io-package.json",
+        "type": "energy"
+    },
+    "gruenbeck": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.gruenbeck/master/admin/gruenbeck.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.gruenbeck/master/io-package.json",
+        "type": "household"
+    },
+    "gsmsms": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.gsmsms/main/admin/gsmsms.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.gsmsms/main/io-package.json",
+        "type": "messaging"
+    },
+    "haassohn": {
+        "icon": "https://raw.githubusercontent.com/marvingrieger/ioBroker.haassohn/master/admin/haassohn.png",
+        "meta": "https://raw.githubusercontent.com/marvingrieger/ioBroker.haassohn/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "habpanel": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.habpanel/master/admin/habpanel.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.habpanel/master/io-package.json",
+        "type": "visualization"
+    },
+    "hagelschutz-vkf": {
+        "icon": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.hagelschutz-vkf/main/admin/hagelschutz-vkf.jpg",
+        "meta": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.hagelschutz-vkf/main/io-package.json",
+        "type": "weather"
+    },
+    "haier": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.haier/master/admin/haier.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.haier/master/io-package.json",
+        "type": "climate-control"
+    },
+    "ham": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.ham/master/admin/ham.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.ham/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "ham-wemo": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.ham-wemo/master/admin/ham-wemo.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.ham-wemo/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "harmony": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.harmony/master/admin/harmony.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.harmony/master/io-package.json",
+        "type": "multimedia"
+    },
+    "hass": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.hass/master/admin/hass.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.hass/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "hass-mqtt": {
+        "icon": "https://raw.githubusercontent.com/smarthomefans/ioBroker.hass-mqtt/master/admin/hass-mqtt.png",
+        "meta": "https://raw.githubusercontent.com/smarthomefans/ioBroker.hass-mqtt/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "hassemu": {
+        "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.hassemu/main/admin/hassemu.svg",
+        "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.hassemu/main/io-package.json",
+        "type": "infrastructure"
+    },
+    "hausbus_de": {
+        "icon": "https://raw.githubusercontent.com/hausbus/ioBroker.hausbus_de/main/admin/hausbusde.png",
+        "meta": "https://raw.githubusercontent.com/hausbus/ioBroker.hausbus_de/main/io-package.json",
+        "type": "iot-systems"
+    },
+    "hdg-bavaria": {
+        "icon": "https://raw.githubusercontent.com/stemaker/ioBroker.hdg-bavaria/master/admin/hdg-bavaria.png",
+        "meta": "https://raw.githubusercontent.com/stemaker/ioBroker.hdg-bavaria/master/io-package.json",
+        "type": "climate-control"
+    },
+    "heatingcontrol": {
+        "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.heatingcontrol/master/admin/heatingcontrol.png",
+        "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.heatingcontrol/master/io-package.json",
+        "type": "climate-control"
+    },
+    "heizoel": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.heizoel/master/admin/heizoel.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.heizoel/master/io-package.json",
+        "type": "misc-data"
+    },
+    "heizoel24-mex": {
+        "icon": "https://raw.githubusercontent.com/ltspicer/ioBroker.heizoel24-mex/main/admin/heizoel24-mex.png",
+        "meta": "https://raw.githubusercontent.com/ltspicer/ioBroker.heizoel24-mex/main/io-package.json",
+        "type": "metering"
+    },
+    "heizungssteuerung": {
+        "icon": "https://raw.githubusercontent.com/jbeenenga/ioBroker.heizungssteuerung/main/admin/heizungssteuerung.png",
+        "meta": "https://raw.githubusercontent.com/jbeenenga/ioBroker.heizungssteuerung/main/io-package.json",
+        "type": "climate-control"
+    },
+    "hekr": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.hekr/master/admin/hekr.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.hekr/master/io-package.json",
+        "type": "household"
+    },
+    "helios": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.helios/master/admin/helios.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.helios/master/io-package.json",
+        "type": "climate-control"
+    },
+    "heos": {
+        "icon": "https://raw.githubusercontent.com/withstu/ioBroker.heos/main/admin/heos.png",
+        "meta": "https://raw.githubusercontent.com/withstu/ioBroker.heos/main/io-package.json",
+        "type": "multimedia"
+    },
+    "heytech": {
+        "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.heytech/master/admin/heytech.png",
+        "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.heytech/master/io-package.json",
+        "type": "hardware"
+    },
+    "hid-community": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.hid-community/master/admin/hid.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.hid-community/master/io-package.json",
+        "type": "utility"
+    },
+    "hikvision-alarmserver": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.hikvision-alarmserver/main/admin/hikvision-alarmserver.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.hikvision-alarmserver/main/io-package.json",
+        "type": "alarm"
+    },
+    "hiob": {
+        "icon": "https://raw.githubusercontent.com/moba15/ioBroker.hiob/main/admin/hiob.png",
+        "meta": "https://raw.githubusercontent.com/moba15/ioBroker.hiob/main/io-package.json",
+        "type": "visualization"
+    },
+    "history": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.history/master/admin/history.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.history/master/io-package.json",
+        "type": "storage"
+    },
+    "hm-rega": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.hm-rega/master/admin/homematic.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.hm-rega/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "hm-rpc": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.hm-rpc/master/admin/homematic.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.hm-rpc/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "hmip": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.hmip/master/admin/homematic.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.hmip/master/io-package.json",
+        "type": "hardware"
+    },
+    "homeconnect": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.homeconnect/master/admin/homeconnect.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.homeconnect/master/io-package.json",
+        "type": "household"
+    },
+    "homee": {
+        "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.homee/master/admin/homee.png",
+        "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.homee/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "homekit-controller": {
+        "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.homekit-controller/main/admin/homekit-controller.png",
+        "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.homekit-controller/main/io-package.json",
+        "type": "iot-systems"
+    },
+    "homenet": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.homenet/main/admin/homenet.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.homenet/main/io-package.json",
+        "type": "household"
+    },
+    "homepilot": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.homepilot/master/admin/homepilot.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.homepilot/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "homewizard": {
+        "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.homewizard/main/admin/homewizard.svg",
+        "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.homewizard/main/io-package.json",
+        "type": "energy"
+    },
+    "hoover": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.hoover/main/admin/hoover.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.hoover/main/io-package.json",
+        "type": "household"
+    },
+    "hoymiles": {
+        "icon": "https://raw.githubusercontent.com/Eistee82/ioBroker.hoymiles/main/admin/hoymiles.png",
+        "meta": "https://raw.githubusercontent.com/Eistee82/ioBroker.hoymiles/main/io-package.json",
+        "type": "energy"
+    },
+    "hoymiles-ms": {
+        "icon": "https://raw.githubusercontent.com/mcm4iob/ioBroker.hoymiles-ms/main/admin/hoymiles-ms.png",
+        "meta": "https://raw.githubusercontent.com/mcm4iob/ioBroker.hoymiles-ms/main/io-package.json",
+        "type": "hardware"
+    },
+    "hp-ilo": {
+        "icon": "https://raw.githubusercontent.com/SebastianSchultz/ioBroker.hp-ilo/master/admin/hp-ilo.png",
+        "meta": "https://raw.githubusercontent.com/SebastianSchultz/ioBroker.hp-ilo/master/io-package.json",
+        "type": "hardware"
+    },
+    "hs100": {
+        "icon": "https://raw.githubusercontent.com/arteck/ioBroker.hs100/master/admin/hs100.png",
+        "meta": "https://raw.githubusercontent.com/arteck/ioBroker.hs100/master/io-package.json",
+        "type": "hardware"
+    },
+    "hue": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.hue/master/admin/hue.jpeg",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.hue/master/io-package.json",
+        "type": "lighting"
+    },
+    "hue-sync-box": {
+        "icon": "https://raw.githubusercontent.com/xXBJXx/ioBroker.hue-sync-box/main/admin/hueSyncBox.png",
+        "meta": "https://raw.githubusercontent.com/xXBJXx/ioBroker.hue-sync-box/main/io-package.json",
+        "type": "lighting"
+    },
+    "hueemu": {
+        "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.hueemu/main/admin/hue-emu-logo.svg",
+        "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.hueemu/main/io-package.json",
+        "type": "lighting"
+    },
+    "huum-sauna": {
+        "icon": "https://raw.githubusercontent.com/Chris-656/ioBroker.huum-sauna/main/admin/huum-sauna.png",
+        "meta": "https://raw.githubusercontent.com/Chris-656/ioBroker.huum-sauna/main/io-package.json",
+        "type": "climate-control"
+    },
+    "hydrawise": {
+        "icon": "https://raw.githubusercontent.com/SentiQ/ioBroker.hydrawise/main/admin/hydrawise.jpg",
+        "meta": "https://raw.githubusercontent.com/SentiQ/ioBroker.hydrawise/main/io-package.json",
+        "type": "garden"
+    },
+    "hydrop": {
+        "icon": "https://raw.githubusercontent.com/simatec/ioBroker.hydrop/main/admin/hydrop.png",
+        "meta": "https://raw.githubusercontent.com/simatec/ioBroker.hydrop/main/io-package.json",
+        "type": "metering"
+    },
+    "hyperion-connector": {
+        "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.hyperion-connector/main/admin/hyperion-connector.png",
+        "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.hyperion-connector/main/io-package.json",
+        "type": "lighting"
+    },
+    "hyperion_ng": {
+        "icon": "https://raw.githubusercontent.com/felixganzer/ioBroker.hyperion_ng/master/admin/hyperion_ng.png",
+        "meta": "https://raw.githubusercontent.com/felixganzer/ioBroker.hyperion_ng/master/io-package.json",
+        "type": "lighting"
+    },
+    "i2c": {
+        "icon": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.i2c/master/admin/i2c.png",
+        "meta": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.i2c/master/io-package.json",
+        "type": "hardware"
+    },
+    "ical": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ical/master/admin/ical.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ical/master/io-package.json",
+        "type": "date-and-time"
+    },
+    "iceroad": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.iceroad/main/admin/iceroad.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.iceroad/main/io-package.json",
+        "type": "weather"
+    },
+    "icloud": {
+        "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.icloud/main/admin/icloud.png",
+        "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.icloud/main/io-package.json",
+        "type": "misc-data"
+    },
+    "ico-cloud": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ico-cloud/main/admin/ico-cloud.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ico-cloud/main/io-package.json",
+        "type": "metering"
+    },
+    "icons-addictive-flavour-png": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-addictive-flavour-png/master/admin/icons-addictive-flavour-png.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-addictive-flavour-png/master/io-package.json",
+        "type": "visualization-icons"
+    },
+    "icons-eclipse-smarthome-classic": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.icons-eclipse-smarthome-classic/main/admin/icons-eclipse-smarthome-classic.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.icons-eclipse-smarthome-classic/main/io-package.json",
+        "type": "visualization-icons"
+    },
+    "icons-fatcow-hosting": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-fatcow-hosting/master/admin/icons-fatcow-hosting.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-fatcow-hosting/master/io-package.json",
+        "type": "visualization-icons"
+    },
+    "icons-freepic": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.icons-freepic/main/admin/icons-freepic.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.icons-freepic/main/io-package.json",
+        "type": "visualization-icons"
+    },
+    "icons-icons8": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-icons8/master/admin/icons8.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-icons8/master/io-package.json",
+        "type": "visualization-icons"
+    },
+    "icons-material-png": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-material-png/master/admin/icons-material-png.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-material-png/master/io-package.json",
+        "type": "visualization-icons"
+    },
+    "icons-material-svg": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-material-svg/master/admin/icons-material-svg.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-material-svg/master/io-package.json",
+        "type": "visualization-icons"
+    },
+    "icons-mfd-png": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-mfd-png/master/admin/icons-mfd-png.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-mfd-png/master/io-package.json",
+        "type": "visualization-icons"
+    },
+    "icons-mfd-svg": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-mfd-svg/master/admin/icons-mfd-svg.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-mfd-svg/master/io-package.json",
+        "type": "visualization-icons"
+    },
+    "icons-open-icon-library-png": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-open-icon-library-png/master/admin/icons-open-icon-library-png.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-open-icon-library-png/master/io-package.json",
+        "type": "visualization-icons"
+    },
+    "icons-smarthome": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.icons-smarthome/main/admin/icons-smarthome.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.icons-smarthome/main/io-package.json",
+        "type": "visualization-icons"
+    },
+    "icons-ultimate-png": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-ultimate-png/master/admin/icons-ultimate-png.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-ultimate-png/master/io-package.json",
+        "type": "visualization-icons"
+    },
+    "ikettle2": {
+        "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.ikettle2/master/admin/ikettle2.png",
+        "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.ikettle2/master/io-package.json",
+        "type": "household"
+    },
+    "imap": {
+        "icon": "https://raw.githubusercontent.com/Lucky-ESA/ioBroker.imap/master/admin/imap.png",
+        "meta": "https://raw.githubusercontent.com/Lucky-ESA/ioBroker.imap/master/io-package.json",
+        "type": "messaging"
+    },
+    "imow": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.imow/main/admin/imow.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.imow/main/io-package.json",
+        "type": "garden"
+    },
+    "influxdb": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.influxdb/master/admin/influxdb.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.influxdb/master/io-package.json",
+        "type": "storage"
+    },
+    "influxdb-prologger": {
+        "icon": "https://raw.githubusercontent.com/simpros/ioBroker.influxdb-prologger/main/admin/influxdb-prologger.png",
+        "meta": "https://raw.githubusercontent.com/simpros/ioBroker.influxdb-prologger/main/io-package.json",
+        "type": "storage"
+    },
+    "innogy-smarthome": {
+        "icon": "https://raw.githubusercontent.com/PArns/ioBroker.innogy-smarthome/master/admin/innogy-smarthome.png",
+        "meta": "https://raw.githubusercontent.com/PArns/ioBroker.innogy-smarthome/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "innoxel": {
+        "icon": "https://raw.githubusercontent.com/matthsc/ioBroker.innoxel/main/admin/innoxel.png",
+        "meta": "https://raw.githubusercontent.com/matthsc/ioBroker.innoxel/main/io-package.json",
+        "type": "iot-systems"
+    },
+    "intesishome": {
+        "icon": "https://raw.githubusercontent.com/maxtox/ioBroker.intesishome/master/admin/intesishome.png",
+        "meta": "https://raw.githubusercontent.com/maxtox/ioBroker.intesishome/master/io-package.json",
+        "type": "climate-control"
+    },
+    "intex": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.intex/master/admin/intex.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.intex/master/io-package.json",
+        "type": "household"
+    },
+    "iopooleco": {
+        "icon": "https://raw.githubusercontent.com/mule1972/ioBroker.iopooleco/main/admin/iopooleco.png",
+        "meta": "https://raw.githubusercontent.com/mule1972/ioBroker.iopooleco/main/io-package.json",
+        "type": "metering"
+    },
+    "iot": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.iot/master/admin/iot.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.iot/master/io-package.json",
+        "type": "communication"
+    },
+    "iqontrol": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.iqontrol/master/admin/iqontrol.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.iqontrol/master/io-package.json",
+        "type": "visualization"
+    },
+    "jablotron": {
+        "icon": "https://raw.githubusercontent.com/DEV2DEV-DE/ioBroker.jablotron/main/admin/jablotron.png",
+        "meta": "https://raw.githubusercontent.com/DEV2DEV-DE/ioBroker.jablotron/main/io-package.json",
+        "type": "alarm"
+    },
+    "janitza-gridvis": {
+        "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.janitza-gridvis/main/admin/janitza-gridvis.png",
+        "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.janitza-gridvis/main/io-package.json",
+        "type": "energy"
+    },
+    "jarvis": {
+        "icon": "https://raw.githubusercontent.com/Zefau/ioBroker.jarvis/master/admin/jarvis.png",
+        "meta": "https://raw.githubusercontent.com/Zefau/ioBroker.jarvis/master/io-package.json",
+        "type": "visualization"
+    },
+    "javascript": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.javascript/master/admin/javascript.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.javascript/master/io-package.json",
+        "type": "logic"
+    },
+    "jeelink": {
+        "icon": "https://raw.githubusercontent.com/foxthefox/ioBroker.jeelink/master/admin/jeelab_logo.png",
+        "meta": "https://raw.githubusercontent.com/foxthefox/ioBroker.jeelink/master/io-package.json",
+        "type": "hardware"
+    },
+    "js-controller": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.js-controller/master/iobroker.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.js-controller/master/packages/controller/io-package.json",
+        "type": "general"
+    },
+    "judoisoft": {
+        "icon": "https://raw.githubusercontent.com/arteck/ioBroker.judoisoft/master/admin/judo.png",
+        "meta": "https://raw.githubusercontent.com/arteck/ioBroker.judoisoft/master/io-package.json",
+        "type": "household"
+    },
+    "kecontact": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.kecontact/master/admin/kecontact.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.kecontact/master/io-package.json",
+        "type": "hardware"
+    },
+    "kisshome-defender": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.kisshome-defender/main/admin/kisshome-defender.svg",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.kisshome-defender/main/io-package.json",
+        "type": "utility"
+    },
+    "klf200": {
+        "icon": "https://raw.githubusercontent.com/MiSchroe/ioBroker.klf200/master/admin/klf200.png",
+        "meta": "https://raw.githubusercontent.com/MiSchroe/ioBroker.klf200/master/io-package.json",
+        "type": "hardware"
+    },
+    "knmi-weather": {
+        "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.knmi-weather/main/admin/knmi-weather.png",
+        "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.knmi-weather/main/io-package.json",
+        "type": "weather"
+    },
+    "knx": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.knx/master/admin/knx.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.knx/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "kodi": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.kodi/master/admin/kodi.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.kodi/master/io-package.json",
+        "type": "multimedia"
+    },
+    "kostal-piko-ba": {
+        "icon": "https://raw.githubusercontent.com/hombach/ioBroker.kostal-piko-ba/master/admin/picoba.png",
+        "meta": "https://raw.githubusercontent.com/hombach/ioBroker.kostal-piko-ba/master/io-package.json",
+        "type": "energy"
+    },
+    "lametric": {
+        "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.lametric/master/admin/lametric.png",
+        "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.lametric/master/io-package.json",
+        "type": "hardware"
+    },
+    "lcn": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.lcn/master/admin/lcn.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.lcn/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "legrand-ecocompteur": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.legrand-ecocompteur/master/admin/legrand-ecocompteur.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.legrand-ecocompteur/master/io-package.json",
+        "type": "energy"
+    },
+    "letrika_comgw": {
+        "icon": "https://raw.githubusercontent.com/AWhiteKnight/ioBroker.letrika_comgw/master/admin/letrika_comgw.png",
+        "meta": "https://raw.githubusercontent.com/AWhiteKnight/ioBroker.letrika_comgw/master/io-package.json",
+        "type": "energy"
+    },
+    "lg-ess-home": {
+        "icon": "https://raw.githubusercontent.com/Morluktom/ioBroker.lg-ess-home/master/admin/lg-ess-home.png",
+        "meta": "https://raw.githubusercontent.com/Morluktom/ioBroker.lg-ess-home/master/io-package.json",
+        "type": "energy"
+    },
+    "lg-thinq": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.lg-thinq/master/admin/lg-thinq.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.lg-thinq/master/io-package.json",
+        "type": "household"
+    },
+    "lgtv": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.lgtv/master/admin/lgtv.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.lgtv/master/io-package.json",
+        "type": "multimedia"
+    },
+    "lgtv-rs": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.lgtv-rs/master/admin/lg.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.lgtv-rs/master/io-package.json",
+        "type": "multimedia"
+    },
+    "lgtv11": {
+        "icon": "https://raw.githubusercontent.com/SebastianSchultz/ioBroker.lgtv11/master/admin/lgtv2011.png",
+        "meta": "https://raw.githubusercontent.com/SebastianSchultz/ioBroker.lgtv11/master/io-package.json",
+        "type": "multimedia"
+    },
+    "libre": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.libre/main/admin/libre.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.libre/main/io-package.json",
+        "type": "health"
+    },
+    "life360ng": {
+        "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.life360ng/main/admin/Life360_s.svg",
+        "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.life360ng/main/io-package.json",
+        "type": "geoposition"
+    },
+    "lifx": {
+        "icon": "https://raw.githubusercontent.com/foxthefox/ioBroker.lifx/master/admin/lifx_logo.png",
+        "meta": "https://raw.githubusercontent.com/foxthefox/ioBroker.lifx/master/io-package.json",
+        "type": "lighting"
+    },
+    "lightcontrol": {
+        "icon": "https://raw.githubusercontent.com/Schmakus/ioBroker.lightcontrol/main/admin/lightcontrol.png",
+        "meta": "https://raw.githubusercontent.com/Schmakus/ioBroker.lightcontrol/main/io-package.json",
+        "type": "lighting"
+    },
+    "lightify": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.lightify/master/admin/lightify.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.lightify/master/io-package.json",
+        "type": "lighting"
+    },
+    "link": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.link/master/admin/link.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.link/master/io-package.json",
+        "type": "communication"
+    },
+    "link2home": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.link2home/main/admin/link2home.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.link2home/main/io-package.json",
+        "type": "iot-systems"
+    },
+    "linkeddevices": {
+        "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.linkeddevices/master/admin/linkeddevices.png",
+        "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.linkeddevices/master/io-package.json",
+        "type": "logic"
+    },
+    "linktap": {
+        "icon": "https://raw.githubusercontent.com/Smart-Gang/ioBroker.linktap/master/admin/LinkTap_Logo.png",
+        "meta": "https://raw.githubusercontent.com/Smart-Gang/ioBroker.linktap/master/io-package.json",
+        "type": "garden"
+    },
+    "linky": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.linky/main/admin/linky.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.linky/main/io-package.json",
+        "type": "energy"
+    },
+    "linux-control": {
+        "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.linux-control/master/admin/linux-control.png",
+        "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.linux-control/master/io-package.json",
+        "type": "hardware"
+    },
+    "logparser": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.logparser/master/admin/logparser.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.logparser/master/io-package.json",
+        "type": "logic"
+    },
+    "loqed": {
+        "icon": "https://raw.githubusercontent.com/foxriver76/ioBroker.loqed/main/admin/loqed.png",
+        "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.loqed/main/io-package.json",
+        "type": "hardware"
+    },
+    "lorawan": {
+        "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lorawan/main/admin/lorawan.png",
+        "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lorawan/main/io-package.json",
+        "type": "protocols"
+    },
+    "lovelace": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.lovelace/master/admin/lovelace.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.lovelace/master/io-package.json",
+        "type": "visualization"
+    },
+    "lowpass-filter": {
+        "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lowpass-filter/main/admin/lowpass-filter.png",
+        "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lowpass-filter/main/io-package.json",
+        "type": "misc-data"
+    },
+    "loxone": {
+        "icon": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.loxone/master/admin/loxone.png",
+        "meta": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.loxone/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "luftdaten": {
+        "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.luftdaten/master/admin/luftdaten.png",
+        "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.luftdaten/master/io-package.json",
+        "type": "weather"
+    },
+    "lupusec": {
+        "icon": "https://raw.githubusercontent.com/schmupu/ioBroker.lupusec/master/admin/lupusec.png",
+        "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.lupusec/master/io-package.json",
+        "type": "alarm"
+    },
+    "luxtronik1": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.luxtronik1/master/admin/luxtronik1.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.luxtronik1/master/io-package.json",
+        "type": "climate-control"
+    },
+    "luxtronik2": {
+        "icon": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.luxtronik2/master/admin/luxtronik2.png",
+        "meta": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.luxtronik2/master/io-package.json",
+        "type": "climate-control"
+    },
+    "material": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.material/master/admin/material.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.material/master/io-package.json",
+        "type": "visualization"
+    },
+    "matrix-org": {
+        "icon": "https://raw.githubusercontent.com/oelison/ioBroker.matrix-org/main/admin/matrix-logo.png",
+        "meta": "https://raw.githubusercontent.com/oelison/ioBroker.matrix-org/main/io-package.json",
+        "type": "messaging"
+    },
+    "matter": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.matter/main/admin/matter.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.matter/main/io-package.json",
+        "type": "iot-systems"
+    },
+    "maveo": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.maveo/master/admin/maveo.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.maveo/master/io-package.json",
+        "type": "household"
+    },
+    "maxcube": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.maxcube/master/admin/maxcube.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.maxcube/master/io-package.json",
+        "type": "climate-control"
+    },
+    "maxcul": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.maxcul/master/admin/maxcul.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.maxcul/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "maxxi-charge": {
+        "icon": "https://raw.githubusercontent.com/blabond/ioBroker.maxxi-charge/main/admin/maxxi-charge.png",
+        "meta": "https://raw.githubusercontent.com/blabond/ioBroker.maxxi-charge/main/io-package.json",
+        "type": "energy"
+    },
+    "mbus": {
+        "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.mbus/master/admin/mbus.png",
+        "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.mbus/master/io-package.json",
+        "type": "energy"
+    },
+    "mcdu": {
+        "icon": "https://raw.githubusercontent.com/Flixhummel/ioBroker.mcdu/main/admin/mcdu.png",
+        "meta": "https://raw.githubusercontent.com/Flixhummel/ioBroker.mcdu/main/io-package.json",
+        "type": "hardware"
+    },
+    "mclighting": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mclighting/master/admin/mclighting.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mclighting/master/io-package.json",
+        "type": "lighting"
+    },
+    "mcp": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.mcp/main/admin/mcp.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.mcp/main/io-package.json",
+        "type": "utility"
+    },
+    "meater": {
+        "icon": "https://raw.githubusercontent.com/Standarduser/ioBroker.meater/main/admin/meater.png",
+        "meta": "https://raw.githubusercontent.com/Standarduser/ioBroker.meater/main/io-package.json",
+        "type": "household"
+    },
+    "mediola-gateway": {
+        "icon": "https://raw.githubusercontent.com/oelison/ioBroker.mediola-gateway/main/admin/mediola-gateway.png",
+        "meta": "https://raw.githubusercontent.com/oelison/ioBroker.mediola-gateway/main/io-package.json",
+        "type": "multimedia"
+    },
+    "megad": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.megad/master/admin/megad.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.megad/master/io-package.json",
+        "type": "hardware"
+    },
+    "melcloud": {
+        "icon": "https://raw.githubusercontent.com/Black-Thunder/ioBroker.melcloud/master/admin/melcloud.png",
+        "meta": "https://raw.githubusercontent.com/Black-Thunder/ioBroker.melcloud/master/io-package.json",
+        "type": "climate-control"
+    },
+    "mempool-space": {
+        "icon": "https://raw.githubusercontent.com/Hans-Wurst-21/ioBroker.mempool-space/main/admin/mempool-space.png",
+        "meta": "https://raw.githubusercontent.com/Hans-Wurst-21/ioBroker.mempool-space/main/io-package.json",
+        "type": "infrastructure"
+    },
+    "mercedesme": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.mercedesme/master/admin/mercedesme.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.mercedesme/master/io-package.json",
+        "type": "vehicle"
+    },
+    "mercury": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mercury/master/admin/mercury.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mercury/master/io-package.json",
+        "type": "energy"
+    },
+    "meross": {
+        "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.meross/master/admin/meross.png",
+        "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.meross/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "message-queue": {
+        "icon": "https://raw.githubusercontent.com/MK-2001/ioBroker.message-queue/main/admin/message-queue.png",
+        "meta": "https://raw.githubusercontent.com/MK-2001/ioBroker.message-queue/main/io-package.json",
+        "type": "communication"
+    },
+    "meteoalarm": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.meteoalarm/master/admin/meteoalarm.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.meteoalarm/master/io-package.json",
+        "type": "weather"
+    },
+    "meteoswiss": {
+        "icon": "https://raw.githubusercontent.com/deMynchi/ioBroker.meteoswiss/master/admin/meteoswiss.png",
+        "meta": "https://raw.githubusercontent.com/deMynchi/ioBroker.meteoswiss/master/io-package.json",
+        "type": "weather"
+    },
+    "mhi-wfrac": {
+        "icon": "https://raw.githubusercontent.com/hacki11/ioBroker.mhi-wfrac/main/admin/mhi-wfrac.png",
+        "meta": "https://raw.githubusercontent.com/hacki11/ioBroker.mhi-wfrac/main/io-package.json",
+        "type": "climate-control"
+    },
+    "micronova": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.micronova/main/admin/micronova.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.micronova/main/io-package.json",
+        "type": "climate-control"
+    },
+    "midea": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.midea/master/admin/midea.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.midea/master/io-package.json",
+        "type": "climate-control"
+    },
+    "miele": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.miele/master/admin/xmiele.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.miele/master/io-package.json",
+        "type": "household"
+    },
+    "mielecloudservice": {
+        "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.mielecloudservice/master/admin/mielecloudservice.svg",
+        "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.mielecloudservice/master/io-package.json",
+        "type": "household"
+    },
+    "mihome": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.mihome/master/admin/mihome.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.mihome/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "mihome-airpurifier": {
+        "icon": "https://raw.githubusercontent.com/JoJ123/ioBroker.mihome-airpurifier/master/admin/mihome-airpurifier.png",
+        "meta": "https://raw.githubusercontent.com/JoJ123/ioBroker.mihome-airpurifier/master/io-package.json",
+        "type": "climate-control"
+    },
+    "mihome-cloud": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.mihome-cloud/main/admin/mihome-cloud.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.mihome-cloud/main/io-package.json",
+        "type": "iot-systems"
+    },
+    "mihome-plug": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mihome-plug/master/admin/mihome-plug.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mihome-plug/master/io-package.json",
+        "type": "hardware"
+    },
+    "mihome-vacuum": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mihome-vacuum/master/admin/mihome-vacuum.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mihome-vacuum/master/io-package.json",
+        "type": "household"
+    },
+    "miio": {
+        "icon": "https://raw.githubusercontent.com/smarthomefans/ioBroker.miio/master/admin/miio.png",
+        "meta": "https://raw.githubusercontent.com/smarthomefans/ioBroker.miio/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "mikrotik": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mikrotik/master/admin/mikrotik.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mikrotik/master/io-package.json",
+        "type": "hardware"
+    },
+    "milight": {
+        "icon": "https://raw.githubusercontent.com/foxthefox/ioBroker.milight/master/admin/easybulb_logo.png",
+        "meta": "https://raw.githubusercontent.com/foxthefox/ioBroker.milight/master/io-package.json",
+        "type": "lighting"
+    },
+    "milight-smart-light": {
+        "icon": "https://raw.githubusercontent.com/Steiger04/ioBroker.milight-smart-light/master/admin/milight-smart-light.png",
+        "meta": "https://raw.githubusercontent.com/Steiger04/ioBroker.milight-smart-light/master/io-package.json",
+        "type": "lighting"
+    },
+    "miner": {
+        "icon": "https://raw.githubusercontent.com/SimonFischer04/ioBroker.miner/main/admin/miner.png",
+        "meta": "https://raw.githubusercontent.com/SimonFischer04/ioBroker.miner/main/io-package.json",
+        "type": "hardware"
+    },
+    "minuaru": {
+        "icon": "https://raw.githubusercontent.com/minukodu/ioBroker.minuaru/main/admin/minuaru.png",
+        "meta": "https://raw.githubusercontent.com/minukodu/ioBroker.minuaru/main/io-package.json",
+        "type": "misc-data"
+    },
+    "minuvis": {
+        "icon": "https://raw.githubusercontent.com/minukodu/ioBroker.minuvis/master/admin/minuvis.png",
+        "meta": "https://raw.githubusercontent.com/minukodu/ioBroker.minuvis/master/io-package.json",
+        "type": "visualization"
+    },
+    "mitsubishi-local-control": {
+        "icon": "https://raw.githubusercontent.com/Black-Thunder/ioBroker.mitsubishi-local-control/main/admin/mitsubishi-local-control.png",
+        "meta": "https://raw.githubusercontent.com/Black-Thunder/ioBroker.mitsubishi-local-control/main/io-package.json",
+        "type": "climate-control"
+    },
+    "mobile": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.mobile/master/admin/mobile.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.mobile/master/io-package.json",
+        "type": "visualization"
+    },
+    "modbus": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.modbus/master/admin/modbus.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.modbus/master/io-package.json",
+        "type": "protocols"
+    },
+    "moma": {
+        "icon": "https://raw.githubusercontent.com/AWhiteKnight/ioBroker.moma/master/admin/moma.png",
+        "meta": "https://raw.githubusercontent.com/AWhiteKnight/ioBroker.moma/master/io-package.json",
+        "type": "general"
+    },
+    "mpd": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mpd/master/admin/mpd.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mpd/master/io-package.json",
+        "type": "multimedia"
+    },
+    "mqtt": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.mqtt/master/admin/mqtt.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.mqtt/master/io-package.json",
+        "type": "protocols"
+    },
+    "mqtt-client": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mqtt-client/master/admin/mqtt-client.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mqtt-client/master/io-package.json",
+        "type": "protocols"
+    },
+    "mspa": {
+        "icon": "https://raw.githubusercontent.com/arteck/ioBroker.mspa/main/admin/mspa.png",
+        "meta": "https://raw.githubusercontent.com/arteck/ioBroker.mspa/main/io-package.json",
+        "type": "climate-control"
+    },
+    "multicast": {
+        "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.multicast/main/admin/multicast.png",
+        "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.multicast/main/io-package.json",
+        "type": "network"
+    },
+    "musiccast": {
+        "icon": "https://raw.githubusercontent.com/foxthefox/ioBroker.musiccast/master/admin/musiccast.png",
+        "meta": "https://raw.githubusercontent.com/foxthefox/ioBroker.musiccast/master/io-package.json",
+        "type": "multimedia"
+    },
+    "mydlink": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mydlink/master/admin/mydlink.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mydlink/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "myenergi": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.myenergi/main/admin/myenergi.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.myenergi/main/io-package.json",
+        "type": "energy"
+    },
+    "myq": {
+        "icon": "https://raw.githubusercontent.com/pixcept/ioBroker.myq/master/admin/myq.png",
+        "meta": "https://raw.githubusercontent.com/pixcept/ioBroker.myq/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "mysensors": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.mysensors/master/admin/mysensors.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.mysensors/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "mystrom": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.mystrom/master/admin/mystrom.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.mystrom/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "mytime": {
+        "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.mytime/main/admin/mytime.png",
+        "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.mytime/main/io-package.json",
+        "type": "visualization"
+    },
+    "myuplink": {
+        "icon": "https://raw.githubusercontent.com/sebilm/ioBroker.myuplink/main/admin/myuplink.png",
+        "meta": "https://raw.githubusercontent.com/sebilm/ioBroker.myuplink/main/io-package.json",
+        "type": "climate-control"
+    },
+    "myvbus": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.myvbus/master/admin/myvbus.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.myvbus/master/io-package.json",
+        "type": "climate-control"
+    },
+    "mywallbox": {
+        "icon": "https://raw.githubusercontent.com/SKB-CGN/ioBroker.mywallbox/main/admin/wallbox.png",
+        "meta": "https://raw.githubusercontent.com/SKB-CGN/ioBroker.mywallbox/main/io-package.json",
+        "type": "hardware"
+    },
+    "n8n": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.n8n/main/admin/n8n.svg",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.n8n/main/io-package.json",
+        "type": "logic"
+    },
+    "nanoleaf-lightpanels": {
+        "icon": "https://raw.githubusercontent.com/daniel-2k/ioBroker.nanoleaf-lightpanels/master/admin/nanoleaf-lightpanels.png",
+        "meta": "https://raw.githubusercontent.com/daniel-2k/ioBroker.nanoleaf-lightpanels/master/io-package.json",
+        "type": "lighting"
+    },
+    "net-tools": {
+        "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.net-tools/master/admin/net-tools.png",
+        "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.net-tools/master/io-package.json",
+        "type": "network"
+    },
+    "netatmo": {
+        "icon": "https://raw.githubusercontent.com/PArns/ioBroker.netatmo/master/admin/netatmo.png",
+        "meta": "https://raw.githubusercontent.com/PArns/ioBroker.netatmo/master/io-package.json",
+        "type": "weather"
+    },
+    "netatmo-crawler": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.netatmo-crawler/master/admin/netatmo-crawler.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.netatmo-crawler/master/io-package.json",
+        "type": "weather"
+    },
+    "netatmo-energy": {
+        "icon": "https://raw.githubusercontent.com/Homemade-Disaster/ioBroker.netatmo-energy/master/admin/netatmo-energy.png",
+        "meta": "https://raw.githubusercontent.com/Homemade-Disaster/ioBroker.netatmo-energy/master/io-package.json",
+        "type": "climate-control"
+    },
+    "netro": {
+        "icon": "https://raw.githubusercontent.com/realhawker/ioBroker.netro/master/admin/netro.png",
+        "meta": "https://raw.githubusercontent.com/realhawker/ioBroker.netro/master/io-package.json",
+        "type": "garden"
+    },
+    "nextcloud-monitoring": {
+        "icon": "https://raw.githubusercontent.com/H5N1v2/ioBroker.nextcloud-monitoring/main/admin/nextcloud_monitoring.png",
+        "meta": "https://raw.githubusercontent.com/H5N1v2/ioBroker.nextcloud-monitoring/main/io-package.json",
+        "type": "network"
+    },
+    "nextcloudtalk": {
+        "icon": "https://raw.githubusercontent.com/Rello/ioBroker.nextcloudtalk/main/admin/nextcloud.png",
+        "meta": "https://raw.githubusercontent.com/Rello/ioBroker.nextcloudtalk/main/io-package.json",
+        "type": "messaging"
+    },
+    "nina": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.nina/master/admin/nina.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.nina/master/io-package.json",
+        "type": "misc-data"
+    },
+    "nissan": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.nissan/master/admin/nissan.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.nissan/master/io-package.json",
+        "type": "vehicle"
+    },
+    "niu": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.niu/main/admin/niu.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.niu/main/io-package.json",
+        "type": "vehicle"
+    },
+    "nmea": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.nmea/main/admin/nmea.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.nmea/main/io-package.json",
+        "type": "protocols"
+    },
+    "node-red": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.node-red/master/admin/node-red.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.node-red/master/io-package.json",
+        "type": "logic"
+    },
+    "noolitef": {
+        "icon": "https://raw.githubusercontent.com/paveltsytovich/ioBroker.noolitef/master/admin/noolitef.png",
+        "meta": "https://raw.githubusercontent.com/paveltsytovich/ioBroker.noolitef/master/io-package.json",
+        "type": "hardware"
+    },
+    "notification-manager": {
+        "icon": "https://raw.githubusercontent.com/foxriver76/ioBroker.notification-manager/main/admin/notification-manager.png",
+        "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.notification-manager/main/io-package.json",
+        "type": "utility"
+    },
+    "notificationforandroidtv": {
+        "icon": "https://raw.githubusercontent.com/DNAngelX/ioBroker.notificationforandroidtv/main/admin/notificationforandroidtv.png",
+        "meta": "https://raw.githubusercontent.com/DNAngelX/ioBroker.notificationforandroidtv/main/io-package.json",
+        "type": "messaging"
+    },
+    "nsclient": {
+        "icon": "https://raw.githubusercontent.com/mcm4iob/ioBroker.nsclient/master/admin/nsclient.png",
+        "meta": "https://raw.githubusercontent.com/mcm4iob/ioBroker.nsclient/master/io-package.json",
+        "type": "infrastructure"
+    },
+    "nspanel-lovelace-ui": {
+        "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.nspanel-lovelace-ui/main/admin/nspanel-lovelace-ui.png",
+        "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.nspanel-lovelace-ui/main/io-package.json",
+        "type": "hardware"
+    },
+    "ntfy-client": {
+        "icon": "https://raw.githubusercontent.com/lubepi/ioBroker.ntfy-client/main/admin/ntfy-client.png",
+        "meta": "https://raw.githubusercontent.com/lubepi/ioBroker.ntfy-client/main/io-package.json",
+        "type": "messaging"
+    },
+    "nuki": {
+        "icon": "https://raw.githubusercontent.com/smaragdschlange/ioBroker.nuki/master/admin/nuki-logo.png",
+        "meta": "https://raw.githubusercontent.com/smaragdschlange/ioBroker.nuki/master/io-package.json",
+        "type": "hardware"
+    },
+    "nuki-extended": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.nuki-extended/master/admin/nuki-extended.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.nuki-extended/master/io-package.json",
+        "type": "hardware"
+    },
+    "nut": {
+        "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.nut/master/admin/nut.png",
+        "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.nut/master/io-package.json",
+        "type": "hardware"
+    },
+    "oasecontrol": {
+        "icon": "https://raw.githubusercontent.com/mr-suw/ioBroker.oasecontrol/main/admin/oasecontrol.png",
+        "meta": "https://raw.githubusercontent.com/mr-suw/ioBroker.oasecontrol/main/io-package.json",
+        "type": "garden"
+    },
+    "ocpp": {
+        "icon": "https://raw.githubusercontent.com/foxriver76/ioBroker.ocpp/main/admin/ocpp.png",
+        "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.ocpp/main/io-package.json",
+        "type": "energy"
+    },
+    "octoprint": {
+        "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.octoprint/master/admin/octoprint.png",
+        "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.octoprint/master/io-package.json",
+        "type": "hardware"
+    },
+    "odl": {
+        "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.odl/master/admin/odl.png",
+        "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.odl/master/io-package.json",
+        "type": "misc-data"
+    },
+    "oekofen-json": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.oekofen-json/main/admin/oekofen-json.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.oekofen-json/main/io-package.json",
+        "type": "climate-control"
+    },
+    "oilfox": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.oilfox/master/admin/oilfox.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.oilfox/master/io-package.json",
+        "type": "hardware"
+    },
+    "omnicomm-lls": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.omnicomm-lls/master/admin/omnicomm-lls.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.omnicomm-lls/master/io-package.json",
+        "type": "metering"
+    },
+    "omron-fins": {
+        "icon": "https://raw.githubusercontent.com/TheBam1990/ioBroker.omron-fins/master/admin/omron-fins.png",
+        "meta": "https://raw.githubusercontent.com/TheBam1990/ioBroker.omron-fins/master/io-package.json",
+        "type": "hardware"
+    },
+    "onkyo": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.onkyo/master/admin/onkyo.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.onkyo/master/io-package.json",
+        "type": "multimedia"
+    },
+    "onlycat": {
+        "icon": "https://raw.githubusercontent.com/Sickboy78/ioBroker.onlycat/main/admin/onlycat.png",
+        "meta": "https://raw.githubusercontent.com/Sickboy78/ioBroker.onlycat/main/io-package.json",
+        "type": "iot-systems"
+    },
+    "onvif": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.onvif/main/admin/onvif.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.onvif/main/io-package.json",
+        "type": "infrastructure"
+    },
+    "opcua": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.opcua/master/admin/opcua.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.opcua/master/io-package.json",
+        "type": "protocols"
+    },
+    "open-meteo-weather": {
+        "icon": "https://raw.githubusercontent.com/H5N1v2/ioBroker.open-meteo-weather/main/admin/open-meteo.png",
+        "meta": "https://raw.githubusercontent.com/H5N1v2/ioBroker.open-meteo-weather/main/io-package.json",
+        "type": "weather"
+    },
+    "opendtu": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.opendtu/main/admin/opendtu.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.opendtu/main/io-package.json",
+        "type": "energy"
+    },
+    "openhab": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.openhab/master/admin/openhab.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.openhab/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "openknx": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.openknx/master/admin/openknx.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.openknx/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "openligadb": {
+        "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.openligadb/main/admin/openligadb_n.png",
+        "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.openligadb/main/io-package.json",
+        "type": "misc-data"
+    },
+    "openmediavault": {
+        "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.openmediavault/main/admin/openmediavault.png",
+        "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.openmediavault/main/io-package.json",
+        "type": "infrastructure"
+    },
+    "openmeteo-notify": {
+        "icon": "https://raw.githubusercontent.com/ipod86/ioBroker.openmeteo-notify/main/admin/openmeteo-notify.png",
+        "meta": "https://raw.githubusercontent.com/ipod86/ioBroker.openmeteo-notify/main/io-package.json",
+        "type": "weather"
+    },
+    "opensmartcity": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.opensmartcity/main/admin/opensmartcity.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.opensmartcity/main/io-package.json",
+        "type": "weather"
+    },
+    "opentherm": {
+        "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.opentherm/main/admin/opentherm.png",
+        "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.opentherm/main/io-package.json",
+        "type": "hardware"
+    },
+    "openweathermap": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.openweathermap/master/admin/openweathermap.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.openweathermap/master/io-package.json",
+        "type": "weather"
+    },
+    "operating-hours": {
+        "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.operating-hours/main/admin/operating-hours.png",
+        "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.operating-hours/main/io-package.json",
+        "type": "metering"
+    },
+    "opi": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.opi/master/admin/opi.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.opi/master/io-package.json",
+        "type": "hardware"
+    },
+    "oppoplayer": {
+        "icon": "https://raw.githubusercontent.com/volkerrichert/ioBroker.oppoplayer/master/admin/oppoplayer.png",
+        "meta": "https://raw.githubusercontent.com/volkerrichert/ioBroker.oppoplayer/master/io-package.json",
+        "type": "multimedia"
+    },
+    "otlp": {
+        "icon": "https://raw.githubusercontent.com/OlliMartin/ioBroker.otlp/main/admin/otlp.png",
+        "meta": "https://raw.githubusercontent.com/OlliMartin/ioBroker.otlp/main/io-package.json",
+        "type": "storage"
+    },
+    "owfs": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.owfs/master/admin/owfs.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.owfs/master/io-package.json",
+        "type": "hardware"
+    },
+    "owntracks": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.owntracks/master/admin/owntracks.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.owntracks/master/io-package.json",
+        "type": "geoposition"
+    },
+    "oxxify-fan-control": {
+        "icon": "https://raw.githubusercontent.com/N-b-dy/ioBroker.oxxify-fan-control/main/admin/oxxify-fan-control.png",
+        "meta": "https://raw.githubusercontent.com/N-b-dy/ioBroker.oxxify-fan-control/main/io-package.json",
+        "type": "climate-control"
+    },
+    "p2pool": {
+        "icon": "https://raw.githubusercontent.com/oelison/ioBroker.p2pool/main/admin/p2pool.png",
+        "meta": "https://raw.githubusercontent.com/oelison/ioBroker.p2pool/main/io-package.json",
+        "type": "misc-data"
+    },
+    "palazzetti": {
+        "icon": "https://raw.githubusercontent.com/inapsis/ioBroker.palazzetti/master/admin/palazzetti.png",
+        "meta": "https://raw.githubusercontent.com/inapsis/ioBroker.palazzetti/master/io-package.json",
+        "type": "climate-control"
+    },
+    "panasonic-comfort-cloud": {
+        "icon": "https://raw.githubusercontent.com/marc2016/ioBroker.panasonic-comfort-cloud/main/admin/panasonic-comfort-cloud.png",
+        "meta": "https://raw.githubusercontent.com/marc2016/ioBroker.panasonic-comfort-cloud/main/io-package.json",
+        "type": "climate-control"
+    },
+    "panasonic-viera": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.panasonic-viera/master/admin/panasonic-viera.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.panasonic-viera/master/io-package.json",
+        "type": "multimedia"
+    },
+    "paperless-ngx": {
+        "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.paperless-ngx/main/admin/paperless-ngx.png",
+        "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.paperless-ngx/main/io-package.json",
+        "type": "storage"
+    },
+    "parcel": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.parcel/master/admin/parcel.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.parcel/master/io-package.json",
+        "type": "misc-data"
+    },
+    "parcelapp": {
+        "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.parcelapp/main/admin/parcelapp.svg",
+        "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.parcelapp/main/io-package.json",
+        "type": "infrastructure"
+    },
+    "parser": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.parser/master/admin/parser.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.parser/master/io-package.json",
+        "type": "logic"
+    },
+    "pegelalarm": {
+        "icon": "https://raw.githubusercontent.com/simatec/ioBroker.pegelalarm/master/admin/pegelalarm.png",
+        "meta": "https://raw.githubusercontent.com/simatec/ioBroker.pegelalarm/master/io-package.json",
+        "type": "weather"
+    },
+    "ph803w": {
+        "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.ph803w/main/admin/ph803w_icon.png",
+        "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.ph803w/main/io-package.json",
+        "type": "metering"
+    },
+    "phantomjs": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.phantomjs/master/admin/phantomjs.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.phantomjs/master/io-package.json",
+        "type": "utility"
+    },
+    "philips-air": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.philips-air/master/admin/philips-air.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.philips-air/master/io-package.json",
+        "type": "household"
+    },
+    "philips-tv": {
+        "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.philips-tv/master/admin/philips-tv.png",
+        "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.philips-tv/master/io-package.json",
+        "type": "multimedia"
+    },
+    "pi-hole": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pi-hole/master/admin/pi-hole.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pi-hole/master/io-package.json",
+        "type": "network"
+    },
+    "pi-hole2": {
+        "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.pi-hole2/main/admin/pi-hole2.png",
+        "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.pi-hole2/main/io-package.json",
+        "type": "network"
+    },
+    "pid": {
+        "icon": "https://raw.githubusercontent.com/mcm4iob/ioBroker.pid/master/admin/pid.png",
+        "meta": "https://raw.githubusercontent.com/mcm4iob/ioBroker.pid/master/io-package.json",
+        "type": "general"
+    },
+    "piface": {
+        "icon": "https://raw.githubusercontent.com/Eisbaeeer/ioBroker.piface/master/admin/piface.png",
+        "meta": "https://raw.githubusercontent.com/Eisbaeeer/ioBroker.piface/master/io-package.json",
+        "type": "hardware"
+    },
+    "pimatic": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.pimatic/master/admin/pimatic.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.pimatic/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "ping": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.ping/master/admin/ping.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.ping/master/io-package.json",
+        "type": "network"
+    },
+    "pirate-weather": {
+        "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.pirate-weather/main/admin/pirate-weather.png",
+        "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.pirate-weather/main/io-package.json",
+        "type": "weather"
+    },
+    "pixelit": {
+        "icon": "https://raw.githubusercontent.com/pixelit-project/ioBroker.pixelit/master/admin/pixelit.png",
+        "meta": "https://raw.githubusercontent.com/pixelit-project/ioBroker.pixelit/master/io-package.json",
+        "type": "hardware"
+    },
+    "pjlink": {
+        "icon": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.pjlink/main/admin/pjlink.png",
+        "meta": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.pjlink/main/io-package.json",
+        "type": "multimedia"
+    },
+    "places": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.places/master/admin/places.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.places/master/io-package.json",
+        "type": "geoposition"
+    },
+    "playstation": {
+        "icon": "https://raw.githubusercontent.com/Lucky-ESA/ioBroker.playstation/main/admin/playstation.png",
+        "meta": "https://raw.githubusercontent.com/Lucky-ESA/ioBroker.playstation/main/io-package.json",
+        "type": "iot-systems"
+    },
+    "plenticore": {
+        "icon": "https://raw.githubusercontent.com/pixcept/ioBroker.plenticore/master/admin/plenticore.png",
+        "meta": "https://raw.githubusercontent.com/pixcept/ioBroker.plenticore/master/io-package.json",
+        "type": "energy"
+    },
+    "plenticore-g3": {
+        "icon": "https://raw.githubusercontent.com/FernetMenta/ioBroker.plenticore-g3/main/admin/plenticore-g3.png",
+        "meta": "https://raw.githubusercontent.com/FernetMenta/ioBroker.plenticore-g3/main/io-package.json",
+        "type": "energy"
+    },
+    "plex": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.plex/master/admin/plex.jpg",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.plex/master/io-package.json",
+        "type": "multimedia"
+    },
+    "plexconnect": {
+        "icon": "https://raw.githubusercontent.com/eisbaeeer/ioBroker.plexconnect/master/admin/plex-logo.png",
+        "meta": "https://raw.githubusercontent.com/eisbaeeer/ioBroker.plexconnect/master/io-package.json",
+        "type": "multimedia"
+    },
+    "pollenflug": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pollenflug/master/admin/pollenflug.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pollenflug/master/io-package.json",
+        "type": "weather"
+    },
+    "poolcontrol": {
+        "icon": "https://raw.githubusercontent.com/DasBo1975/ioBroker.poolcontrol/main/admin/poolcontrol.png",
+        "meta": "https://raw.githubusercontent.com/DasBo1975/ioBroker.poolcontrol/main/io-package.json",
+        "type": "climate-control"
+    },
+    "porsche": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.porsche/master/admin/porsche.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.porsche/master/io-package.json",
+        "type": "vehicle"
+    },
+    "powerfox2": {
+        "icon": "https://raw.githubusercontent.com/Ax-LED/ioBroker.powerfox2/main/admin/powerfox2.png",
+        "meta": "https://raw.githubusercontent.com/Ax-LED/ioBroker.powerfox2/main/io-package.json",
+        "type": "energy"
+    },
+    "procon-ip": {
+        "icon": "https://raw.githubusercontent.com/ylabonte/ioBroker.procon-ip/master/admin/procon-ip.png",
+        "meta": "https://raw.githubusercontent.com/ylabonte/ioBroker.procon-ip/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "proxmox": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.proxmox/master/admin/proxmox.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.proxmox/master/io-package.json",
+        "type": "infrastructure"
+    },
+    "proxy": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.proxy/master/admin/proxy.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.proxy/master/io-package.json",
+        "type": "network"
+    },
+    "public-transport": {
+        "icon": "https://raw.githubusercontent.com/tt-tom17/ioBroker.public-transport/main/admin/public-transport.png",
+        "meta": "https://raw.githubusercontent.com/tt-tom17/ioBroker.public-transport/main/io-package.json",
+        "type": "date-and-time"
+    },
+    "puppeteer": {
+        "icon": "https://raw.githubusercontent.com/foxriver76/ioBroker.puppeteer/main/admin/puppeteer.png",
+        "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.puppeteer/main/io-package.json",
+        "type": "utility"
+    },
+    "pushbullet": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pushbullet/master/admin/pushbullet.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pushbullet/master/io-package.json",
+        "type": "messaging"
+    },
+    "pushover": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.pushover/master/admin/pushover.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.pushover/master/io-package.json",
+        "type": "messaging"
+    },
+    "pushsafer": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.pushsafer/master/admin/pushsafer.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.pushsafer/master/io-package.json",
+        "type": "messaging"
+    },
+    "pv-notifications": {
+        "icon": "https://raw.githubusercontent.com/sadam6752-tech/ioBroker.pv-notifications/main/admin/pv-notifications.png",
+        "meta": "https://raw.githubusercontent.com/sadam6752-tech/ioBroker.pv-notifications/main/io-package.json",
+        "type": "energy"
+    },
+    "pvforecast": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pvforecast/main/admin/pvforecast.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pvforecast/main/io-package.json",
+        "type": "energy"
+    },
+    "pvoutputorg": {
+        "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.pvoutputorg/master/admin/pvoutputorg.png",
+        "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.pvoutputorg/master/io-package.json",
+        "type": "energy"
+    },
+    "pwned-check": {
+        "icon": "https://raw.githubusercontent.com/ipod86/ioBroker.pwned-check/main/admin/pwned-check.svg",
+        "meta": "https://raw.githubusercontent.com/ipod86/ioBroker.pwned-check/main/io-package.json",
+        "type": "alarm"
+    },
+    "pylontech": {
+        "icon": "https://raw.githubusercontent.com/PLCHome/ioBroker.pylontech/master/admin/pylontech.png",
+        "meta": "https://raw.githubusercontent.com/PLCHome/ioBroker.pylontech/master/io-package.json",
+        "type": "energy"
+    },
+    "radar-trap": {
+        "icon": "https://raw.githubusercontent.com/Steiger04/ioBroker.radar-trap/main/admin/radar-trap.png",
+        "meta": "https://raw.githubusercontent.com/Steiger04/ioBroker.radar-trap/main/io-package.json",
+        "type": "geoposition"
+    },
+    "radar2": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.radar2/master/admin/radar2.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.radar2/master/io-package.json",
+        "type": "network"
+    },
+    "radiohead": {
+        "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.radiohead/master/admin/radiohead.png",
+        "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.radiohead/master/io-package.json",
+        "type": "protocols"
+    },
+    "rainbird": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.rainbird/master/admin/rainbird.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.rainbird/master/io-package.json",
+        "type": "garden"
+    },
+    "rct": {
+        "icon": "https://raw.githubusercontent.com/aruttkamp/ioBroker.rct/main/admin/rct-logo.square.png",
+        "meta": "https://raw.githubusercontent.com/aruttkamp/ioBroker.rct/main/io-package.json",
+        "type": "energy"
+    },
+    "refoss": {
+        "icon": "https://raw.githubusercontent.com/Refoss/ioBroker.refoss/main/admin/refoss.png",
+        "meta": "https://raw.githubusercontent.com/Refoss/ioBroker.refoss/main/io-package.json",
+        "type": "iot-systems"
+    },
+    "remeha-home": {
+        "icon": "https://raw.githubusercontent.com/simatec/ioBroker.remeha-home/master/admin/remeha-home.png",
+        "meta": "https://raw.githubusercontent.com/simatec/ioBroker.remeha-home/master/io-package.json",
+        "type": "climate-control"
+    },
+    "renacidc": {
+        "icon": "https://raw.githubusercontent.com/raschy/ioBroker.renacidc/main/admin/renacidc.png",
+        "meta": "https://raw.githubusercontent.com/raschy/ioBroker.renacidc/main/io-package.json",
+        "type": "energy"
+    },
+    "renault": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.renault/main/admin/renault.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.renault/main/io-package.json",
+        "type": "vehicle"
+    },
+    "reolink": {
+        "icon": "https://raw.githubusercontent.com/aendue/ioBroker.reolink/main/admin/reolink.png",
+        "meta": "https://raw.githubusercontent.com/aendue/ioBroker.reolink/main/io-package.json",
+        "type": "alarm"
+    },
+    "residents": {
+        "icon": "https://raw.githubusercontent.com/jpawlowski/ioBroker.residents/main/admin/residents.svg",
+        "meta": "https://raw.githubusercontent.com/jpawlowski/ioBroker.residents/main/io-package.json",
+        "type": "logic"
+    },
+    "resol": {
+        "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.resol/master/admin/resol.svg",
+        "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.resol/master/io-package.json",
+        "type": "energy"
+    },
+    "rest-api": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.rest-api/master/admin/rest-api.svg",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.rest-api/master/io-package.json",
+        "type": "communication"
+    },
+    "rflink": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.rflink/master/admin/rflink.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.rflink/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "rfxcom": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.rfxcom/master/admin/rfxcom.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.rfxcom/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "rickshaw": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.rickshaw/master/admin/rickshaw.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.rickshaw/master/io-package.json",
+        "type": "visualization"
+    },
+    "ring": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ring/master/admin/ring.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ring/master/io-package.json",
+        "type": "hardware"
+    },
+    "roadtraffic": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.roadtraffic/master/admin/roadtraffic.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.roadtraffic/master/io-package.json",
+        "type": "misc-data"
+    },
+    "robonect": {
+        "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.robonect/master/admin/robonect.png",
+        "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.robonect/master/io-package.json",
+        "type": "garden"
+    },
+    "roborock": {
+        "icon": "https://raw.githubusercontent.com/copystring/ioBroker.roborock/main/admin/roborock.png",
+        "meta": "https://raw.githubusercontent.com/copystring/ioBroker.roborock/main/io-package.json",
+        "type": "household"
+    },
+    "roomba": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.roomba/master/admin/roomba.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.roomba/master/io-package.json",
+        "type": "household"
+    },
+    "rpi2": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.rpi2/master/admin/rpi2.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.rpi2/master/io-package.json",
+        "type": "hardware"
+    },
+    "rssfeed": {
+        "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.rssfeed/main/admin/rssfeed.png",
+        "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.rssfeed/main/io-package.json",
+        "type": "misc-data"
+    },
+    "s7": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.s7/master/admin/s7.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.s7/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "sainlogic": {
+        "icon": "https://raw.githubusercontent.com/phifogg/ioBroker.sainlogic/master/admin/sainlogic.png",
+        "meta": "https://raw.githubusercontent.com/phifogg/ioBroker.sainlogic/master/io-package.json",
+        "type": "weather"
+    },
+    "samsung": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.samsung/master/admin/samsung.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.samsung/master/io-package.json",
+        "type": "multimedia"
+    },
+    "samsung_tizen": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.samsung_tizen/master/admin/samsung.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.samsung_tizen/master/io-package.json",
+        "type": "multimedia"
+    },
+    "sanext": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.sanext/master/admin/sanext.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.sanext/master/io-package.json",
+        "type": "energy"
+    },
+    "sayit": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.sayit/master/admin/sayit.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.sayit/master/io-package.json",
+        "type": "multimedia"
+    },
+    "sbfspot": {
+        "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.sbfspot/master/admin/sbfspot.png",
+        "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.sbfspot/master/io-package.json",
+        "type": "hardware"
+    },
+    "sbms": {
+        "icon": "https://raw.githubusercontent.com/buffoletti/ioBroker.sbms/main/admin/sbms.png",
+        "meta": "https://raw.githubusercontent.com/buffoletti/ioBroker.sbms/main/io-package.json",
+        "type": "energy"
+    },
+    "scenes": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.scenes/master/admin/scenes.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.scenes/master/io-package.json",
+        "type": "logic"
+    },
+    "schedule-switcher": {
+        "icon": "https://raw.githubusercontent.com/Lucky-ESA/ioBroker.schedule-switcher/main/admin/schedule-switcher.png",
+        "meta": "https://raw.githubusercontent.com/Lucky-ESA/ioBroker.schedule-switcher/main/io-package.json",
+        "type": "date-and-time"
+    },
+    "scheduler": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.scheduler/master/admin/scheduler.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.scheduler/master/io-package.json",
+        "type": "logic"
+    },
+    "schlueter-thermostat": {
+        "icon": "https://raw.githubusercontent.com/patricknitsch/ioBroker.schlueter-thermostat/main/admin/schlueter-thermostat.png",
+        "meta": "https://raw.githubusercontent.com/patricknitsch/ioBroker.schlueter-thermostat/main/io-package.json",
+        "type": "climate-control"
+    },
+    "schoolfree": {
+        "icon": "https://raw.githubusercontent.com/simatec/ioBroker.schoolfree/master/admin/schoolfree.png",
+        "meta": "https://raw.githubusercontent.com/simatec/ioBroker.schoolfree/master/io-package.json",
+        "type": "date-and-time"
+    },
+    "schwoerer-ventcube": {
+        "icon": "https://raw.githubusercontent.com/Excodibur/ioBroker.schwoerer-ventcube/master/admin/schwoerer-ventcube.png",
+        "meta": "https://raw.githubusercontent.com/Excodibur/ioBroker.schwoerer-ventcube/master/io-package.json",
+        "type": "climate-control"
+    },
+    "script-restore": {
+        "icon": "https://raw.githubusercontent.com/ipod86/ioBroker.script-restore/main/admin/script-restore.svg",
+        "meta": "https://raw.githubusercontent.com/ipod86/ioBroker.script-restore/main/io-package.json",
+        "type": "utility"
+    },
+    "seko": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.seko/main/admin/seko.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.seko/main/io-package.json",
+        "type": "climate-control"
+    },
+    "selverf": {
+        "icon": "https://raw.githubusercontent.com/Rintrium/ioBroker.selverf/master/admin/selverf.png",
+        "meta": "https://raw.githubusercontent.com/Rintrium/ioBroker.selverf/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "semp": {
+        "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.semp/master/admin/semp.png",
+        "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.semp/master/io-package.json",
+        "type": "energy"
+    },
+    "senec": {
+        "icon": "https://raw.githubusercontent.com/nobl/ioBroker.senec/master/admin/senec.png",
+        "meta": "https://raw.githubusercontent.com/nobl/ioBroker.senec/master/io-package.json",
+        "type": "energy"
+    },
+    "sensebox": {
+        "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.sensebox/master/admin/sensebox.svg?sanitize=true",
+        "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.sensebox/master/io-package.json",
+        "type": "weather"
+    },
+    "seplos-v3-sniffer": {
+        "icon": "https://raw.githubusercontent.com/DpunktS/ioBroker.seplos-v3-sniffer/main/admin/seplos-v3-sniffer.jpg",
+        "meta": "https://raw.githubusercontent.com/DpunktS/ioBroker.seplos-v3-sniffer/main/io-package.json",
+        "type": "iot-systems"
+    },
+    "seq": {
+        "icon": "https://raw.githubusercontent.com/arteck/ioBroker.seq/master/admin/seq.png",
+        "meta": "https://raw.githubusercontent.com/arteck/ioBroker.seq/master/io-package.json",
+        "type": "logic"
+    },
+    "serial-gps": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.serial-gps/main/admin/serial-gps.svg",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.serial-gps/main/io-package.json",
+        "type": "utility"
+    },
+    "shelly": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.shelly/master/admin/shelly.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.shelly/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "shrdzm": {
+        "icon": "https://raw.githubusercontent.com/mcm4iob/ioBroker.shrdzm/main/admin/shrdzm.png",
+        "meta": "https://raw.githubusercontent.com/mcm4iob/ioBroker.shrdzm/main/io-package.json",
+        "type": "energy"
+    },
+    "shuttercontrol": {
+        "icon": "https://raw.githubusercontent.com/simatec/ioBroker.shuttercontrol/master/admin/shuttercontrol.png",
+        "meta": "https://raw.githubusercontent.com/simatec/ioBroker.shuttercontrol/master/io-package.json",
+        "type": "climate-control"
+    },
+    "sia": {
+        "icon": "https://raw.githubusercontent.com/schmupu/ioBroker.sia/master/admin/sia.png",
+        "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.sia/master/io-package.json",
+        "type": "alarm"
+    },
+    "siegenia": {
+        "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.siegenia/master/admin/siegenia.png",
+        "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.siegenia/master/io-package.json",
+        "type": "climate-control"
+    },
+    "sigenergy": {
+        "icon": "https://raw.githubusercontent.com/ssbingo/ioBroker.sigenergy/main/admin/sigenergy.png",
+        "meta": "https://raw.githubusercontent.com/ssbingo/ioBroker.sigenergy/main/io-package.json",
+        "type": "energy"
+    },
+    "signal-cmb": {
+        "icon": "https://raw.githubusercontent.com/derAlff/ioBroker.signal-cmb/master/admin/signal-cmb.png",
+        "meta": "https://raw.githubusercontent.com/derAlff/ioBroker.signal-cmb/master/io-package.json",
+        "type": "messaging"
+    },
+    "signifylights": {
+        "icon": "https://raw.githubusercontent.com/disaster123/ioBroker.signifylights/main/admin/signifylights.png",
+        "meta": "https://raw.githubusercontent.com/disaster123/ioBroker.signifylights/main/io-package.json",
+        "type": "lighting"
+    },
+    "simple-api": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.simple-api/master/admin/simple-api.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.simple-api/master/io-package.json",
+        "type": "communication"
+    },
+    "simple-proxy-manager": {
+        "icon": "https://raw.githubusercontent.com/lubepi/ioBroker.simple-proxy-manager/main/admin/simple-proxy-manager.png",
+        "meta": "https://raw.githubusercontent.com/lubepi/ioBroker.simple-proxy-manager/main/io-package.json",
+        "type": "network"
+    },
+    "skiinfo": {
+        "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.skiinfo/main/admin/skiinfo.png",
+        "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.skiinfo/main/io-package.json",
+        "type": "misc-data"
+    },
+    "slideshow": {
+        "icon": "https://raw.githubusercontent.com/gaudes/ioBroker.slideshow/main/admin/slideshow.png",
+        "meta": "https://raw.githubusercontent.com/gaudes/ioBroker.slideshow/main/io-package.json",
+        "type": "visualization"
+    },
+    "sma-em": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.sma-em/master/admin/sma-em.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.sma-em/master/io-package.json",
+        "type": "energy"
+    },
+    "smappee": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.smappee/master/admin/smappee.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.smappee/master/io-package.json",
+        "type": "energy"
+    },
+    "smart-eq": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.smart-eq/master/admin/smart-eq.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.smart-eq/master/io-package.json",
+        "type": "vehicle"
+    },
+    "smartcontrol": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.smartcontrol/master/admin/smartcontrol.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.smartcontrol/master/io-package.json",
+        "type": "logic"
+    },
+    "smartfriends": {
+        "icon": "https://raw.githubusercontent.com/Black-Thunder/ioBroker.smartfriends/master/admin/smartfriends.png",
+        "meta": "https://raw.githubusercontent.com/Black-Thunder/ioBroker.smartfriends/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "smartgarden": {
+        "icon": "https://raw.githubusercontent.com/jpgorganizer/ioBroker.smartgarden/master/admin/smartgarden.png",
+        "meta": "https://raw.githubusercontent.com/jpgorganizer/ioBroker.smartgarden/master/io-package.json",
+        "type": "garden"
+    },
+    "smartloadmanager": {
+        "icon": "https://raw.githubusercontent.com/quorle/ioBroker.smartloadmanager/main/admin/smartloadmanager.png",
+        "meta": "https://raw.githubusercontent.com/quorle/ioBroker.smartloadmanager/main/io-package.json",
+        "type": "logic"
+    },
+    "smartm": {
+        "icon": "https://raw.githubusercontent.com/strulli85/ioBroker.smartm/main/admin/smartm.svg",
+        "meta": "https://raw.githubusercontent.com/strulli85/ioBroker.smartm/main/io-package.json",
+        "type": "energy"
+    },
+    "smartmeter": {
+        "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.smartmeter/master/admin/smartmeter.png",
+        "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.smartmeter/master/io-package.json",
+        "type": "energy"
+    },
+    "smartthings": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.smartthings/master/admin/smartthings.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.smartthings/master/io-package.json",
+        "type": "household"
+    },
+    "smoothed": {
+        "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.smoothed/main/admin/smoothed.png",
+        "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.smoothed/main/io-package.json",
+        "type": "logic"
+    },
+    "snips": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snips/master/admin/snips.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snips/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "snmp": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snmp/master/admin/snmp.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snmp/master/io-package.json",
+        "type": "infrastructure"
+    },
+    "socketio": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.socketio/master/admin/socketio.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.socketio/master/io-package.json",
+        "type": "communication"
+    },
+    "sofarcloud": {
+        "icon": "https://raw.githubusercontent.com/ltspicer/ioBroker.sofarcloud/main/admin/sofarcloud.jpg",
+        "meta": "https://raw.githubusercontent.com/ltspicer/ioBroker.sofarcloud/main/io-package.json",
+        "type": "energy"
+    },
+    "solaredge": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solaredge/master/admin/solaredge.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solaredge/master/io-package.json",
+        "type": "energy"
+    },
+    "solarlog": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solarlog/master/admin/solarlog.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solarlog/master/io-package.json",
+        "type": "energy"
+    },
+    "solarmanpv": {
+        "icon": "https://raw.githubusercontent.com/raschy/ioBroker.solarmanpv/main/admin/solarmanpv.png",
+        "meta": "https://raw.githubusercontent.com/raschy/ioBroker.solarmanpv/main/io-package.json",
+        "type": "energy"
+    },
+    "solarprognose": {
+        "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.solarprognose/main/admin/solarprognose.png",
+        "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.solarprognose/main/io-package.json",
+        "type": "weather"
+    },
+    "solarviewdatareader": {
+        "icon": "https://raw.githubusercontent.com/afuerhoff/ioBroker.solarviewdatareader/master/admin/solarviewdatareader.png",
+        "meta": "https://raw.githubusercontent.com/afuerhoff/ioBroker.solarviewdatareader/master/io-package.json",
+        "type": "energy"
+    },
+    "solarwetter": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solarwetter/master/admin/solarwetter.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solarwetter/master/io-package.json",
+        "type": "weather"
+    },
+    "solax": {
+        "icon": "https://raw.githubusercontent.com/simatec/ioBroker.solax/master/admin/solax.png",
+        "meta": "https://raw.githubusercontent.com/simatec/ioBroker.solax/master/io-package.json",
+        "type": "energy"
+    },
+    "solectrus-influxdb": {
+        "icon": "https://raw.githubusercontent.com/patricknitsch/ioBroker.solectrus-influxdb/main/admin/solectrus-influxdb.png",
+        "meta": "https://raw.githubusercontent.com/patricknitsch/ioBroker.solectrus-influxdb/main/io-package.json",
+        "type": "communication"
+    },
+    "soliscloud": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.soliscloud/main/admin/solis.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.soliscloud/main/io-package.json",
+        "type": "energy"
+    },
+    "sonnen": {
+        "icon": "https://raw.githubusercontent.com/foxriver76/ioBroker.sonnen/master/admin/sonnen.png",
+        "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.sonnen/master/io-package.json",
+        "type": "energy"
+    },
+    "sonnen-charger": {
+        "icon": "https://raw.githubusercontent.com/ChrisWbb/ioBroker.sonnen-charger/main/admin/sonnen-charger.png",
+        "meta": "https://raw.githubusercontent.com/ChrisWbb/ioBroker.sonnen-charger/main/io-package.json",
+        "type": "energy"
+    },
+    "sonoff": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.sonoff/master/admin/sonoff.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.sonoff/master/io-package.json",
+        "type": "lighting"
+    },
+    "sonos": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.sonos/master/admin/sonos.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.sonos/master/io-package.json",
+        "type": "multimedia"
+    },
+    "sonus": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.sonus/master/admin/sonus.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.sonus/master/io-package.json",
+        "type": "multimedia"
+    },
+    "sony-bravia": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.sony-bravia/master/admin/sony-bravia.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.sony-bravia/master/io-package.json",
+        "type": "multimedia"
+    },
+    "sourceanalytix": {
+        "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.sourceanalytix/main/admin/sourceanalytix.png",
+        "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.sourceanalytix/main/io-package.json",
+        "type": "energy"
+    },
+    "speedport": {
+        "icon": "https://raw.githubusercontent.com/hacki11/ioBroker.speedport/master/admin/speedport.png",
+        "meta": "https://raw.githubusercontent.com/hacki11/ioBroker.speedport/master/io-package.json",
+        "type": "infrastructure"
+    },
+    "spotify-premium": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.spotify-premium/master/admin/spotify-premium.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.spotify-premium/master/io-package.json",
+        "type": "multimedia"
+    },
+    "sprinklecontrol": {
+        "icon": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/admin/sprinklecontrol.png",
+        "meta": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/io-package.json",
+        "type": "garden"
+    },
+    "sql": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.sql/master/admin/sql.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.sql/master/io-package.json",
+        "type": "storage"
+    },
+    "squeezeboxrpc": {
+        "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.squeezeboxrpc/main/admin/squeezeboxrpc.png",
+        "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.squeezeboxrpc/main/io-package.json",
+        "type": "multimedia"
+    },
+    "srm": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.srm/main/admin/srm.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.srm/main/io-package.json",
+        "type": "hardware"
+    },
+    "starline": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.starline/master/admin/starline.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.starline/master/io-package.json",
+        "type": "vehicle"
+    },
+    "statistics": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.statistics/master/admin/statistics.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.statistics/master/io-package.json",
+        "type": "misc-data"
+    },
+    "steam": {
+        "icon": "https://raw.githubusercontent.com/bloop16/ioBroker.steam/main/admin/steam.png",
+        "meta": "https://raw.githubusercontent.com/bloop16/ioBroker.steam/main/io-package.json",
+        "type": "multimedia"
+    },
+    "stiebel-isg": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.stiebel-isg/master/admin/stiebel-isg.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.stiebel-isg/master/io-package.json",
+        "type": "climate-control"
+    },
+    "stockmarket": {
+        "icon": "https://raw.githubusercontent.com/waoler/ioBroker.stockmarket/master/admin/stockmarket.png",
+        "meta": "https://raw.githubusercontent.com/waoler/ioBroker.stockmarket/master/io-package.json",
+        "type": "misc-data"
+    },
+    "sun2000": {
+        "icon": "https://raw.githubusercontent.com/bolliy/ioBroker.sun2000/main/admin/sun2000.png",
+        "meta": "https://raw.githubusercontent.com/bolliy/ioBroker.sun2000/main/io-package.json",
+        "type": "energy"
+    },
+    "sun2000-modbus": {
+        "icon": "https://raw.githubusercontent.com/daolis/ioBroker.sun2000-modbus/main/admin/sun2000-modbus.png",
+        "meta": "https://raw.githubusercontent.com/daolis/ioBroker.sun2000-modbus/main/io-package.json",
+        "type": "energy"
+    },
+    "sureflap": {
+        "icon": "https://raw.githubusercontent.com/Sickboy78/ioBroker.sureflap/master/admin/sureflap.png",
+        "meta": "https://raw.githubusercontent.com/Sickboy78/ioBroker.sureflap/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "swiss-weather-api": {
+        "icon": "https://raw.githubusercontent.com/baerengraben/ioBroker.swiss-weather-api/master/admin/swiss-weather-api.png",
+        "meta": "https://raw.githubusercontent.com/baerengraben/ioBroker.swiss-weather-api/master/io-package.json",
+        "type": "weather"
+    },
+    "synochat": {
+        "icon": "https://raw.githubusercontent.com/phoeluga/ioBroker.synochat/master/admin/synochat.png",
+        "meta": "https://raw.githubusercontent.com/phoeluga/ioBroker.synochat/master/io-package.json",
+        "type": "messaging"
+    },
+    "synology": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.synology/master/admin/synology.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.synology/master/io-package.json",
+        "type": "infrastructure"
+    },
+    "systeminfo": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.systeminfo/master/admin/systeminfo.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.systeminfo/master/io-package.json",
+        "type": "misc-data"
+    },
+    "ta-blnet": {
+        "icon": "https://raw.githubusercontent.com/weberk/ioBroker.ta-blnet/main/admin/ta-blnet.png",
+        "meta": "https://raw.githubusercontent.com/weberk/ioBroker.ta-blnet/main/io-package.json",
+        "type": "climate-control"
+    },
+    "tado": {
+        "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.tado/main/admin/tado.png",
+        "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.tado/main/io-package.json",
+        "type": "climate-control"
+    },
+    "tagesschau": {
+        "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.tagesschau/main/admin/tagesschau.png",
+        "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.tagesschau/main/io-package.json",
+        "type": "misc-data"
+    },
+    "tahoma": {
+        "icon": "https://raw.githubusercontent.com/Excodibur/ioBroker.tahoma/master/admin/tahoma.png",
+        "meta": "https://raw.githubusercontent.com/Excodibur/ioBroker.tahoma/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "tankerkoenig": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tankerkoenig/master/admin/tankerkoenig.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tankerkoenig/master/io-package.json",
+        "type": "vehicle"
+    },
+    "tapo": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.tapo/main/admin/tapo.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.tapo/main/io-package.json",
+        "type": "iot-systems"
+    },
+    "tedee": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.tedee/main/admin/tedee.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.tedee/main/io-package.json",
+        "type": "hardware"
+    },
+    "telegram": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.telegram/master/admin/telegram.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.telegram/master/io-package.json",
+        "type": "messaging"
+    },
+    "telegram-menu": {
+        "icon": "https://raw.githubusercontent.com/MiRo1310/ioBroker.telegram-menu/main/admin/telegram-menu.png",
+        "meta": "https://raw.githubusercontent.com/MiRo1310/ioBroker.telegram-menu/main/io-package.json",
+        "type": "messaging"
+    },
+    "teltonika": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.teltonika/master/admin/teltonika.svg",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.teltonika/master/io-package.json",
+        "type": "network"
+    },
+    "terminal": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.terminal/master/admin/terminal.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.terminal/master/io-package.json",
+        "type": "utility"
+    },
+    "tesla-motors": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tesla-motors/master/admin/tesla-motors.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tesla-motors/master/io-package.json",
+        "type": "vehicle"
+    },
+    "tesla-wallconnector3": {
+        "icon": "https://raw.githubusercontent.com/nobl/ioBroker.tesla-wallconnector3/main/admin/tesla-wallconnector3.png",
+        "meta": "https://raw.githubusercontent.com/nobl/ioBroker.tesla-wallconnector3/main/io-package.json",
+        "type": "vehicle"
+    },
+    "teslafi": {
+        "icon": "https://raw.githubusercontent.com/hombach/ioBroker.teslafi/master/admin/teslafi.png",
+        "meta": "https://raw.githubusercontent.com/hombach/ioBroker.teslafi/master/io-package.json",
+        "type": "vehicle"
+    },
+    "text2command": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.text2command/master/admin/text2command.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.text2command/master/io-package.json",
+        "type": "logic"
+    },
+    "tibberlink": {
+        "icon": "https://raw.githubusercontent.com/hombach/ioBroker.tibberlink/master/admin/tibberlink.png",
+        "meta": "https://raw.githubusercontent.com/hombach/ioBroker.tibberlink/master/io-package.json",
+        "type": "energy"
+    },
+    "tidy": {
+        "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.tidy/main/admin/tidy.svg",
+        "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.tidy/main/io-package.json",
+        "type": "storage"
+    },
+    "tileboard": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.tileboard/master/admin/tileboard.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.tileboard/master/io-package.json",
+        "type": "visualization"
+    },
+    "time-switch": {
+        "icon": "https://raw.githubusercontent.com/walli545/ioBroker.time-switch/master/admin/time-switch.png",
+        "meta": "https://raw.githubusercontent.com/walli545/ioBroker.time-switch/master/io-package.json",
+        "type": "date-and-time"
+    },
+    "tinker": {
+        "icon": "https://raw.githubusercontent.com/simatec/ioBroker.tinker/master/admin/tinker.png",
+        "meta": "https://raw.githubusercontent.com/simatec/ioBroker.tinker/master/io-package.json",
+        "type": "hardware"
+    },
+    "tino": {
+        "icon": "https://raw.githubusercontent.com/bowao/ioBroker.tino/master/admin/tino.png",
+        "meta": "https://raw.githubusercontent.com/bowao/ioBroker.tino/master/io-package.json",
+        "type": "hardware"
+    },
+    "tinymqttbroker": {
+        "icon": "https://raw.githubusercontent.com/HGlab01/ioBroker.tinymqttbroker/main/admin/tinymqttbroker.png",
+        "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.tinymqttbroker/main/io-package.json",
+        "type": "protocols"
+    },
+    "tinyrx4": {
+        "icon": "https://raw.githubusercontent.com/bowao/ioBroker.tinyrx4/master/admin/tinyRX4.png",
+        "meta": "https://raw.githubusercontent.com/bowao/ioBroker.tinyrx4/master/io-package.json",
+        "type": "hardware"
+    },
+    "toyota": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.toyota/master/admin/toyota.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.toyota/master/io-package.json",
+        "type": "vehicle"
+    },
+    "tr-064": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tr-064/master/admin/tr-064.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tr-064/master/io-package.json",
+        "type": "infrastructure"
+    },
+    "traccar": {
+        "icon": "https://raw.githubusercontent.com/arteck/ioBroker.traccar/master/admin/traccar.png",
+        "meta": "https://raw.githubusercontent.com/arteck/ioBroker.traccar/master/io-package.json",
+        "type": "geoposition"
+    },
+    "tractive-gps": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tractive-gps/main/admin/tractive-gps.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tractive-gps/main/io-package.json",
+        "type": "geoposition"
+    },
+    "tradfri": {
+        "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.tradfri/master/admin/tradfri.png",
+        "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.tradfri/master/io-package.json",
+        "type": "lighting"
+    },
+    "trashschedule": {
+        "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.trashschedule/master/admin/trashschedule.png",
+        "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.trashschedule/master/io-package.json",
+        "type": "date-and-time"
+    },
+    "trivum": {
+        "icon": "https://raw.githubusercontent.com/TheBam1990/ioBroker.trivum/main/admin/trivum.png",
+        "meta": "https://raw.githubusercontent.com/TheBam1990/ioBroker.trivum/main/io-package.json",
+        "type": "multimedia"
+    },
+    "tronity": {
+        "icon": "https://raw.githubusercontent.com/tronity/ioBroker.tronity/main/admin/tronity.png",
+        "meta": "https://raw.githubusercontent.com/tronity/ioBroker.tronity/main/io-package.json",
+        "type": "vehicle"
+    },
+    "tunnelbroker-endpoint-updater": {
+        "icon": "https://raw.githubusercontent.com/wattnpapa/ioBroker.tunnelbroker-endpoint-updater/master/admin/tunnelbroker-endpoint-updater.png",
+        "meta": "https://raw.githubusercontent.com/wattnpapa/ioBroker.tunnelbroker-endpoint-updater/master/io-package.json",
+        "type": "network"
+    },
+    "tuya": {
+        "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.tuya/master/admin/tuya.png",
+        "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.tuya/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "tvprogram": {
+        "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.tvprogram/master/admin/tvprogram.png",
+        "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.tvprogram/master/io-package.json",
+        "type": "misc-data"
+    },
+    "tvspielfilm": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tvspielfilm/master/admin/tvspielfilm.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tvspielfilm/master/io-package.json",
+        "type": "misc-data"
+    },
+    "twinkly": {
+        "icon": "https://raw.githubusercontent.com/patrickbs96/ioBroker.twinkly/master/admin/twinkly.png",
+        "meta": "https://raw.githubusercontent.com/patrickbs96/ioBroker.twinkly/master/io-package.json",
+        "type": "lighting"
+    },
+    "ultrahuman": {
+        "icon": "https://raw.githubusercontent.com/SmarterPapa/ioBroker.ultrahuman/main/admin/ultrahuman.png",
+        "meta": "https://raw.githubusercontent.com/SmarterPapa/ioBroker.ultrahuman/main/io-package.json",
+        "type": "health"
+    },
+    "unifi": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.unifi/master/admin/unifi.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.unifi/master/io-package.json",
+        "type": "network"
+    },
+    "unifi-network": {
+        "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.unifi-network/main/admin/unifi-network.png",
+        "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.unifi-network/main/io-package.json",
+        "type": "network"
+    },
+    "unifi-protect": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.unifi-protect/master/admin/unifi-protect.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.unifi-protect/master/io-package.json",
+        "type": "alarm"
+    },
+    "unraid": {
+        "icon": "https://raw.githubusercontent.com/ingel81/ioBroker.unraid/master/admin/unraid.png",
+        "meta": "https://raw.githubusercontent.com/ingel81/ioBroker.unraid/master/io-package.json",
+        "type": "infrastructure"
+    },
+    "upnp": {
+        "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.upnp/master/admin/upnp.png",
+        "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.upnp/master/io-package.json",
+        "type": "network"
+    },
+    "uv-protect": {
+        "icon": "https://raw.githubusercontent.com/simatec/ioBroker.uv-protect/master/admin/uv-protect.png",
+        "meta": "https://raw.githubusercontent.com/simatec/ioBroker.uv-protect/master/io-package.json",
+        "type": "weather"
+    },
+    "vaillant": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.vaillant/master/admin/vaillant.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.vaillant/master/io-package.json",
+        "type": "climate-control"
+    },
+    "valloxmv": {
+        "icon": "https://raw.githubusercontent.com/hacki11/ioBroker.valloxmv/master/admin/valloxmv.png",
+        "meta": "https://raw.githubusercontent.com/hacki11/ioBroker.valloxmv/master/io-package.json",
+        "type": "climate-control"
+    },
+    "valuetrackerovertime": {
+        "icon": "https://raw.githubusercontent.com/Omega236/ioBroker.valuetrackerovertime/master/admin/valuetrackerovertime.png",
+        "meta": "https://raw.githubusercontent.com/Omega236/ioBroker.valuetrackerovertime/master/io-package.json",
+        "type": "misc-data"
+    },
+    "vbus-gw": {
+        "icon": "https://raw.githubusercontent.com/pdbjjens/ioBroker.vbus-gw/main/admin/vbus-gw.png",
+        "meta": "https://raw.githubusercontent.com/pdbjjens/ioBroker.vbus-gw/main/io-package.json",
+        "type": "network"
+    },
+    "vds2465-server": {
+        "icon": "https://raw.githubusercontent.com/Hirsch-DE/ioBroker.vds2465-server/main/admin/vds2465-server.png",
+        "meta": "https://raw.githubusercontent.com/Hirsch-DE/ioBroker.vds2465-server/main/io-package.json",
+        "type": "alarm"
+    },
+    "vedirect": {
+        "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.vedirect/main/admin/Vedirect_Adapterimage.png",
+        "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.vedirect/main/io-package.json",
+        "type": "energy"
+    },
+    "velux": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.velux/master/admin/velux.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.velux/master/io-package.json",
+        "type": "household"
+    },
+    "vesync": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.vesync/main/admin/vesync.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.vesync/main/io-package.json",
+        "type": "climate-control"
+    },
+    "victron-cerbo": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.victron-cerbo/main/admin/victron-cerbo.svg",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.victron-cerbo/main/io-package.json",
+        "type": "energy"
+    },
+    "viessmann": {
+        "icon": "https://raw.githubusercontent.com/misanorot/ioBroker.viessmann/master/admin/viessmann.png",
+        "meta": "https://raw.githubusercontent.com/misanorot/ioBroker.viessmann/master/io-package.json",
+        "type": "climate-control"
+    },
+    "viessmannapi": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.viessmannapi/master/admin/viessmannapi.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.viessmannapi/master/io-package.json",
+        "type": "climate-control"
+    },
+    "virtualpowermeter": {
+        "icon": "https://raw.githubusercontent.com/Omega236/ioBroker.virtualpowermeter/master/admin/virtualpowermeter.png",
+        "meta": "https://raw.githubusercontent.com/Omega236/ioBroker.virtualpowermeter/master/io-package.json",
+        "type": "energy"
+    },
+    "vis": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis/master/admin/vis.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis/master/io-package.json",
+        "type": "visualization"
+    },
+    "vis-2": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2/master/packages/iobroker.vis-2/admin/vis-2.svg",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2/master/packages/iobroker.vis-2/io-package.json",
+        "type": "visualization"
+    },
+    "vis-2-widgets-collection": {
+        "icon": "https://raw.githubusercontent.com/Steiger04/ioBroker.vis-2-widgets-collection/main/admin/vis-2-widgets-collection.png",
+        "meta": "https://raw.githubusercontent.com/Steiger04/ioBroker.vis-2-widgets-collection/main/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-2-widgets-energy": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-energy/main/admin/vis-2-widgets-energy.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-energy/main/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-2-widgets-gauges": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-gauges/main/admin/vis-2-widgets-gauges.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-gauges/main/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-2-widgets-icontwo": {
+        "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-icontwo/main/admin/vis-2-widgets-icontwo.png",
+        "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-icontwo/main/io-package.json",
+        "type": "visualization-icons"
+    },
+    "vis-2-widgets-inventwo": {
+        "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-inventwo/main/admin/vis-2-widgets-inventwo.png",
+        "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-inventwo/main/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-2-widgets-jaeger-design": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-jaeger-design/main/admin/vis-2-widgets-jaeger-design.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-jaeger-design/main/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-2-widgets-material": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-material/main/admin/vis-2-widgets-material.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-material/main/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-2-widgets-ovarious": {
+        "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-2-widgets-ovarious/main/admin/vis-2-widgets-ovarious.png",
+        "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-2-widgets-ovarious/main/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-2-widgets-radar-trap": {
+        "icon": "https://raw.githubusercontent.com/Steiger04/ioBroker.vis-2-widgets-radar-trap/main/admin/vis-2-widgets-radar-trap.png",
+        "meta": "https://raw.githubusercontent.com/Steiger04/ioBroker.vis-2-widgets-radar-trap/main/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-2-widgets-rssfeed": {
+        "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-2-widgets-rssfeed/main/admin/vis-2-widgets-rssfeed.png",
+        "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-2-widgets-rssfeed/main/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-2-widgets-sigenergy": {
+        "icon": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-sigenergy/main/admin/vis-2-widgets-sigenergy.png",
+        "meta": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-sigenergy/main/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-2-widgets-sweethome3d": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-sweethome3d/main/admin/vis-2-widgets-sweethome3d.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-sweethome3d/main/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-2-widgets-tibberlink": {
+        "icon": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-tibberlink/main/admin/vis-2-widgets-tibberlink.png",
+        "meta": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-tibberlink/main/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-2-widgets-weather-and-heating": {
+        "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-2-widgets-weather-and-heating/master/admin/vis-2-widgets-weather-and-heating.png",
+        "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-2-widgets-weather-and-heating/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-3dmodel": {
+        "icon": "https://raw.githubusercontent.com/Excodibur/ioBroker.vis-3dmodel/master/admin/vis-3dmodel.png",
+        "meta": "https://raw.githubusercontent.com/Excodibur/ioBroker.vis-3dmodel/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-bars": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-bars/master/admin/bars.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-bars/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-canvas-gauges": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-canvas-gauges/master/admin/vis-canvas-gauges.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-canvas-gauges/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-colorpicker": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-colorpicker/master/admin/colorpicker.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-colorpicker/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-fancyswitch": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-fancyswitch/master/admin/fancyswitch.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-fancyswitch/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-google-fonts": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-google-fonts/master/admin/vis-google-fonts.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-google-fonts/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-history": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-history/master/admin/vis-history.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-history/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-homekittiles": {
+        "icon": "https://raw.githubusercontent.com/Standarduser/ioBroker.vis-homekittiles/main/admin/vis-homekittiles.png",
+        "meta": "https://raw.githubusercontent.com/Standarduser/ioBroker.vis-homekittiles/main/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-hqwidgets": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-hqwidgets/master/admin/hqwidgets.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-hqwidgets/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-icontwo": {
+        "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-icontwo/master/admin/icontwo.png",
+        "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-icontwo/master/io-package.json",
+        "type": "visualization-icons"
+    },
+    "vis-inventwo": {
+        "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-inventwo/master/admin/inventwo.png",
+        "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-inventwo/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-jqui-mfd": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-jqui-mfd/master/admin/jqui-mfd.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-jqui-mfd/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-jsontemplate": {
+        "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-jsontemplate/main/admin/vis-jsontemplate.png",
+        "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-jsontemplate/main/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-justgage": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-justgage/master/admin/justgage.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-justgage/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-keyboard": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-keyboard/master/admin/keyboard.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-keyboard/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-lcars": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-lcars/master/admin/lcars.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-lcars/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-map": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-map/master/admin/vis-map.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-map/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-material": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-material/master/admin/material.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-material/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-material-advanced": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-material-advanced/master/admin/vis-material-advanced.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-material-advanced/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-material-webfont": {
+        "icon": "https://raw.githubusercontent.com/om2804/ioBroker.vis-material-webfont/master/admin/material-webfont.png",
+        "meta": "https://raw.githubusercontent.com/om2804/ioBroker.vis-material-webfont/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-materialdesign": {
+        "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.vis-materialdesign/master/admin/vis-materialdesign.png",
+        "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.vis-materialdesign/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-metro": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-metro/master/admin/metro.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-metro/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-players": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-players/master/admin/players.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-players/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-plumb": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-plumb/master/admin/plumb.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-plumb/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-rgraph": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-rgraph/master/admin/rgraph.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-rgraph/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-timeandweather": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-timeandweather/master/admin/timeandweather.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-timeandweather/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vis-weather": {
+        "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-weather/master/admin/vis-weather.png",
+        "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-weather/master/io-package.json",
+        "type": "visualization-widgets"
+    },
+    "vivitek": {
+        "icon": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.vivitek/master/admin/vivitek.png",
+        "meta": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.vivitek/master/io-package.json",
+        "type": "multimedia"
+    },
+    "vofo-speedtest": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vofo-speedtest/master/admin/vofo-speedtest.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vofo-speedtest/master/io-package.json",
+        "type": "network"
+    },
+    "voltoplus": {
+        "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.voltoplus/main/admin/voltoplus.png",
+        "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.voltoplus/main/io-package.json",
+        "type": "energy"
+    },
+    "volumio": {
+        "icon": "https://raw.githubusercontent.com/a-i-ks/ioBroker.volumio/master/admin/volumio.png",
+        "meta": "https://raw.githubusercontent.com/a-i-ks/ioBroker.volumio/master/io-package.json",
+        "type": "multimedia"
+    },
+    "volvo": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.volvo/master/admin/volvo.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.volvo/master/io-package.json",
+        "type": "vehicle"
+    },
+    "vr200": {
+        "icon": "https://raw.githubusercontent.com/Eisbaeeer/ioBroker.vr200/master/admin/VR200.png",
+        "meta": "https://raw.githubusercontent.com/Eisbaeeer/ioBroker.vr200/master/io-package.json",
+        "type": "household"
+    },
+    "vw-connect": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.vw-connect/master/admin/vw-connect.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.vw-connect/master/io-package.json",
+        "type": "vehicle"
+    },
+    "wallpanel": {
+        "icon": "https://raw.githubusercontent.com/xXBJXx/ioBroker.wallpanel/main/admin/wallpanel.png",
+        "meta": "https://raw.githubusercontent.com/xXBJXx/ioBroker.wallpanel/main/io-package.json",
+        "type": "hardware"
+    },
+    "wamo": {
+        "icon": "https://raw.githubusercontent.com/smarthausleben/ioBroker.wamo/main/admin/wamo.png",
+        "meta": "https://raw.githubusercontent.com/smarthausleben/ioBroker.wamo/main/io-package.json",
+        "type": "iot-systems"
+    },
+    "warp": {
+        "icon": "https://raw.githubusercontent.com/pottio/ioBroker.warp/main/admin/warp.png",
+        "meta": "https://raw.githubusercontent.com/pottio/ioBroker.warp/main/io-package.json",
+        "type": "vehicle"
+    },
+    "waterkotte-easycon": {
+        "icon": "https://raw.githubusercontent.com/theknut/ioBroker.waterkotte-easycon/main/admin/waterkotte-easycon.png",
+        "meta": "https://raw.githubusercontent.com/theknut/ioBroker.waterkotte-easycon/main/io-package.json",
+        "type": "climate-control"
+    },
+    "wattcycle": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.wattcycle/main/admin/wattcycle.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.wattcycle/main/io-package.json",
+        "type": "energy"
+    },
+    "weather-warnings": {
+        "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.weather-warnings/main/admin/weather-warnings.png",
+        "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.weather-warnings/main/io-package.json",
+        "type": "weather"
+    },
+    "weatherflow-tempest-api": {
+        "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.weatherflow-tempest-api/main/admin/weatherflow-tempest-api.png",
+        "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.weatherflow-tempest-api/main/io-package.json",
+        "type": "weather"
+    },
+    "weatherflow_udp": {
+        "icon": "https://raw.githubusercontent.com/woessmich/ioBroker.weatherflow_udp/master/admin/weatherflow_udp.png",
+        "meta": "https://raw.githubusercontent.com/woessmich/ioBroker.weatherflow_udp/master/io-package.json",
+        "type": "weather"
+    },
+    "weathersense": {
+        "icon": "https://raw.githubusercontent.com/ltspicer/ioBroker.weathersense/main/admin/weathersense.png",
+        "meta": "https://raw.githubusercontent.com/ltspicer/ioBroker.weathersense/main/io-package.json",
+        "type": "metering"
+    },
+    "weatherunderground": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.weatherunderground/master/admin/wu.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.weatherunderground/master/io-package.json",
+        "type": "weather"
+    },
+    "web": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.web/master/admin/web.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.web/master/io-package.json",
+        "type": "general"
+    },
+    "web-speedy": {
+        "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.web-speedy/main/admin/web-speedy.png",
+        "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.web-speedy/main/io-package.json",
+        "type": "network"
+    },
+    "webcal": {
+        "icon": "https://raw.githubusercontent.com/dirkhe/ioBroker.webcal/master/admin/webcal.png",
+        "meta": "https://raw.githubusercontent.com/dirkhe/ioBroker.webcal/master/io-package.json",
+        "type": "date-and-time"
+    },
+    "weblogin": {
+        "icon": "https://raw.githubusercontent.com/Vertumnus/ioBroker.weblogin/master/admin/logo-login.png",
+        "meta": "https://raw.githubusercontent.com/Vertumnus/ioBroker.weblogin/master/io-package.json",
+        "type": "utility"
+    },
+    "webui": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.webui/master/admin/logo.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.webui/master/io-package.json",
+        "type": "visualization"
+    },
+    "webuntis": {
+        "icon": "https://raw.githubusercontent.com/Newan/ioBroker.webuntis/main/admin/webuntis.png",
+        "meta": "https://raw.githubusercontent.com/Newan/ioBroker.webuntis/main/io-package.json",
+        "type": "date-and-time"
+    },
+    "weishaupt-wem": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.weishaupt-wem/master/admin/weishaupt-wem.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.weishaupt-wem/master/io-package.json",
+        "type": "climate-control"
+    },
+    "welcome": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.welcome/main/admin/welcome.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.welcome/main/io-package.json",
+        "type": "general"
+    },
+    "whatsapp-cmb": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.whatsapp-cmb/master/admin/whatsapp-cmb.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.whatsapp-cmb/master/io-package.json",
+        "type": "messaging"
+    },
+    "wiegand-tcpip": {
+        "icon": "https://raw.githubusercontent.com/kBrausew/ioBroker.wiegand-tcpip/master/admin/wiegand-tcpip.png",
+        "meta": "https://raw.githubusercontent.com/kBrausew/ioBroker.wiegand-tcpip/master/io-package.json",
+        "type": "hardware"
+    },
+    "wiffi-wz": {
+        "icon": "https://raw.githubusercontent.com/t4qjXH8N/ioBroker.wiffi-wz/master/admin/wiffi-wz.png",
+        "meta": "https://raw.githubusercontent.com/t4qjXH8N/ioBroker.wiffi-wz/master/io-package.json",
+        "type": "hardware"
+    },
+    "wifilight": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.wifilight/master/admin/wifilight.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.wifilight/master/io-package.json",
+        "type": "lighting"
+    },
+    "wiobrowser": {
+        "icon": "https://raw.githubusercontent.com/Bettman66/ioBroker.wiobrowser/master/admin/wiobrowser.png",
+        "meta": "https://raw.githubusercontent.com/Bettman66/ioBroker.wiobrowser/master/io-package.json",
+        "type": "communication"
+    },
+    "wireguard": {
+        "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.wireguard/main/admin/wireguard.svg",
+        "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.wireguard/main/io-package.json",
+        "type": "infrastructure"
+    },
+    "wireless-mbus": {
+        "icon": "https://raw.githubusercontent.com/lvogt/ioBroker.wireless-mbus/master/admin/wireless-mbus.png",
+        "meta": "https://raw.githubusercontent.com/lvogt/ioBroker.wireless-mbus/master/io-package.json",
+        "type": "energy"
+    },
+    "wireless-settings": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.wireless-settings/master/admin/wireless-settings.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.wireless-settings/master/io-package.json",
+        "type": "network"
+    },
+    "withings": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.withings/master/admin/withings.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.withings/master/io-package.json",
+        "type": "health"
+    },
+    "witmotion": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.witmotion/master/admin/witmotion.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.witmotion/master/io-package.json",
+        "type": "utility"
+    },
+    "wlanthermo-nano": {
+        "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.wlanthermo-nano/main/admin/wlanthermo-nano.png",
+        "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.wlanthermo-nano/main/io-package.json",
+        "type": "household"
+    },
+    "wled": {
+        "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.wled/main/admin/wled.png",
+        "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.wled/main/io-package.json",
+        "type": "lighting"
+    },
+    "wmswebcontrol": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.wmswebcontrol/master/admin/wmswebcontrol.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.wmswebcontrol/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "wolf": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.wolf/master/admin/wolf.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.wolf/master/io-package.json",
+        "type": "climate-control"
+    },
+    "wolf-smartset": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.wolf-smartset/master/admin/wolf-smartset.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.wolf-smartset/master/io-package.json",
+        "type": "climate-control"
+    },
+    "worx": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.worx/master/admin/worx.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.worx/master/io-package.json",
+        "type": "garden"
+    },
+    "ws": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.ws/main/admin/ws.svg",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.ws/main/io-package.json",
+        "type": "communication"
+    },
+    "x-touch": {
+        "icon": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.x-touch/master/admin/x-touch.png",
+        "meta": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.x-touch/master/io-package.json",
+        "type": "hardware"
+    },
+    "xbox": {
+        "icon": "https://raw.githubusercontent.com/foxriver76/ioBroker.xbox/master/admin/xbox.png",
+        "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.xbox/master/io-package.json",
+        "type": "multimedia"
+    },
+    "xiaomi-gateway3": {
+        "icon": "https://raw.githubusercontent.com/lasthead0/ioBroker.xiaomi-gateway3/master/admin/xiaomi-gateway3.png",
+        "meta": "https://raw.githubusercontent.com/lasthead0/ioBroker.xiaomi-gateway3/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "xs1": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.xs1/master/admin/xs1.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.xs1/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "xsense": {
+        "icon": "https://raw.githubusercontent.com/arteck/ioBroker.xsense/main/admin/xsense.png",
+        "meta": "https://raw.githubusercontent.com/arteck/ioBroker.xsense/main/io-package.json",
+        "type": "utility"
+    },
+    "xterm": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.xterm/master/admin/xterm.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.xterm/master/io-package.json",
+        "type": "utility"
+    },
+    "yahka": {
+        "icon": "https://raw.githubusercontent.com/jensweigele/ioBroker.yahka/master/admin/yahka.png",
+        "meta": "https://raw.githubusercontent.com/jensweigele/ioBroker.yahka/master/io-package.json",
+        "type": "iot-systems"
+    },
+    "yahoo-stock-market": {
+        "icon": "https://raw.githubusercontent.com/Newan/ioBroker.yahoo-stock-market/main/admin/yahoo-stock-market.png",
+        "meta": "https://raw.githubusercontent.com/Newan/ioBroker.yahoo-stock-market/main/io-package.json",
+        "type": "misc-data"
+    },
+    "yamaha": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.yamaha/master/admin/yamaha.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.yamaha/master/io-package.json",
+        "type": "multimedia"
+    },
+    "yeelight-2": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.yeelight-2/master/admin/yeelight.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.yeelight-2/master/io-package.json",
+        "type": "lighting"
+    },
+    "youtube": {
+        "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.youtube/master/admin/youtube.png",
+        "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.youtube/master/io-package.json",
+        "type": "misc-data"
+    },
+    "yr": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.yr/master/admin/yr.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.yr/master/io-package.json",
+        "type": "weather"
+    },
+    "zehnder-cloud": {
+        "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.zehnder-cloud/master/admin/zehnder-cloud.png",
+        "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.zehnder-cloud/master/io-package.json",
+        "type": "climate-control"
+    },
+    "zendure-solarflow": {
+        "icon": "https://raw.githubusercontent.com/nograx/ioBroker.zendure-solarflow/main/admin/zendure-solarflow.png",
+        "meta": "https://raw.githubusercontent.com/nograx/ioBroker.zendure-solarflow/main/io-package.json",
+        "type": "energy"
+    },
+    "zigbee": {
+        "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.zigbee/master/admin/zigbee.png",
+        "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.zigbee/master/io-package.json",
+        "type": "hardware"
+    },
+    "zigbee2mqtt": {
+        "icon": "https://raw.githubusercontent.com/arteck/ioBroker.zigbee2mqtt/main/admin/zigbee2mqtt.png",
+        "meta": "https://raw.githubusercontent.com/arteck/ioBroker.zigbee2mqtt/main/io-package.json",
+        "type": "hardware"
+    },
+    "zoe2": {
+        "icon": "https://raw.githubusercontent.com/fungus75/ioBroker.zoe2/master/admin/zoe.png",
+        "meta": "https://raw.githubusercontent.com/fungus75/ioBroker.zoe2/master/io-package.json",
+        "type": "vehicle"
+    },
+    "zoneminder": {
+        "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.zoneminder/master/admin/zoneminder.png",
+        "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.zoneminder/master/io-package.json",
+        "type": "alarm"
+    },
+    "zont": {
+        "icon": "https://raw.githubusercontent.com/kirovilya/ioBroker.zont/master/admin/zont.png",
+        "meta": "https://raw.githubusercontent.com/kirovilya/ioBroker.zont/master/io-package.json",
+        "type": "climate-control"
+    },
+    "zwavews": {
+        "icon": "https://raw.githubusercontent.com/arteck/ioBroker.zwavews/main/admin/zwavews.png?sanitize=true",
+        "meta": "https://raw.githubusercontent.com/arteck/ioBroker.zwavews/main/io-package.json",
+        "type": "hardware"
+    },
+    "zwift": {
+        "icon": "https://raw.githubusercontent.com/Flixhummel/ioBroker.zwift/main/admin/zwift.png",
+        "meta": "https://raw.githubusercontent.com/Flixhummel/ioBroker.zwift/main/io-package.json",
+        "type": "health"
     }
-  },
-  "accuweather": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.accuweather/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.accuweather/master/admin/accuweather.png",
-    "type": "weather"
-  },
-  "acme": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.acme/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.acme/main/admin/acme.png",
-    "type": "general"
-  },
-  "adb": {
-    "meta": "https://raw.githubusercontent.com/om2804/ioBroker.adb/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/om2804/ioBroker.adb/master/admin/adb.png",
-    "type": "hardware"
-  },
-  "adguard": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.adguard/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.adguard/main/admin/adguard.png",
-    "type": "network"
-  },
-  "admin": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.admin/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.admin/master/admin/admin.svg",
-    "type": "general"
-  },
-  "ai-assistant": {
-    "meta": "https://raw.githubusercontent.com/ToGe3688/ioBroker.ai-assistant/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ToGe3688/ioBroker.ai-assistant/main/admin/ai-assistant.png",
-    "type": "messaging"
-  },
-  "ai-toolbox": {
-    "meta": "https://raw.githubusercontent.com/ToGe3688/ioBroker.ai-toolbox/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ToGe3688/ioBroker.ai-toolbox/main/admin/ai-toolbox.png",
-    "type": "logic"
-  },
-  "aio": {
-    "meta": "https://raw.githubusercontent.com/Newan/ioBroker.aio/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Newan/ioBroker.aio/master/admin/aio.png",
-    "type": "energy"
-  },
-  "air-q": {
-    "meta": "https://raw.githubusercontent.com/CorantGmbH/ioBroker.air-q/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/CorantGmbH/ioBroker.air-q/main/admin/air-q.png",
-    "type": "weather"
-  },
-  "airconwithme": {
-    "meta": "https://raw.githubusercontent.com/weggetor/ioBroker.airconwithme/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/weggetor/ioBroker.airconwithme/main/admin/airconwithme.png",
-    "type": "climate-control"
-  },
-  "airquality": {
-    "meta": "https://raw.githubusercontent.com/raschy/ioBroker.airquality/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/raschy/ioBroker.airquality/main/admin/airquality.png",
-    "type": "weather"
-  },
-  "airzone": {
-    "meta": "https://raw.githubusercontent.com/SilentPhoenix11/ioBroker.airzone/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/SilentPhoenix11/ioBroker.airzone/master/admin/Airzone.png",
-    "type": "climate-control"
-  },
-  "al-ko": {
-    "meta": "https://raw.githubusercontent.com/zechnerhubert/ioBroker.al-ko/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/zechnerhubert/ioBroker.al-ko/master/admin/al-ko-128.png",
-    "type": "garden"
-  },
-  "alarm": {
-    "meta": "https://raw.githubusercontent.com/misanorot/ioBroker.alarm/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/misanorot/ioBroker.alarm/master/admin/alarm.png",
-    "type": "alarm"
-  },
-  "alexa-shoppinglist": {
-    "meta": "https://raw.githubusercontent.com/MiRo1310/ioBroker.alexa-shoppinglist/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/MiRo1310/ioBroker.alexa-shoppinglist/main/admin/alexa-shoppinglist.png",
-    "type": "logic"
-  },
-  "alexa-timer-vis": {
-    "meta": "https://raw.githubusercontent.com/MiRo1310/ioBroker.alexa-timer-vis/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/MiRo1310/ioBroker.alexa-timer-vis/main/admin/alexa-timer-vis.png",
-    "type": "logic"
-  },
-  "alexa2": {
-    "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.alexa2/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.alexa2/master/admin/alexa.png",
-    "type": "iot-systems"
-  },
-  "alias-manager": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.alias-manager/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.alias-manager/master/admin/alias-manager.png",
-    "type": "general"
-  },
-  "alpha-ess": {
-    "meta": "https://raw.githubusercontent.com/Gaspode69/ioBroker.alpha-ess/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Gaspode69/ioBroker.alpha-ess/main/admin/alpha-ess.png",
-    "type": "energy"
-  },
-  "alpha2": {
-    "meta": "https://raw.githubusercontent.com/Eisbaeeer/ioBroker.alpha2/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Eisbaeeer/ioBroker.alpha2/master/admin/mh-logo.png",
-    "type": "climate-control"
-  },
-  "amazon-dash": {
-    "meta": "https://raw.githubusercontent.com/PArns/ioBroker.amazon-dash/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/PArns/ioBroker.amazon-dash/master/admin/amazon-dash.png",
-    "type": "hardware"
-  },
-  "amtronwallbox": {
-    "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.amtronwallbox/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.amtronwallbox/master/admin/amtronwallbox.png",
-    "type": "energy"
-  },
-  "anelhut": {
-    "meta": "https://raw.githubusercontent.com/dan1-de/ioBroker.anelhut/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/dan1-de/ioBroker.anelhut/main/admin/anelhut.png",
-    "type": "iot-systems"
-  },
-  "ankersolix2": {
-    "meta": "https://raw.githubusercontent.com/ronny130286/ioBroker.ankersolix2/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ronny130286/ioBroker.ankersolix2/main/admin/ankersolix2.png",
-    "type": "iot-systems"
-  },
-  "apcups": {
-    "meta": "https://raw.githubusercontent.com/XHunter74/ioBroker.apcups/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/XHunter74/ioBroker.apcups/master/admin/ups.png",
-    "type": "hardware"
-  },
-  "apg-info": {
-    "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.apg-info/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/HGlab01/ioBroker.apg-info/main/admin/apg-info.png",
-    "type": "general"
-  },
-  "apsystems-ez1": {
-    "meta": "https://raw.githubusercontent.com/zhihaining/ioBroker.apsystems-ez1/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/zhihaining/ioBroker.apsystems-ez1/master/admin/apsystems-ez1.png",
-    "type": "energy"
-  },
-  "artnet": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.artnet/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.artnet/master/admin/artnet.png",
-    "type": "lighting"
-  },
-  "artnet-recorder": {
-    "meta": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.artnet-recorder/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.artnet-recorder/master/admin/artnet-recorder.png",
-    "type": "lighting"
-  },
-  "asterisk": {
-    "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.asterisk/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/schmupu/ioBroker.asterisk/master/admin/asterisk.png",
-    "type": "communication"
-  },
-  "asuswrt": {
-    "meta": "https://raw.githubusercontent.com/mcdhrts/ioBroker.asuswrt/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/mcdhrts/ioBroker.asuswrt/master/admin/asuswrt.png",
-    "type": "hardware"
-  },
-  "atlas-scientific-ezo-i2c": {
-    "meta": "https://raw.githubusercontent.com/Buzze11/ioBroker.atlas-scientific-ezo-i2c/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Buzze11/ioBroker.atlas-scientific-ezo-i2c/master/admin/atlas-scientific-ezo-i2c.png",
-    "type": "hardware"
-  },
-  "aura": {
-    "meta": "https://raw.githubusercontent.com/hdering/ioBroker.aura/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/hdering/ioBroker.aura/master/admin/aura.png",
-    "type": "visualization"
-  },
-  "aurora-nowcast": {
-    "meta": "https://raw.githubusercontent.com/chrmenne/ioBroker.aurora-nowcast/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/chrmenne/ioBroker.aurora-nowcast/main/admin/aurora-nowcast.png",
-    "type": "weather"
-  },
-  "autodarts": {
-    "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.autodarts/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.autodarts/main/admin/autodarts.svg",
-    "type": "protocols"
-  },
-  "awattar": {
-    "meta": "https://raw.githubusercontent.com/sirjojo69/ioBroker.awattar/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/sirjojo69/ioBroker.awattar/master/admin/awattar.png",
-    "type": "utility"
-  },
-  "awtrix-light": {
-    "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.awtrix-light/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.awtrix-light/master/admin/awtrix-light.png",
-    "type": "iot-systems"
-  },
-  "b-control-em": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.b-control-em/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.b-control-em/master/admin/bcontrol.png",
-    "type": "energy"
-  },
-  "backitup": {
-    "meta": "https://raw.githubusercontent.com/simatec/ioBroker.backitup/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/simatec/ioBroker.backitup/master/admin/backitup.png",
-    "type": "general"
-  },
-  "bambulab": {
-    "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.bambulab/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.bambulab/main/admin/bambulab.png",
-    "type": "hardware"
-  },
-  "bascloud": {
-    "meta": "https://raw.githubusercontent.com/bascloud/ioBroker.bascloud/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/bascloud/ioBroker.bascloud/main/admin/bascloud.png",
-    "type": "communication"
-  },
-  "batrium-bms": {
-    "meta": "https://raw.githubusercontent.com/bembelstemmer/ioBroker.batrium-bms/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/bembelstemmer/ioBroker.batrium-bms/main/admin/batrium-bms.png",
-    "type": "energy"
-  },
-  "bayernluft": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.bayernluft/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.bayernluft/main/admin/bayernluft.png",
-    "type": "climate-control"
-  },
-  "beckhoff": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.beckhoff/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.beckhoff/master/admin/beckhoff.png",
-    "type": "hardware"
-  },
-  "benchmark": {
-    "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.benchmark/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/foxriver76/ioBroker.benchmark/main/admin/benchmark.png",
-    "type": "utility"
-  },
-  "benq": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.benq/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.benq/master/admin/benq.png",
-    "type": "multimedia"
-  },
-  "bestway": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.bestway/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.bestway/master/admin/bestway.png",
-    "type": "household"
-  },
-  "beszel": {
-    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.beszel/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.beszel/main/admin/beszel.svg",
-    "type": "hardware"
-  },
-  "bidirectional-counter": {
-    "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.bidirectional-counter/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.bidirectional-counter/main/admin/bidirectional-counter.png",
-    "type": "misc-data"
-  },
-  "birthdays": {
-    "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.birthdays/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.birthdays/master/admin/birthdays.png",
-    "type": "date-and-time"
-  },
-  "ble": {
-    "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.ble/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.ble/master/admin/ble.png",
-    "type": "hardware"
-  },
-  "blebox": {
-    "meta": "https://raw.githubusercontent.com/ka-vaNu/ioBroker.blebox/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ka-vaNu/ioBroker.blebox/master/admin/blebox.png",
-    "type": "iot-systems"
-  },
-  "bluelink": {
-    "meta": "https://raw.githubusercontent.com/Newan/ioBroker.bluelink/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Newan/ioBroker.bluelink/master/admin/bluelink.png",
-    "type": "vehicle"
-  },
-  "bluesound": {
-    "meta": "https://raw.githubusercontent.com/Uwe1958/ioBroker.bluesound/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Uwe1958/ioBroker.bluesound/main/admin/bluesound.png",
-    "type": "multimedia"
-  },
-  "bmw": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.bmw/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.bmw/master/admin/bmw.png",
-    "type": "vehicle"
-  },
-  "bosch-ebike": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.bosch-ebike/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.bosch-ebike/main/admin/bosch-ebike.png",
-    "type": "vehicle"
-  },
-  "boschindego": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.boschindego/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.boschindego/main/admin/boschindego.png",
-    "type": "garden"
-  },
-  "bosesoundtouch": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.bosesoundtouch/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.bosesoundtouch/master/admin/bosesoundtouch.png",
-    "type": "multimedia"
-  },
-  "botslab360": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.botslab360/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.botslab360/main/admin/botslab360.png",
-    "type": "household"
-  },
-  "botvac": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.botvac/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.botvac/master/admin/botvac.png",
-    "type": "household"
-  },
-  "brightsky": {
-    "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.brightsky/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.brightsky/main/admin/brightsky.png",
-    "type": "weather"
-  },
-  "bring": {
-    "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.bring/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/foxriver76/ioBroker.bring/master/admin/bring.png",
-    "type": "household"
-  },
-  "broadlink2": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.broadlink2/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.broadlink2/master/admin/broadlink.png",
-    "type": "iot-systems"
-  },
-  "brunner-eas3": {
-    "meta": "https://raw.githubusercontent.com/JR-Home/ioBroker.brunner-eas3/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/JR-Home/ioBroker.brunner-eas3/main/admin/brunner-eas3.png",
-    "type": "iot-systems"
-  },
-  "bsblan": {
-    "meta": "https://raw.githubusercontent.com/hacki11/ioBroker.bsblan/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/hacki11/ioBroker.bsblan/master/admin/bsblan.png",
-    "type": "climate-control"
-  },
-  "bshb": {
-    "meta": "https://raw.githubusercontent.com/holomekc/ioBroker.bshb/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/holomekc/ioBroker.bshb/master/admin/bshb-logo.jpg",
-    "type": "iot-systems"
-  },
-  "bwt": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.bwt/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.bwt/master/admin/bwt.png",
-    "type": "household"
-  },
-  "bydbatt": {
-    "meta": "https://raw.githubusercontent.com/arteck/ioBroker.bydbatt/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/arteck/ioBroker.bydbatt/master/admin/byd-batterybox.png",
-    "type": "household"
-  },
-  "bydhvs": {
-    "meta": "https://raw.githubusercontent.com/christianh17/ioBroker.bydhvs/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/christianh17/ioBroker.bydhvs/master/admin/bydhvs.png",
-    "type": "energy"
-  },
-  "calendar": {
-    "meta": "https://raw.githubusercontent.com/maxblome/ioBroker.calendar/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/maxblome/ioBroker.calendar/master/admin/calendar.png",
-    "type": "date-and-time"
-  },
-  "cameras": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.cameras/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.cameras/master/admin/cameras.png",
-    "type": "multimedia"
-  },
-  "canbus": {
-    "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.canbus/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.canbus/master/admin/canbus.png",
-    "type": "hardware"
-  },
-  "cec2": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.cec2/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.cec2/master/admin/cec2.png",
-    "type": "multimedia"
-  },
-  "chargemaster": {
-    "meta": "https://raw.githubusercontent.com/hombach/ioBroker.chargemaster/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/hombach/ioBroker.chargemaster/master/admin/chargemaster.png",
-    "type": "energy"
-  },
-  "chromecast": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.chromecast/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.chromecast/master/admin/chromecast.png",
-    "type": "multimedia"
-  },
-  "cisco-checkpresence": {
-    "meta": "https://raw.githubusercontent.com/NurPech/ioBroker.cisco-checkpresence/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/NurPech/ioBroker.cisco-checkpresence/main/admin/cisco-checkpresence.png",
-    "type": "infrastructure"
-  },
-  "cloud": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.cloud/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.cloud/master/admin/cloud.png",
-    "type": "communication"
-  },
-  "cloudflare": {
-    "meta": "https://raw.githubusercontent.com/Marco15453/ioBroker.cloudflare/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Marco15453/ioBroker.cloudflare/main/admin/cloudflare.png",
-    "type": "infrastructure"
-  },
-  "cloudless-homeconnect": {
-    "meta": "https://raw.githubusercontent.com/eifel-tech/ioBroker.cloudless-homeconnect/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/eifel-tech/ioBroker.cloudless-homeconnect/master/admin/cloudless-homeconnect.png",
-    "type": "household"
-  },
-  "cmicoe": {
-    "meta": "https://raw.githubusercontent.com/FreDeko06/ioBroker.cmicoe/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/FreDeko06/ioBroker.cmicoe/main/admin/cmicoe.png",
-    "type": "iot-systems"
-  },
-  "comfoair": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.comfoair/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.comfoair/master/admin/comfoair.png",
-    "type": "climate-control"
-  },
-  "comfoairq": {
-    "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.comfoairq/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.comfoairq/master/admin/comfoairq.png",
-    "type": "climate-control"
-  },
-  "consumption": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.consumption/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.consumption/master/admin/consumption.png",
-    "type": "logic"
-  },
-  "contact": {
-    "meta": "https://raw.githubusercontent.com/maxblome/ioBroker.contact/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/maxblome/ioBroker.contact/master/admin/contact.png",
-    "type": "misc-data"
-  },
-  "contactid": {
-    "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.contactid/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/schmupu/ioBroker.contactid/master/admin/contactid.png",
-    "type": "network"
-  },
-  "controme": {
-    "meta": "https://raw.githubusercontent.com/MadErstam/ioBroker.controme/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/MadErstam/ioBroker.controme/main/admin/controme.png",
-    "type": "climate-control"
-  },
-  "coronavirus-statistics": {
-    "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.coronavirus-statistics/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.coronavirus-statistics/main/admin/coronavirus-statistics.png",
-    "type": "health"
-  },
-  "corrently": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.corrently/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.corrently/master/admin/corrently.png",
-    "type": "misc-data"
-  },
-  "countdown": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.countdown/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.countdown/master/admin/countdown.png",
-    "type": "misc-data"
-  },
-  "cul": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.cul/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.cul/master/admin/busware.jpg",
-    "type": "iot-systems"
-  },
-  "daikin": {
-    "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.daikin/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.daikin/master/admin/daikin.jpg",
-    "type": "climate-control"
-  },
-  "daikin-cloud": {
-    "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.daikin-cloud/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.daikin-cloud/master/admin/daikin-cloud.jpg",
-    "type": "climate-control"
-  },
-  "danfoss-ally": {
-    "meta": "https://raw.githubusercontent.com/Stefan8485/ioBroker.danfoss-ally/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Stefan8485/ioBroker.danfoss-ally/main/admin/danfoss.png",
-    "type": "climate-control"
-  },
-  "daswetter": {
-    "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.daswetter/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.daswetter/master/admin/daswettercom.png",
-    "type": "weather"
-  },
-  "deconz": {
-    "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.deconz/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.deconz/master/admin/deconz.png",
-    "type": "hardware"
-  },
-  "denon": {
-    "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.denon/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/foxriver76/ioBroker.denon/master/admin/denon.png",
-    "type": "multimedia"
-  },
-  "device-reminder": {
-    "meta": "https://raw.githubusercontent.com/Xenon-s/ioBroker.device-reminder/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Xenon-s/ioBroker.device-reminder/master/admin/device-reminder.png",
-    "type": "logic"
-  },
-  "device-watcher": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.device-watcher/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.device-watcher/main/admin/device-watcher.png",
-    "type": "misc-data"
-  },
-  "devices": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.devices/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.devices/master/admin/devices.svg",
-    "type": "general"
-  },
-  "deyeidc": {
-    "meta": "https://raw.githubusercontent.com/raschy/ioBroker.deyeidc/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/raschy/ioBroker.deyeidc/main/admin/deyeidc.png",
-    "type": "energy"
-  },
-  "digitalstrom": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.digitalstrom/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.digitalstrom/master/admin/digitalstrom.png",
-    "type": "iot-systems"
-  },
-  "discord": {
-    "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.discord/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.discord/main/admin/discord.png",
-    "type": "messaging"
-  },
-  "discovergy": {
-    "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.discovergy/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.discovergy/main/admin/discovergy.png",
-    "type": "energy"
-  },
-  "discovery": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.discovery/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.discovery/master/admin/discovery.png",
-    "type": "general"
-  },
-  "divera247": {
-    "meta": "https://raw.githubusercontent.com/TKnpl/ioBroker.divera247/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TKnpl/ioBroker.divera247/main/admin/divera247.png",
-    "type": "alarm"
-  },
-  "dnscope": {
-    "meta": "https://raw.githubusercontent.com/simatec/ioBroker.dnscope/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/simatec/ioBroker.dnscope/main/admin/dnscope.png",
-    "type": "network"
-  },
-  "docker-manager": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.docker-manager/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.docker-manager/main/admin/docker-manager.svg",
-    "type": "iot-systems"
-  },
-  "doorbird": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.doorbird/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.doorbird/master/admin/doorbird.png",
-    "type": "iot-systems"
-  },
-  "doorio": {
-    "meta": "https://raw.githubusercontent.com/Bettman66/ioBroker.doorio/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Bettman66/ioBroker.doorio/master/admin/doorio.png",
-    "type": "communication"
-  },
-  "drag-indicator": {
-    "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.drag-indicator/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.drag-indicator/main/admin/drag-indicator.png",
-    "type": "misc-data"
-  },
-  "dreame": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.dreame/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.dreame/main/admin/dreame.png",
-    "type": "household"
-  },
-  "drops-weather": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.drops-weather/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.drops-weather/main/admin/drops-weather.png",
-    "type": "weather"
-  },
-  "ds18b20": {
-    "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.ds18b20/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.ds18b20/master/admin/ds18b20.png",
-    "type": "hardware"
-  },
-  "dune-hd-remote": {
-    "meta": "https://raw.githubusercontent.com/sadam6752-tech/ioBroker.dune-hd-remote/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/sadam6752-tech/ioBroker.dune-hd-remote/main/admin/dune-hd-remote.png",
-    "type": "multimedia"
-  },
-  "dwd": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.dwd/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.dwd/master/admin/dwd.png",
-    "type": "weather"
-  },
-  "dysonairpurifier": {
-    "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.dysonairpurifier/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.dysonairpurifier/main/admin/dyson_logo.svg",
-    "type": "climate-control"
-  },
-  "e3dc-rscp": {
-    "meta": "https://raw.githubusercontent.com/git-kick/ioBroker.e3dc-rscp/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/git-kick/ioBroker.e3dc-rscp/master/admin/e3dc-rscp.png",
-    "type": "energy"
-  },
-  "e3oncan": {
-    "meta": "https://raw.githubusercontent.com/MyHomeMyData/ioBroker.e3oncan/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/MyHomeMyData/ioBroker.e3oncan/main/admin/e3oncan_small.png",
-    "type": "iot-systems"
-  },
-  "easee": {
-    "meta": "https://raw.githubusercontent.com/Newan/ioBroker.easee/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Newan/ioBroker.easee/master/admin/easee.png",
-    "type": "vehicle"
-  },
-  "ebus": {
-    "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.ebus/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.ebus/master/admin/ebus.png",
-    "type": "hardware"
-  },
-  "echarts": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.echarts/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.echarts/master/admin/echarts.png",
-    "type": "visualization"
-  },
-  "ecoflow": {
-    "meta": "https://raw.githubusercontent.com/Newan/ioBroker.ecoflow/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Newan/ioBroker.ecoflow/main/admin/ecoflow.png",
-    "type": "energy"
-  },
-  "ecoflow-mqtt": {
-    "meta": "https://raw.githubusercontent.com/foxthefox/ioBroker.ecoflow-mqtt/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/foxthefox/ioBroker.ecoflow-mqtt/main/admin/ecoflow-mqtt.png",
-    "type": "iot-systems"
-  },
-  "ecovacs-deebot": {
-    "meta": "https://raw.githubusercontent.com/mrbungle64/ioBroker.ecovacs-deebot/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/mrbungle64/ioBroker.ecovacs-deebot/master/admin/ecovacs-deebot.png",
-    "type": "household"
-  },
-  "egigeozone2": {
-    "meta": "https://raw.githubusercontent.com/obakuhl/ioBroker.egigeozone2/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/obakuhl/ioBroker.egigeozone2/master/admin/egigeozone.png",
-    "type": "geoposition"
-  },
-  "ekey": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.ekey/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.ekey/master/admin/ekey.png",
-    "type": "hardware"
-  },
-  "elero-usb-transmitter": {
-    "meta": "https://raw.githubusercontent.com/marc2016/ioBroker.elero-usb-transmitter/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/marc2016/ioBroker.elero-usb-transmitter/master/admin/elero-usb-transmitter.png",
-    "type": "iot-systems"
-  },
-  "elgato-key-light": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.elgato-key-light/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.elgato-key-light/main/admin/elgato-key-light.png",
-    "type": "lighting"
-  },
-  "elv-sup2": {
-    "meta": "https://raw.githubusercontent.com/pdbjjens/ioBroker.elv-sup2/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/pdbjjens/ioBroker.elv-sup2/master/admin/elv-sup2.png",
-    "type": "multimedia"
-  },
-  "email": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.email/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.email/master/admin/email.png",
-    "type": "messaging"
-  },
-  "emby": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.emby/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.emby/master/admin/emby.png",
-    "type": "multimedia"
-  },
-  "emporia": {
-    "meta": "https://raw.githubusercontent.com/Chris-656/ioBroker.emporia/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Chris-656/ioBroker.emporia/main/admin/emporia.png",
-    "type": "energy"
-  },
-  "ems-esp": {
-    "meta": "https://raw.githubusercontent.com/tp1de/ioBroker.ems-esp/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/tp1de/ioBroker.ems-esp/main/admin/ems-esp.png",
-    "type": "climate-control"
-  },
-  "energiefluss": {
-    "meta": "https://raw.githubusercontent.com/SKB-CGN/ioBroker.energiefluss/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/SKB-CGN/ioBroker.energiefluss/main/admin/energiefluss.png",
-    "type": "visualization"
-  },
-  "energiefluss-erweitert": {
-    "meta": "https://raw.githubusercontent.com/SKB-CGN/ioBroker.energiefluss-erweitert/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/SKB-CGN/ioBroker.energiefluss-erweitert/main/admin/energiefluss-erweitert.png",
-    "type": "visualization"
-  },
-  "energy-tracker": {
-    "meta": "https://raw.githubusercontent.com/energy-tracker/ioBroker.energy-tracker/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/energy-tracker/ioBroker.energy-tracker/main/admin/energy-tracker.png",
-    "type": "iot-systems"
-  },
-  "energymanager": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.energymanager/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.energymanager/master/admin/energymanager.png",
-    "type": "energy"
-  },
-  "enet": {
-    "meta": "https://raw.githubusercontent.com/stoffel7/ioBroker.enet/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/stoffel7/ioBroker.enet/master/admin/enet.png",
-    "type": "iot-systems"
-  },
-  "enigma2": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.enigma2/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.enigma2/master/admin/enigma2.png",
-    "type": "multimedia"
-  },
-  "enocean": {
-    "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.enocean/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.enocean/master/admin/enocean.png",
-    "type": "hardware"
-  },
-  "enpal": {
-    "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.enpal/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.enpal/main/admin/enpal.svg",
-    "type": "energy"
-  },
-  "envertech-pv": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.envertech-pv/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.envertech-pv/master/admin/envertech-pv.png",
-    "type": "energy"
-  },
-  "epson_ecotank_et_2750": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.epson_ecotank_et_2750/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.epson_ecotank_et_2750/master/admin/epson_ecotank_et_2750.png",
-    "type": "infrastructure"
-  },
-  "epson_stylus_px830": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.epson_stylus_px830/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.epson_stylus_px830/master/admin/epson_stylus_px830.png",
-    "type": "infrastructure"
-  },
-  "esphome": {
-    "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.esphome/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.esphome/main/admin/esphome.png",
-    "type": "hardware"
-  },
-  "espresense": {
-    "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.espresense/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.espresense/main/admin/espresense.png",
-    "type": "geoposition"
-  },
-  "eusec": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.eusec/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.eusec/master/admin/eusec.png",
-    "type": "alarm"
-  },
-  "evcc": {
-    "meta": "https://raw.githubusercontent.com/Newan/ioBroker.evcc/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Newan/ioBroker.evcc/main/admin/evcc.png",
-    "type": "energy"
-  },
-  "eventlist": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.eventlist/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.eventlist/master/admin/eventlist.png",
-    "type": "visualization"
-  },
-  "exchangerates": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.exchangerates/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.exchangerates/master/admin/exchangerates.png",
-    "type": "misc-data"
-  },
-  "extron": {
-    "meta": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.extron/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.extron/master/admin/extron.png",
-    "type": "hardware"
-  },
-  "f1": {
-    "meta": "https://raw.githubusercontent.com/bloop16/ioBroker.f1/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/bloop16/ioBroker.f1/main/admin/f1.png",
-    "type": "misc-data"
-  },
-  "fahrplan": {
-    "meta": "https://raw.githubusercontent.com/gaudes/ioBroker.fahrplan/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/gaudes/ioBroker.fahrplan/master/admin/fahrplan.png",
-    "type": "date-and-time"
-  },
-  "fakeroku": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fakeroku/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fakeroku/master/admin/fakeroku.png",
-    "type": "multimedia"
-  },
-  "fb-checkpresence": {
-    "meta": "https://raw.githubusercontent.com/afuerhoff/ioBroker.fb-checkpresence/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/afuerhoff/ioBroker.fb-checkpresence/master/admin/fb-checkpresence.png",
-    "type": "infrastructure"
-  },
-  "feiertage": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.feiertage/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.feiertage/master/admin/feiertage.png",
-    "type": "date-and-time"
-  },
-  "fenecon": {
-    "meta": "https://raw.githubusercontent.com/sg-app/ioBroker.fenecon/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/sg-app/ioBroker.fenecon/main/admin/fenecon.png",
-    "type": "energy"
-  },
-  "fhem": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fhem/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fhem/master/admin/fhem.png",
-    "type": "iot-systems"
-  },
-  "fiat": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.fiat/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.fiat/master/admin/fiat.png",
-    "type": "vehicle"
-  },
-  "firetv": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.firetv/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.firetv/master/admin/firetv.png",
-    "type": "multimedia"
-  },
-  "fitbit-fitness": {
-    "meta": "https://raw.githubusercontent.com/Chris-656/ioBroker.fitbit-fitness/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Chris-656/ioBroker.fitbit-fitness/main/admin/fitbit-fitness.png",
-    "type": "health"
-  },
-  "flexcharts": {
-    "meta": "https://raw.githubusercontent.com/MyHomeMyData/ioBroker.flexcharts/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/MyHomeMyData/ioBroker.flexcharts/main/admin/flexcharts-icon.png",
-    "type": "visualization"
-  },
-  "flot": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.flot/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.flot/master/admin/flot.png",
-    "type": "visualization"
-  },
-  "flowers": {
-    "meta": "https://raw.githubusercontent.com/sadam6752-tech/ioBroker.flowers/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/sadam6752-tech/ioBroker.flowers/main/admin/flowers.png",
-    "type": "climate-control"
-  },
-  "followthesun": {
-    "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.followthesun/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/HGlab01/ioBroker.followthesun/main/admin/followthesun.png",
-    "type": "geoposition"
-  },
-  "foobar2000": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.foobar2000/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.foobar2000/master/admin/foobar2000.png",
-    "type": "multimedia"
-  },
-  "ford": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.ford/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.ford/master/admin/ford.png",
-    "type": "vehicle"
-  },
-  "foxesscloud": {
-    "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.foxesscloud/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.foxesscloud/main/admin/foxesscloud.png",
-    "type": "energy"
-  },
-  "freeair": {
-    "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.freeair/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.freeair/main/admin/freeair.png",
-    "type": "hardware"
-  },
-  "frigate": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.frigate/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.frigate/main/admin/frigate.png",
-    "type": "alarm"
-  },
-  "fritzbox": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fritzbox/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fritzbox/master/admin/fritzbox.png",
-    "type": "infrastructure"
-  },
-  "fritzdect": {
-    "meta": "https://raw.githubusercontent.com/foxthefox/ioBroker.fritzdect/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/foxthefox/ioBroker.fritzdect/master/admin/fritzdect_logo.png",
-    "type": "hardware"
-  },
-  "froeling": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.froeling/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.froeling/master/admin/froeling.png",
-    "type": "climate-control"
-  },
-  "fronius": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fronius/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fronius/master/admin/fronius.png",
-    "type": "energy"
-  },
-  "fronius-solarweb": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.fronius-solarweb/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.fronius-solarweb/master/admin/fronius-solarweb.png",
-    "type": "energy"
-  },
-  "fronius-wattpilot": {
-    "meta": "https://raw.githubusercontent.com/tim2zg/ioBroker.fronius-wattpilot/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/tim2zg/ioBroker.fronius-wattpilot/main/admin/fronius-wattpilot.png",
-    "type": "vehicle"
-  },
-  "frontier_silicon": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.frontier_silicon/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.frontier_silicon/master/admin/radio.png",
-    "type": "multimedia"
-  },
-  "fuelpricemonitor": {
-    "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.fuelpricemonitor/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/HGlab01/ioBroker.fuelpricemonitor/main/admin/fuelpricemonitor.png",
-    "type": "vehicle"
-  },
-  "fullcalendar": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.fullcalendar/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.fullcalendar/master/admin/fullcalendar.png",
-    "type": "date-and-time"
-  },
-  "fullybrowser": {
-    "meta": "https://raw.githubusercontent.com/arteck/ioBroker.fullybrowser/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/arteck/ioBroker.fullybrowser/master/admin/fully.png",
-    "type": "utility"
-  },
-  "fyta": {
-    "meta": "https://raw.githubusercontent.com/muffin142/ioBroker.fyta/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/muffin142/ioBroker.fyta/main/admin/fyta.png",
-    "type": "garden"
-  },
-  "g-homa": {
-    "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.g-homa/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.g-homa/master/admin/g-homa.png",
-    "type": "iot-systems"
-  },
-  "garmin": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.garmin/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.garmin/main/admin/garmin.png",
-    "type": "health"
-  },
-  "geofency": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.geofency/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.geofency/master/admin/geofency.png",
-    "type": "geoposition"
-  },
-  "gira-iot": {
-    "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.gira-iot/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.gira-iot/master/admin/gira-iot.png",
-    "type": "iot-systems"
-  },
-  "go-e": {
-    "meta": "https://raw.githubusercontent.com/MK-2001/ioBroker.go-e/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/MK-2001/ioBroker.go-e/main/admin/go-echarger.png",
-    "type": "vehicle"
-  },
-  "google-sharedlocations2": {
-    "meta": "https://raw.githubusercontent.com/Garfonso/ioBroker.google-sharedlocations2/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Garfonso/ioBroker.google-sharedlocations2/main/admin/google-sharedlocations2.png",
-    "type": "geoposition"
-  },
-  "google-spreadsheet": {
-    "meta": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.google-spreadsheet/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.google-spreadsheet/main/admin/google-spreadsheet.png",
-    "type": "storage"
-  },
-  "googleauth": {
-    "meta": "https://raw.githubusercontent.com/Vertumnus/ioBroker.googleauth/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Vertumnus/ioBroker.googleauth/master/admin/logo-google.svg",
-    "type": "utility"
-  },
-  "gotify": {
-    "meta": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.gotify/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.gotify/main/admin/gotify.png",
-    "type": "messaging"
-  },
-  "gotify-ws": {
-    "meta": "https://raw.githubusercontent.com/simatec/ioBroker.gotify-ws/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/simatec/ioBroker.gotify-ws/master/admin/gotify-ws.png",
-    "type": "messaging"
-  },
-  "govee-local": {
-    "meta": "https://raw.githubusercontent.com/boergegrunicke/ioBroker.govee-local/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/boergegrunicke/ioBroker.govee-local/main/admin/govee-local.png",
-    "type": "lighting"
-  },
-  "govee-smart": {
-    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.govee-smart/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.govee-smart/main/admin/govee-smart.svg",
-    "type": "lighting"
-  },
-  "gree-hvac": {
-    "meta": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/admin/air-conditioner.png",
-    "type": "climate-control"
-  },
-  "grohe-smarthome": {
-    "meta": "https://raw.githubusercontent.com/patricknitsch/ioBroker.grohe-smarthome/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/patricknitsch/ioBroker.grohe-smarthome/main/admin/grohe-smarthome.png",
-    "type": "metering"
-  },
-  "growatt": {
-    "meta": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/PLCHome/ioBroker.growatt/master/admin/growatt.png",
-    "type": "energy"
-  },
-  "gruenbeck": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.gruenbeck/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.gruenbeck/master/admin/gruenbeck.png",
-    "type": "household"
-  },
-  "gsmsms": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.gsmsms/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.gsmsms/main/admin/gsmsms.png",
-    "type": "messaging"
-  },
-  "haassohn": {
-    "meta": "https://raw.githubusercontent.com/marvingrieger/ioBroker.haassohn/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/marvingrieger/ioBroker.haassohn/master/admin/haassohn.png",
-    "type": "iot-systems"
-  },
-  "habpanel": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.habpanel/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.habpanel/master/admin/habpanel.png",
-    "type": "visualization"
-  },
-  "hagelschutz-vkf": {
-    "meta": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.hagelschutz-vkf/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.hagelschutz-vkf/main/admin/hagelschutz-vkf.jpg",
-    "type": "weather"
-  },
-  "haier": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.haier/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.haier/master/admin/haier.png",
-    "type": "climate-control"
-  },
-  "ham": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.ham/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.ham/master/admin/ham.png",
-    "type": "iot-systems"
-  },
-  "ham-wemo": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.ham-wemo/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.ham-wemo/master/admin/ham-wemo.png",
-    "type": "iot-systems"
-  },
-  "harmony": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.harmony/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.harmony/master/admin/harmony.png",
-    "type": "multimedia"
-  },
-  "hass": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.hass/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.hass/master/admin/hass.png",
-    "type": "iot-systems"
-  },
-  "hass-mqtt": {
-    "meta": "https://raw.githubusercontent.com/smarthomefans/ioBroker.hass-mqtt/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/smarthomefans/ioBroker.hass-mqtt/master/admin/hass-mqtt.png",
-    "type": "iot-systems"
-  },
-  "hassemu": {
-    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.hassemu/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.hassemu/main/admin/hassemu.svg",
-    "type": "infrastructure"
-  },
-  "hausbus_de": {
-    "meta": "https://raw.githubusercontent.com/hausbus/ioBroker.hausbus_de/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/hausbus/ioBroker.hausbus_de/main/admin/hausbusde.png",
-    "type": "iot-systems"
-  },
-  "hdg-bavaria": {
-    "meta": "https://raw.githubusercontent.com/stemaker/ioBroker.hdg-bavaria/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/stemaker/ioBroker.hdg-bavaria/master/admin/hdg-bavaria.png",
-    "type": "climate-control"
-  },
-  "heatingcontrol": {
-    "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.heatingcontrol/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.heatingcontrol/master/admin/heatingcontrol.png",
-    "type": "climate-control"
-  },
-  "heizoel": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.heizoel/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.heizoel/master/admin/heizoel.png",
-    "type": "misc-data"
-  },
-  "heizoel24-mex": {
-    "meta": "https://raw.githubusercontent.com/ltspicer/ioBroker.heizoel24-mex/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ltspicer/ioBroker.heizoel24-mex/main/admin/heizoel24-mex.png",
-    "type": "metering"
-  },
-  "heizungssteuerung": {
-    "meta": "https://raw.githubusercontent.com/jbeenenga/ioBroker.heizungssteuerung/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/jbeenenga/ioBroker.heizungssteuerung/main/admin/heizungssteuerung.png",
-    "type": "climate-control"
-  },
-  "hekr": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.hekr/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.hekr/master/admin/hekr.png",
-    "type": "household"
-  },
-  "helios": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.helios/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.helios/master/admin/helios.png",
-    "type": "climate-control"
-  },
-  "heos": {
-    "meta": "https://raw.githubusercontent.com/withstu/ioBroker.heos/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/withstu/ioBroker.heos/main/admin/heos.png",
-    "type": "multimedia"
-  },
-  "heytech": {
-    "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.heytech/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.heytech/master/admin/heytech.png",
-    "type": "hardware"
-  },
-  "hid-community": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.hid-community/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.hid-community/master/admin/hid.png",
-    "type": "utility"
-  },
-  "hikvision-alarmserver": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.hikvision-alarmserver/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.hikvision-alarmserver/main/admin/hikvision-alarmserver.png",
-    "type": "alarm"
-  },
-  "hiob": {
-    "meta": "https://raw.githubusercontent.com/moba15/ioBroker.hiob/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/moba15/ioBroker.hiob/main/admin/hiob.png",
-    "type": "visualization"
-  },
-  "history": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.history/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.history/master/admin/history.png",
-    "type": "storage"
-  },
-  "hm-rega": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.hm-rega/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.hm-rega/master/admin/homematic.png",
-    "type": "iot-systems"
-  },
-  "hm-rpc": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.hm-rpc/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.hm-rpc/master/admin/homematic.png",
-    "type": "iot-systems"
-  },
-  "hmip": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.hmip/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.hmip/master/admin/homematic.png",
-    "type": "hardware"
-  },
-  "homeconnect": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.homeconnect/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.homeconnect/master/admin/homeconnect.png",
-    "type": "household"
-  },
-  "homee": {
-    "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.homee/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.homee/master/admin/homee.png",
-    "type": "iot-systems"
-  },
-  "homekit-controller": {
-    "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.homekit-controller/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.homekit-controller/main/admin/homekit-controller.png",
-    "type": "iot-systems"
-  },
-  "homenet": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.homenet/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.homenet/main/admin/homenet.png",
-    "type": "household"
-  },
-  "homepilot": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.homepilot/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.homepilot/master/admin/homepilot.png",
-    "type": "iot-systems"
-  },
-  "homewizard": {
-    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.homewizard/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.homewizard/main/admin/homewizard.svg",
-    "type": "energy"
-  },
-  "hoover": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.hoover/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.hoover/main/admin/hoover.png",
-    "type": "household"
-  },
-  "hoymiles": {
-    "meta": "https://raw.githubusercontent.com/Eistee82/ioBroker.hoymiles/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Eistee82/ioBroker.hoymiles/main/admin/hoymiles.png",
-    "type": "energy"
-  },
-  "hoymiles-ms": {
-    "meta": "https://raw.githubusercontent.com/mcm4iob/ioBroker.hoymiles-ms/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/mcm4iob/ioBroker.hoymiles-ms/main/admin/hoymiles-ms.png",
-    "type": "hardware"
-  },
-  "hp-ilo": {
-    "meta": "https://raw.githubusercontent.com/SebastianSchultz/ioBroker.hp-ilo/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/SebastianSchultz/ioBroker.hp-ilo/master/admin/hp-ilo.png",
-    "type": "hardware"
-  },
-  "hs100": {
-    "meta": "https://raw.githubusercontent.com/arteck/ioBroker.hs100/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/arteck/ioBroker.hs100/master/admin/hs100.png",
-    "type": "hardware"
-  },
-  "hue": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.hue/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.hue/master/admin/hue.jpeg",
-    "type": "lighting"
-  },
-  "hue-sync-box": {
-    "meta": "https://raw.githubusercontent.com/xXBJXx/ioBroker.hue-sync-box/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/xXBJXx/ioBroker.hue-sync-box/main/admin/hueSyncBox.png",
-    "type": "lighting"
-  },
-  "hueemu": {
-    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.hueemu/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.hueemu/main/admin/hue-emu-logo.svg",
-    "type": "lighting"
-  },
-  "huum-sauna": {
-    "meta": "https://raw.githubusercontent.com/Chris-656/ioBroker.huum-sauna/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Chris-656/ioBroker.huum-sauna/main/admin/huum-sauna.png",
-    "type": "climate-control"
-  },
-  "hydrawise": {
-    "meta": "https://raw.githubusercontent.com/SentiQ/ioBroker.hydrawise/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/SentiQ/ioBroker.hydrawise/main/admin/hydrawise.jpg",
-    "type": "garden"
-  },
-  "hydrop": {
-    "meta": "https://raw.githubusercontent.com/simatec/ioBroker.hydrop/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/simatec/ioBroker.hydrop/main/admin/hydrop.png",
-    "type": "metering"
-  },
-  "hyperion-connector": {
-    "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.hyperion-connector/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.hyperion-connector/main/admin/hyperion-connector.png",
-    "type": "lighting"
-  },
-  "hyperion_ng": {
-    "meta": "https://raw.githubusercontent.com/felixganzer/ioBroker.hyperion_ng/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/felixganzer/ioBroker.hyperion_ng/master/admin/hyperion_ng.png",
-    "type": "lighting"
-  },
-  "i2c": {
-    "meta": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.i2c/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.i2c/master/admin/i2c.png",
-    "type": "hardware"
-  },
-  "ical": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ical/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ical/master/admin/ical.png",
-    "type": "date-and-time"
-  },
-  "iceroad": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.iceroad/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.iceroad/main/admin/iceroad.png",
-    "type": "weather"
-  },
-  "icloud": {
-    "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.icloud/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.icloud/main/admin/icloud.png",
-    "type": "misc-data"
-  },
-  "ico-cloud": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ico-cloud/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ico-cloud/main/admin/ico-cloud.png",
-    "type": "metering"
-  },
-  "icons-addictive-flavour-png": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-addictive-flavour-png/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-addictive-flavour-png/master/admin/icons-addictive-flavour-png.png",
-    "type": "visualization-icons"
-  },
-  "icons-eclipse-smarthome-classic": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.icons-eclipse-smarthome-classic/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.icons-eclipse-smarthome-classic/main/admin/icons-eclipse-smarthome-classic.png",
-    "type": "visualization-icons"
-  },
-  "icons-fatcow-hosting": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-fatcow-hosting/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-fatcow-hosting/master/admin/icons-fatcow-hosting.png",
-    "type": "visualization-icons"
-  },
-  "icons-freepic": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.icons-freepic/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.icons-freepic/main/admin/icons-freepic.png",
-    "type": "visualization-icons"
-  },
-  "icons-icons8": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-icons8/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-icons8/master/admin/icons8.png",
-    "type": "visualization-icons"
-  },
-  "icons-material-png": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-material-png/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-material-png/master/admin/icons-material-png.png",
-    "type": "visualization-icons"
-  },
-  "icons-material-svg": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-material-svg/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-material-svg/master/admin/icons-material-svg.png",
-    "type": "visualization-icons"
-  },
-  "icons-mfd-png": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-mfd-png/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-mfd-png/master/admin/icons-mfd-png.png",
-    "type": "visualization-icons"
-  },
-  "icons-mfd-svg": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-mfd-svg/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-mfd-svg/master/admin/icons-mfd-svg.png",
-    "type": "visualization-icons"
-  },
-  "icons-open-icon-library-png": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-open-icon-library-png/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-open-icon-library-png/master/admin/icons-open-icon-library-png.png",
-    "type": "visualization-icons"
-  },
-  "icons-smarthome": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.icons-smarthome/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.icons-smarthome/main/admin/icons-smarthome.png",
-    "type": "visualization-icons"
-  },
-  "icons-ultimate-png": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-ultimate-png/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-ultimate-png/master/admin/icons-ultimate-png.png",
-    "type": "visualization-icons"
-  },
-  "ikettle2": {
-    "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.ikettle2/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.ikettle2/master/admin/ikettle2.png",
-    "type": "household"
-  },
-  "imap": {
-    "meta": "https://raw.githubusercontent.com/Lucky-ESA/ioBroker.imap/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Lucky-ESA/ioBroker.imap/master/admin/imap.png",
-    "type": "messaging"
-  },
-  "imow": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.imow/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.imow/main/admin/imow.png",
-    "type": "garden"
-  },
-  "influxdb": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.influxdb/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.influxdb/master/admin/influxdb.png",
-    "type": "storage"
-  },
-  "influxdb-prologger": {
-    "meta": "https://raw.githubusercontent.com/simpros/ioBroker.influxdb-prologger/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/simpros/ioBroker.influxdb-prologger/main/admin/influxdb-prologger.png",
-    "type": "storage"
-  },
-  "innogy-smarthome": {
-    "meta": "https://raw.githubusercontent.com/PArns/ioBroker.innogy-smarthome/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/PArns/ioBroker.innogy-smarthome/master/admin/innogy-smarthome.png",
-    "type": "iot-systems"
-  },
-  "innoxel": {
-    "meta": "https://raw.githubusercontent.com/matthsc/ioBroker.innoxel/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/matthsc/ioBroker.innoxel/main/admin/innoxel.png",
-    "type": "iot-systems"
-  },
-  "intesishome": {
-    "meta": "https://raw.githubusercontent.com/maxtox/ioBroker.intesishome/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/maxtox/ioBroker.intesishome/master/admin/intesishome.png",
-    "type": "climate-control"
-  },
-  "intex": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.intex/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.intex/master/admin/intex.png",
-    "type": "household"
-  },
-  "iopooleco": {
-    "meta": "https://raw.githubusercontent.com/mule1972/ioBroker.iopooleco/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/mule1972/ioBroker.iopooleco/main/admin/iopooleco.png",
-    "type": "metering"
-  },
-  "iot": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.iot/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.iot/master/admin/iot.png",
-    "type": "communication"
-  },
-  "iqontrol": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.iqontrol/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.iqontrol/master/admin/iqontrol.png",
-    "type": "visualization"
-  },
-  "jablotron": {
-    "meta": "https://raw.githubusercontent.com/DEV2DEV-DE/ioBroker.jablotron/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/DEV2DEV-DE/ioBroker.jablotron/main/admin/jablotron.png",
-    "type": "alarm"
-  },
-  "janitza-gridvis": {
-    "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.janitza-gridvis/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.janitza-gridvis/main/admin/janitza-gridvis.png",
-    "type": "energy"
-  },
-  "jarvis": {
-    "meta": "https://raw.githubusercontent.com/Zefau/ioBroker.jarvis/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Zefau/ioBroker.jarvis/master/admin/jarvis.png",
-    "type": "visualization"
-  },
-  "javascript": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.javascript/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.javascript/master/admin/javascript.png",
-    "type": "logic"
-  },
-  "jeelink": {
-    "meta": "https://raw.githubusercontent.com/foxthefox/ioBroker.jeelink/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/foxthefox/ioBroker.jeelink/master/admin/jeelab_logo.png",
-    "type": "hardware"
-  },
-  "js-controller": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.js-controller/master/packages/controller/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.js-controller/master/iobroker.png",
-    "type": "general"
-  },
-  "judoisoft": {
-    "meta": "https://raw.githubusercontent.com/arteck/ioBroker.judoisoft/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/arteck/ioBroker.judoisoft/master/admin/judo.png",
-    "type": "household"
-  },
-  "kecontact": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.kecontact/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.kecontact/master/admin/kecontact.png",
-    "type": "hardware"
-  },
-  "kisshome-defender": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.kisshome-defender/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.kisshome-defender/main/admin/kisshome-defender.svg",
-    "type": "utility"
-  },
-  "klf200": {
-    "meta": "https://raw.githubusercontent.com/MiSchroe/ioBroker.klf200/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/MiSchroe/ioBroker.klf200/master/admin/klf200.png",
-    "type": "hardware"
-  },
-  "knmi-weather": {
-    "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.knmi-weather/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.knmi-weather/main/admin/knmi-weather.png",
-    "type": "weather"
-  },
-  "knx": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.knx/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.knx/master/admin/knx.png",
-    "type": "iot-systems"
-  },
-  "kodi": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.kodi/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.kodi/master/admin/kodi.png",
-    "type": "multimedia"
-  },
-  "kostal-piko-ba": {
-    "meta": "https://raw.githubusercontent.com/hombach/ioBroker.kostal-piko-ba/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/hombach/ioBroker.kostal-piko-ba/master/admin/picoba.png",
-    "type": "energy"
-  },
-  "lametric": {
-    "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.lametric/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.lametric/master/admin/lametric.png",
-    "type": "hardware"
-  },
-  "lcn": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.lcn/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.lcn/master/admin/lcn.png",
-    "type": "iot-systems"
-  },
-  "legrand-ecocompteur": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.legrand-ecocompteur/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.legrand-ecocompteur/master/admin/legrand-ecocompteur.png",
-    "type": "energy"
-  },
-  "letrika_comgw": {
-    "meta": "https://raw.githubusercontent.com/AWhiteKnight/ioBroker.letrika_comgw/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/AWhiteKnight/ioBroker.letrika_comgw/master/admin/letrika_comgw.png",
-    "type": "energy"
-  },
-  "lg-ess-home": {
-    "meta": "https://raw.githubusercontent.com/Morluktom/ioBroker.lg-ess-home/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Morluktom/ioBroker.lg-ess-home/master/admin/lg-ess-home.png",
-    "type": "energy"
-  },
-  "lg-thinq": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.lg-thinq/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.lg-thinq/master/admin/lg-thinq.png",
-    "type": "household"
-  },
-  "lgtv": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.lgtv/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.lgtv/master/admin/lgtv.png",
-    "type": "multimedia"
-  },
-  "lgtv-rs": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.lgtv-rs/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.lgtv-rs/master/admin/lg.png",
-    "type": "multimedia"
-  },
-  "lgtv11": {
-    "meta": "https://raw.githubusercontent.com/SebastianSchultz/ioBroker.lgtv11/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/SebastianSchultz/ioBroker.lgtv11/master/admin/lgtv2011.png",
-    "type": "multimedia"
-  },
-  "libre": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.libre/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.libre/main/admin/libre.png",
-    "type": "health"
-  },
-  "life360ng": {
-    "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.life360ng/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.life360ng/main/admin/Life360_s.svg",
-    "type": "geoposition"
-  },
-  "lifx": {
-    "meta": "https://raw.githubusercontent.com/foxthefox/ioBroker.lifx/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/foxthefox/ioBroker.lifx/master/admin/lifx_logo.png",
-    "type": "lighting"
-  },
-  "lightcontrol": {
-    "meta": "https://raw.githubusercontent.com/Schmakus/ioBroker.lightcontrol/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Schmakus/ioBroker.lightcontrol/main/admin/lightcontrol.png",
-    "type": "lighting"
-  },
-  "lightify": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.lightify/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.lightify/master/admin/lightify.png",
-    "type": "lighting"
-  },
-  "link": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.link/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.link/master/admin/link.png",
-    "type": "communication"
-  },
-  "link2home": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.link2home/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.link2home/main/admin/link2home.png",
-    "type": "iot-systems"
-  },
-  "linkeddevices": {
-    "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.linkeddevices/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.linkeddevices/master/admin/linkeddevices.png",
-    "type": "logic"
-  },
-  "linktap": {
-    "meta": "https://raw.githubusercontent.com/Smart-Gang/ioBroker.linktap/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Smart-Gang/ioBroker.linktap/master/admin/LinkTap_Logo.png",
-    "type": "garden"
-  },
-  "linky": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.linky/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.linky/main/admin/linky.png",
-    "type": "energy"
-  },
-  "linux-control": {
-    "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.linux-control/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.linux-control/master/admin/linux-control.png",
-    "type": "hardware"
-  },
-  "logparser": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.logparser/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.logparser/master/admin/logparser.png",
-    "type": "logic"
-  },
-  "loqed": {
-    "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.loqed/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/foxriver76/ioBroker.loqed/main/admin/loqed.png",
-    "type": "hardware"
-  },
-  "lorawan": {
-    "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lorawan/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lorawan/main/admin/lorawan.png",
-    "type": "protocols"
-  },
-  "lovelace": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.lovelace/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.lovelace/master/admin/lovelace.png",
-    "type": "visualization"
-  },
-  "lowpass-filter": {
-    "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lowpass-filter/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lowpass-filter/main/admin/lowpass-filter.png",
-    "type": "misc-data"
-  },
-  "loxone": {
-    "meta": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.loxone/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.loxone/master/admin/loxone.png",
-    "type": "iot-systems"
-  },
-  "luftdaten": {
-    "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.luftdaten/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.luftdaten/master/admin/luftdaten.png",
-    "type": "weather"
-  },
-  "lupusec": {
-    "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.lupusec/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/schmupu/ioBroker.lupusec/master/admin/lupusec.png",
-    "type": "alarm"
-  },
-  "luxtronik1": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.luxtronik1/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.luxtronik1/master/admin/luxtronik1.png",
-    "type": "climate-control"
-  },
-  "luxtronik2": {
-    "meta": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.luxtronik2/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.luxtronik2/master/admin/luxtronik2.png",
-    "type": "climate-control"
-  },
-  "material": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.material/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.material/master/admin/material.png",
-    "type": "visualization"
-  },
-  "matrix-org": {
-    "meta": "https://raw.githubusercontent.com/oelison/ioBroker.matrix-org/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/oelison/ioBroker.matrix-org/main/admin/matrix-logo.png",
-    "type": "messaging"
-  },
-  "matter": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.matter/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.matter/main/admin/matter.png",
-    "type": "iot-systems"
-  },
-  "maveo": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.maveo/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.maveo/master/admin/maveo.png",
-    "type": "household"
-  },
-  "maxcube": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.maxcube/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.maxcube/master/admin/maxcube.png",
-    "type": "climate-control"
-  },
-  "maxcul": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.maxcul/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.maxcul/master/admin/maxcul.png",
-    "type": "iot-systems"
-  },
-  "maxxi-charge": {
-    "meta": "https://raw.githubusercontent.com/blabond/ioBroker.maxxi-charge/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/blabond/ioBroker.maxxi-charge/main/admin/maxxi-charge.png",
-    "type": "energy"
-  },
-  "mbus": {
-    "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.mbus/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.mbus/master/admin/mbus.png",
-    "type": "energy"
-  },
-  "mcdu": {
-    "meta": "https://raw.githubusercontent.com/Flixhummel/ioBroker.mcdu/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Flixhummel/ioBroker.mcdu/main/admin/mcdu.png",
-    "type": "hardware"
-  },
-  "mclighting": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mclighting/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mclighting/master/admin/mclighting.png",
-    "type": "lighting"
-  },
-  "mcp": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.mcp/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.mcp/main/admin/mcp.png",
-    "type": "utility"
-  },
-  "meater": {
-    "meta": "https://raw.githubusercontent.com/Standarduser/ioBroker.meater/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Standarduser/ioBroker.meater/main/admin/meater.png",
-    "type": "household"
-  },
-  "mediola-gateway": {
-    "meta": "https://raw.githubusercontent.com/oelison/ioBroker.mediola-gateway/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/oelison/ioBroker.mediola-gateway/main/admin/mediola-gateway.png",
-    "type": "multimedia"
-  },
-  "megad": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.megad/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.megad/master/admin/megad.png",
-    "type": "hardware"
-  },
-  "melcloud": {
-    "meta": "https://raw.githubusercontent.com/Black-Thunder/ioBroker.melcloud/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Black-Thunder/ioBroker.melcloud/master/admin/melcloud.png",
-    "type": "climate-control"
-  },
-  "mempool-space": {
-    "meta": "https://raw.githubusercontent.com/Hans-Wurst-21/ioBroker.mempool-space/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Hans-Wurst-21/ioBroker.mempool-space/main/admin/mempool-space.png",
-    "type": "infrastructure"
-  },
-  "mercedesme": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.mercedesme/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.mercedesme/master/admin/mercedesme.png",
-    "type": "vehicle"
-  },
-  "mercury": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mercury/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mercury/master/admin/mercury.png",
-    "type": "energy"
-  },
-  "meross": {
-    "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.meross/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.meross/master/admin/meross.png",
-    "type": "iot-systems"
-  },
-  "message-queue": {
-    "meta": "https://raw.githubusercontent.com/MK-2001/ioBroker.message-queue/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/MK-2001/ioBroker.message-queue/main/admin/message-queue.png",
-    "type": "communication"
-  },
-  "meteoalarm": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.meteoalarm/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.meteoalarm/master/admin/meteoalarm.png",
-    "type": "weather"
-  },
-  "meteoswiss": {
-    "meta": "https://raw.githubusercontent.com/deMynchi/ioBroker.meteoswiss/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/deMynchi/ioBroker.meteoswiss/master/admin/meteoswiss.png",
-    "type": "weather"
-  },
-  "mhi-wfrac": {
-    "meta": "https://raw.githubusercontent.com/hacki11/ioBroker.mhi-wfrac/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/hacki11/ioBroker.mhi-wfrac/main/admin/mhi-wfrac.png",
-    "type": "climate-control"
-  },
-  "micronova": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.micronova/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.micronova/main/admin/micronova.png",
-    "type": "climate-control"
-  },
-  "midea": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.midea/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.midea/master/admin/midea.png",
-    "type": "climate-control"
-  },
-  "miele": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.miele/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.miele/master/admin/xmiele.png",
-    "type": "household"
-  },
-  "mielecloudservice": {
-    "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.mielecloudservice/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.mielecloudservice/master/admin/mielecloudservice.svg",
-    "type": "household"
-  },
-  "mihome": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.mihome/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.mihome/master/admin/mihome.png",
-    "type": "iot-systems"
-  },
-  "mihome-airpurifier": {
-    "meta": "https://raw.githubusercontent.com/JoJ123/ioBroker.mihome-airpurifier/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/JoJ123/ioBroker.mihome-airpurifier/master/admin/mihome-airpurifier.png",
-    "type": "climate-control"
-  },
-  "mihome-cloud": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.mihome-cloud/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.mihome-cloud/main/admin/mihome-cloud.png",
-    "type": "iot-systems"
-  },
-  "mihome-plug": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mihome-plug/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mihome-plug/master/admin/mihome-plug.png",
-    "type": "hardware"
-  },
-  "mihome-vacuum": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mihome-vacuum/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mihome-vacuum/master/admin/mihome-vacuum.png",
-    "type": "household"
-  },
-  "miio": {
-    "meta": "https://raw.githubusercontent.com/smarthomefans/ioBroker.miio/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/smarthomefans/ioBroker.miio/master/admin/miio.png",
-    "type": "iot-systems"
-  },
-  "mikrotik": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mikrotik/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mikrotik/master/admin/mikrotik.png",
-    "type": "hardware"
-  },
-  "milight": {
-    "meta": "https://raw.githubusercontent.com/foxthefox/ioBroker.milight/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/foxthefox/ioBroker.milight/master/admin/easybulb_logo.png",
-    "type": "lighting"
-  },
-  "milight-smart-light": {
-    "meta": "https://raw.githubusercontent.com/Steiger04/ioBroker.milight-smart-light/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Steiger04/ioBroker.milight-smart-light/master/admin/milight-smart-light.png",
-    "type": "lighting"
-  },
-  "miner": {
-    "meta": "https://raw.githubusercontent.com/SimonFischer04/ioBroker.miner/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/SimonFischer04/ioBroker.miner/main/admin/miner.png",
-    "type": "hardware"
-  },
-  "minuaru": {
-    "meta": "https://raw.githubusercontent.com/minukodu/ioBroker.minuaru/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/minukodu/ioBroker.minuaru/main/admin/minuaru.png",
-    "type": "misc-data"
-  },
-  "minuvis": {
-    "meta": "https://raw.githubusercontent.com/minukodu/ioBroker.minuvis/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/minukodu/ioBroker.minuvis/master/admin/minuvis.png",
-    "type": "visualization"
-  },
-  "mitsubishi-local-control": {
-    "meta": "https://raw.githubusercontent.com/Black-Thunder/ioBroker.mitsubishi-local-control/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Black-Thunder/ioBroker.mitsubishi-local-control/main/admin/mitsubishi-local-control.png",
-    "type": "climate-control"
-  },
-  "mobile": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.mobile/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.mobile/master/admin/mobile.png",
-    "type": "visualization"
-  },
-  "modbus": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.modbus/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.modbus/master/admin/modbus.png",
-    "type": "protocols"
-  },
-  "moma": {
-    "meta": "https://raw.githubusercontent.com/AWhiteKnight/ioBroker.moma/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/AWhiteKnight/ioBroker.moma/master/admin/moma.png",
-    "type": "general"
-  },
-  "mpd": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mpd/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mpd/master/admin/mpd.png",
-    "type": "multimedia"
-  },
-  "mqtt": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.mqtt/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.mqtt/master/admin/mqtt.png",
-    "type": "protocols"
-  },
-  "mqtt-client": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mqtt-client/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mqtt-client/master/admin/mqtt-client.png",
-    "type": "protocols"
-  },
-  "mspa": {
-    "meta": "https://raw.githubusercontent.com/arteck/ioBroker.mspa/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/arteck/ioBroker.mspa/main/admin/mspa.png",
-    "type": "climate-control"
-  },
-  "multicast": {
-    "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.multicast/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.multicast/main/admin/multicast.png",
-    "type": "network"
-  },
-  "musiccast": {
-    "meta": "https://raw.githubusercontent.com/foxthefox/ioBroker.musiccast/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/foxthefox/ioBroker.musiccast/master/admin/musiccast.png",
-    "type": "multimedia"
-  },
-  "mydlink": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mydlink/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.mydlink/master/admin/mydlink.png",
-    "type": "iot-systems"
-  },
-  "myenergi": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.myenergi/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.myenergi/main/admin/myenergi.png",
-    "type": "energy"
-  },
-  "myq": {
-    "meta": "https://raw.githubusercontent.com/pixcept/ioBroker.myq/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/pixcept/ioBroker.myq/master/admin/myq.png",
-    "type": "iot-systems"
-  },
-  "mysensors": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.mysensors/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.mysensors/master/admin/mysensors.png",
-    "type": "iot-systems"
-  },
-  "mystrom": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.mystrom/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.mystrom/master/admin/mystrom.png",
-    "type": "iot-systems"
-  },
-  "mytime": {
-    "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.mytime/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.mytime/main/admin/mytime.png",
-    "type": "visualization"
-  },
-  "myuplink": {
-    "meta": "https://raw.githubusercontent.com/sebilm/ioBroker.myuplink/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/sebilm/ioBroker.myuplink/main/admin/myuplink.png",
-    "type": "climate-control"
-  },
-  "myvbus": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.myvbus/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.myvbus/master/admin/myvbus.png",
-    "type": "climate-control"
-  },
-  "mywallbox": {
-    "meta": "https://raw.githubusercontent.com/SKB-CGN/ioBroker.mywallbox/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/SKB-CGN/ioBroker.mywallbox/main/admin/wallbox.png",
-    "type": "hardware"
-  },
-  "n8n": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.n8n/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.n8n/main/admin/n8n.svg",
-    "type": "logic"
-  },
-  "nanoleaf-lightpanels": {
-    "meta": "https://raw.githubusercontent.com/daniel-2k/ioBroker.nanoleaf-lightpanels/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/daniel-2k/ioBroker.nanoleaf-lightpanels/master/admin/nanoleaf-lightpanels.png",
-    "type": "lighting"
-  },
-  "net-tools": {
-    "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.net-tools/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.net-tools/master/admin/net-tools.png",
-    "type": "network"
-  },
-  "netatmo": {
-    "meta": "https://raw.githubusercontent.com/PArns/ioBroker.netatmo/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/PArns/ioBroker.netatmo/master/admin/netatmo.png",
-    "type": "weather"
-  },
-  "netatmo-crawler": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.netatmo-crawler/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.netatmo-crawler/master/admin/netatmo-crawler.png",
-    "type": "weather"
-  },
-  "netatmo-energy": {
-    "meta": "https://raw.githubusercontent.com/Homemade-Disaster/ioBroker.netatmo-energy/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Homemade-Disaster/ioBroker.netatmo-energy/master/admin/netatmo-energy.png",
-    "type": "climate-control"
-  },
-  "netro": {
-    "meta": "https://raw.githubusercontent.com/realhawker/ioBroker.netro/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/realhawker/ioBroker.netro/master/admin/netro.png",
-    "type": "garden"
-  },
-  "nextcloud-monitoring": {
-    "meta": "https://raw.githubusercontent.com/H5N1v2/ioBroker.nextcloud-monitoring/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/H5N1v2/ioBroker.nextcloud-monitoring/main/admin/nextcloud_monitoring.png",
-    "type": "network"
-  },
-  "nextcloudtalk": {
-    "meta": "https://raw.githubusercontent.com/Rello/ioBroker.nextcloudtalk/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Rello/ioBroker.nextcloudtalk/main/admin/nextcloud.png",
-    "type": "messaging"
-  },
-  "nina": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.nina/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.nina/master/admin/nina.png",
-    "type": "misc-data"
-  },
-  "nissan": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.nissan/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.nissan/master/admin/nissan.png",
-    "type": "vehicle"
-  },
-  "niu": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.niu/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.niu/main/admin/niu.png",
-    "type": "vehicle"
-  },
-  "nmea": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.nmea/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.nmea/main/admin/nmea.png",
-    "type": "protocols"
-  },
-  "node-red": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.node-red/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.node-red/master/admin/node-red.png",
-    "type": "logic"
-  },
-  "noolitef": {
-    "meta": "https://raw.githubusercontent.com/paveltsytovich/ioBroker.noolitef/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/paveltsytovich/ioBroker.noolitef/master/admin/noolitef.png",
-    "type": "hardware"
-  },
-  "notification-manager": {
-    "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.notification-manager/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/foxriver76/ioBroker.notification-manager/main/admin/notification-manager.png",
-    "type": "utility"
-  },
-  "notificationforandroidtv": {
-    "meta": "https://raw.githubusercontent.com/DNAngelX/ioBroker.notificationforandroidtv/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/DNAngelX/ioBroker.notificationforandroidtv/main/admin/notificationforandroidtv.png",
-    "type": "messaging"
-  },
-  "nsclient": {
-    "meta": "https://raw.githubusercontent.com/mcm4iob/ioBroker.nsclient/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/mcm4iob/ioBroker.nsclient/master/admin/nsclient.png",
-    "type": "infrastructure"
-  },
-  "nspanel-lovelace-ui": {
-    "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.nspanel-lovelace-ui/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.nspanel-lovelace-ui/main/admin/nspanel-lovelace-ui.png",
-    "type": "hardware"
-  },
-  "ntfy-client": {
-    "meta": "https://raw.githubusercontent.com/lubepi/ioBroker.ntfy-client/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/lubepi/ioBroker.ntfy-client/main/admin/ntfy-client.png",
-    "type": "messaging"
-  },
-  "nuki": {
-    "meta": "https://raw.githubusercontent.com/smaragdschlange/ioBroker.nuki/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/smaragdschlange/ioBroker.nuki/master/admin/nuki-logo.png",
-    "type": "hardware"
-  },
-  "nuki-extended": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.nuki-extended/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.nuki-extended/master/admin/nuki-extended.png",
-    "type": "hardware"
-  },
-  "nut": {
-    "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.nut/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.nut/master/admin/nut.png",
-    "type": "hardware"
-  },
-  "oasecontrol": {
-    "meta": "https://raw.githubusercontent.com/mr-suw/ioBroker.oasecontrol/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/mr-suw/ioBroker.oasecontrol/main/admin/oasecontrol.png",
-    "type": "garden"
-  },
-  "ocpp": {
-    "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.ocpp/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/foxriver76/ioBroker.ocpp/main/admin/ocpp.png",
-    "type": "energy"
-  },
-  "octoprint": {
-    "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.octoprint/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.octoprint/master/admin/octoprint.png",
-    "type": "hardware"
-  },
-  "odl": {
-    "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.odl/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.odl/master/admin/odl.png",
-    "type": "misc-data"
-  },
-  "oekofen-json": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.oekofen-json/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.oekofen-json/main/admin/oekofen-json.png",
-    "type": "climate-control"
-  },
-  "oilfox": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.oilfox/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.oilfox/master/admin/oilfox.png",
-    "type": "hardware"
-  },
-  "omnicomm-lls": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.omnicomm-lls/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.omnicomm-lls/master/admin/omnicomm-lls.png",
-    "type": "metering"
-  },
-  "omron-fins": {
-    "meta": "https://raw.githubusercontent.com/TheBam1990/ioBroker.omron-fins/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TheBam1990/ioBroker.omron-fins/master/admin/omron-fins.png",
-    "type": "hardware"
-  },
-  "onkyo": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.onkyo/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.onkyo/master/admin/onkyo.png",
-    "type": "multimedia"
-  },
-  "onlycat": {
-    "meta": "https://raw.githubusercontent.com/Sickboy78/ioBroker.onlycat/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Sickboy78/ioBroker.onlycat/main/admin/onlycat.png",
-    "type": "iot-systems"
-  },
-  "onvif": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.onvif/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.onvif/main/admin/onvif.png",
-    "type": "infrastructure"
-  },
-  "opcua": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.opcua/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.opcua/master/admin/opcua.png",
-    "type": "protocols"
-  },
-  "open-meteo-weather": {
-    "meta": "https://raw.githubusercontent.com/H5N1v2/ioBroker.open-meteo-weather/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/H5N1v2/ioBroker.open-meteo-weather/main/admin/open-meteo.png",
-    "type": "weather"
-  },
-  "opendtu": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.opendtu/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.opendtu/main/admin/opendtu.png",
-    "type": "energy"
-  },
-  "openhab": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.openhab/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.openhab/master/admin/openhab.png",
-    "type": "iot-systems"
-  },
-  "openknx": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.openknx/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.openknx/master/admin/openknx.png",
-    "type": "iot-systems"
-  },
-  "openligadb": {
-    "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.openligadb/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.openligadb/main/admin/openligadb_n.png",
-    "type": "misc-data"
-  },
-  "openmediavault": {
-    "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.openmediavault/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.openmediavault/main/admin/openmediavault.png",
-    "type": "infrastructure"
-  },
-  "openmeteo-notify": {
-    "meta": "https://raw.githubusercontent.com/ipod86/ioBroker.openmeteo-notify/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ipod86/ioBroker.openmeteo-notify/main/admin/openmeteo-notify.png",
-    "type": "weather"
-  },
-  "opensmartcity": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.opensmartcity/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.opensmartcity/main/admin/opensmartcity.png",
-    "type": "weather"
-  },
-  "opentherm": {
-    "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.opentherm/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.opentherm/main/admin/opentherm.png",
-    "type": "hardware"
-  },
-  "openweathermap": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.openweathermap/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.openweathermap/master/admin/openweathermap.png",
-    "type": "weather"
-  },
-  "operating-hours": {
-    "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.operating-hours/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.operating-hours/main/admin/operating-hours.png",
-    "type": "metering"
-  },
-  "opi": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.opi/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.opi/master/admin/opi.png",
-    "type": "hardware"
-  },
-  "oppoplayer": {
-    "meta": "https://raw.githubusercontent.com/volkerrichert/ioBroker.oppoplayer/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/volkerrichert/ioBroker.oppoplayer/master/admin/oppoplayer.png",
-    "type": "multimedia"
-  },
-  "otlp": {
-    "meta": "https://raw.githubusercontent.com/OlliMartin/ioBroker.otlp/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/OlliMartin/ioBroker.otlp/main/admin/otlp.png",
-    "type": "storage"
-  },
-  "owfs": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.owfs/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.owfs/master/admin/owfs.png",
-    "type": "hardware"
-  },
-  "owntracks": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.owntracks/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.owntracks/master/admin/owntracks.png",
-    "type": "geoposition"
-  },
-  "oxxify-fan-control": {
-    "meta": "https://raw.githubusercontent.com/N-b-dy/ioBroker.oxxify-fan-control/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/N-b-dy/ioBroker.oxxify-fan-control/main/admin/oxxify-fan-control.png",
-    "type": "climate-control"
-  },
-  "p2pool": {
-    "meta": "https://raw.githubusercontent.com/oelison/ioBroker.p2pool/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/oelison/ioBroker.p2pool/main/admin/p2pool.png",
-    "type": "misc-data"
-  },
-  "palazzetti": {
-    "meta": "https://raw.githubusercontent.com/inapsis/ioBroker.palazzetti/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/inapsis/ioBroker.palazzetti/master/admin/palazzetti.png",
-    "type": "climate-control"
-  },
-  "panasonic-comfort-cloud": {
-    "meta": "https://raw.githubusercontent.com/marc2016/ioBroker.panasonic-comfort-cloud/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/marc2016/ioBroker.panasonic-comfort-cloud/main/admin/panasonic-comfort-cloud.png",
-    "type": "climate-control"
-  },
-  "panasonic-viera": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.panasonic-viera/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.panasonic-viera/master/admin/panasonic-viera.png",
-    "type": "multimedia"
-  },
-  "paperless-ngx": {
-    "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.paperless-ngx/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.paperless-ngx/main/admin/paperless-ngx.png",
-    "type": "storage"
-  },
-  "parcel": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.parcel/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.parcel/master/admin/parcel.png",
-    "type": "misc-data"
-  },
-  "parcelapp": {
-    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.parcelapp/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.parcelapp/main/admin/parcelapp.svg",
-    "type": "infrastructure"
-  },
-  "parser": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.parser/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.parser/master/admin/parser.png",
-    "type": "logic"
-  },
-  "pegelalarm": {
-    "meta": "https://raw.githubusercontent.com/simatec/ioBroker.pegelalarm/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/simatec/ioBroker.pegelalarm/master/admin/pegelalarm.png",
-    "type": "weather"
-  },
-  "ph803w": {
-    "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.ph803w/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.ph803w/main/admin/ph803w_icon.png",
-    "type": "metering"
-  },
-  "phantomjs": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.phantomjs/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.phantomjs/master/admin/phantomjs.png",
-    "type": "utility"
-  },
-  "philips-air": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.philips-air/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.philips-air/master/admin/philips-air.png",
-    "type": "household"
-  },
-  "philips-tv": {
-    "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.philips-tv/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.philips-tv/master/admin/philips-tv.png",
-    "type": "multimedia"
-  },
-  "pi-hole": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pi-hole/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pi-hole/master/admin/pi-hole.png",
-    "type": "network"
-  },
-  "pi-hole2": {
-    "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.pi-hole2/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.pi-hole2/main/admin/pi-hole2.png",
-    "type": "network"
-  },
-  "pid": {
-    "meta": "https://raw.githubusercontent.com/mcm4iob/ioBroker.pid/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/mcm4iob/ioBroker.pid/master/admin/pid.png",
-    "type": "general"
-  },
-  "piface": {
-    "meta": "https://raw.githubusercontent.com/Eisbaeeer/ioBroker.piface/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Eisbaeeer/ioBroker.piface/master/admin/piface.png",
-    "type": "hardware"
-  },
-  "pimatic": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.pimatic/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.pimatic/master/admin/pimatic.png",
-    "type": "iot-systems"
-  },
-  "ping": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.ping/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.ping/master/admin/ping.png",
-    "type": "network"
-  },
-  "pirate-weather": {
-    "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.pirate-weather/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.pirate-weather/main/admin/pirate-weather.png",
-    "type": "weather"
-  },
-  "pixelit": {
-    "meta": "https://raw.githubusercontent.com/pixelit-project/ioBroker.pixelit/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/pixelit-project/ioBroker.pixelit/master/admin/pixelit.png",
-    "type": "hardware"
-  },
-  "pjlink": {
-    "meta": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.pjlink/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.pjlink/main/admin/pjlink.png",
-    "type": "multimedia"
-  },
-  "places": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.places/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.places/master/admin/places.png",
-    "type": "geoposition"
-  },
-  "playstation": {
-    "meta": "https://raw.githubusercontent.com/Lucky-ESA/ioBroker.playstation/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Lucky-ESA/ioBroker.playstation/main/admin/playstation.png",
-    "type": "iot-systems"
-  },
-  "plenticore": {
-    "meta": "https://raw.githubusercontent.com/pixcept/ioBroker.plenticore/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/pixcept/ioBroker.plenticore/master/admin/plenticore.png",
-    "type": "energy"
-  },
-  "plenticore-g3": {
-    "meta": "https://raw.githubusercontent.com/FernetMenta/ioBroker.plenticore-g3/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/FernetMenta/ioBroker.plenticore-g3/main/admin/plenticore-g3.png",
-    "type": "energy"
-  },
-  "plex": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.plex/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.plex/master/admin/plex.jpg",
-    "type": "multimedia"
-  },
-  "plexconnect": {
-    "meta": "https://raw.githubusercontent.com/eisbaeeer/ioBroker.plexconnect/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/eisbaeeer/ioBroker.plexconnect/master/admin/plex-logo.png",
-    "type": "multimedia"
-  },
-  "pollenflug": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pollenflug/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pollenflug/master/admin/pollenflug.png",
-    "type": "weather"
-  },
-  "poolcontrol": {
-    "meta": "https://raw.githubusercontent.com/DasBo1975/ioBroker.poolcontrol/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/DasBo1975/ioBroker.poolcontrol/main/admin/poolcontrol.png",
-    "type": "climate-control"
-  },
-  "porsche": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.porsche/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.porsche/master/admin/porsche.png",
-    "type": "vehicle"
-  },
-  "powerfox2": {
-    "meta": "https://raw.githubusercontent.com/Ax-LED/ioBroker.powerfox2/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Ax-LED/ioBroker.powerfox2/main/admin/powerfox2.png",
-    "type": "energy"
-  },
-  "procon-ip": {
-    "meta": "https://raw.githubusercontent.com/ylabonte/ioBroker.procon-ip/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ylabonte/ioBroker.procon-ip/master/admin/procon-ip.png",
-    "type": "iot-systems"
-  },
-  "proxmox": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.proxmox/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.proxmox/master/admin/proxmox.png",
-    "type": "infrastructure"
-  },
-  "proxy": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.proxy/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.proxy/master/admin/proxy.png",
-    "type": "network"
-  },
-  "public-transport": {
-    "meta": "https://raw.githubusercontent.com/tt-tom17/ioBroker.public-transport/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/tt-tom17/ioBroker.public-transport/main/admin/public-transport.png",
-    "type": "date-and-time"
-  },
-  "puppeteer": {
-    "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.puppeteer/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/foxriver76/ioBroker.puppeteer/main/admin/puppeteer.png",
-    "type": "utility"
-  },
-  "pushbullet": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pushbullet/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pushbullet/master/admin/pushbullet.png",
-    "type": "messaging"
-  },
-  "pushover": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.pushover/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.pushover/master/admin/pushover.png",
-    "type": "messaging"
-  },
-  "pushsafer": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.pushsafer/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.pushsafer/master/admin/pushsafer.png",
-    "type": "messaging"
-  },
-  "pv-notifications": {
-    "meta": "https://raw.githubusercontent.com/sadam6752-tech/ioBroker.pv-notifications/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/sadam6752-tech/ioBroker.pv-notifications/main/admin/pv-notifications.png",
-    "type": "energy"
-  },
-  "pvforecast": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pvforecast/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pvforecast/main/admin/pvforecast.png",
-    "type": "energy"
-  },
-  "pvoutputorg": {
-    "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.pvoutputorg/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.pvoutputorg/master/admin/pvoutputorg.png",
-    "type": "energy"
-  },
-  "pwned-check": {
-    "meta": "https://raw.githubusercontent.com/ipod86/ioBroker.pwned-check/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ipod86/ioBroker.pwned-check/main/admin/pwned-check.svg",
-    "type": "alarm"
-  },
-  "pylontech": {
-    "meta": "https://raw.githubusercontent.com/PLCHome/ioBroker.pylontech/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/PLCHome/ioBroker.pylontech/master/admin/pylontech.png",
-    "type": "energy"
-  },
-  "radar-trap": {
-    "meta": "https://raw.githubusercontent.com/Steiger04/ioBroker.radar-trap/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Steiger04/ioBroker.radar-trap/main/admin/radar-trap.png",
-    "type": "geoposition"
-  },
-  "radar2": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.radar2/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.radar2/master/admin/radar2.png",
-    "type": "network"
-  },
-  "radiohead": {
-    "meta": "https://raw.githubusercontent.com/crycode-de/ioBroker.radiohead/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/crycode-de/ioBroker.radiohead/master/admin/radiohead.png",
-    "type": "protocols"
-  },
-  "rainbird": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.rainbird/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.rainbird/master/admin/rainbird.png",
-    "type": "garden"
-  },
-  "rct": {
-    "meta": "https://raw.githubusercontent.com/aruttkamp/ioBroker.rct/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/aruttkamp/ioBroker.rct/main/admin/rct-logo.square.png",
-    "type": "energy"
-  },
-  "refoss": {
-    "meta": "https://raw.githubusercontent.com/Refoss/ioBroker.refoss/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Refoss/ioBroker.refoss/main/admin/refoss.png",
-    "type": "iot-systems"
-  },
-  "remeha-home": {
-    "meta": "https://raw.githubusercontent.com/simatec/ioBroker.remeha-home/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/simatec/ioBroker.remeha-home/master/admin/remeha-home.png",
-    "type": "climate-control"
-  },
-  "renacidc": {
-    "meta": "https://raw.githubusercontent.com/raschy/ioBroker.renacidc/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/raschy/ioBroker.renacidc/main/admin/renacidc.png",
-    "type": "energy"
-  },
-  "renault": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.renault/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.renault/main/admin/renault.png",
-    "type": "vehicle"
-  },
-  "reolink": {
-    "meta": "https://raw.githubusercontent.com/aendue/ioBroker.reolink/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/aendue/ioBroker.reolink/main/admin/reolink.png",
-    "type": "alarm"
-  },
-  "residents": {
-    "meta": "https://raw.githubusercontent.com/jpawlowski/ioBroker.residents/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/jpawlowski/ioBroker.residents/main/admin/residents.svg",
-    "type": "logic"
-  },
-  "resol": {
-    "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.resol/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.resol/master/admin/resol.svg",
-    "type": "energy"
-  },
-  "rest-api": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.rest-api/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.rest-api/master/admin/rest-api.svg",
-    "type": "communication"
-  },
-  "rflink": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.rflink/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.rflink/master/admin/rflink.png",
-    "type": "iot-systems"
-  },
-  "rfxcom": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.rfxcom/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.rfxcom/master/admin/rfxcom.png",
-    "type": "iot-systems"
-  },
-  "rickshaw": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.rickshaw/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.rickshaw/master/admin/rickshaw.png",
-    "type": "visualization"
-  },
-  "ring": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ring/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.ring/master/admin/ring.png",
-    "type": "hardware"
-  },
-  "roadtraffic": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.roadtraffic/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.roadtraffic/master/admin/roadtraffic.png",
-    "type": "misc-data"
-  },
-  "robonect": {
-    "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.robonect/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.robonect/master/admin/robonect.png",
-    "type": "garden"
-  },
-  "roborock": {
-    "meta": "https://raw.githubusercontent.com/copystring/ioBroker.roborock/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/copystring/ioBroker.roborock/main/admin/roborock.png",
-    "type": "household"
-  },
-  "roomba": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.roomba/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.roomba/master/admin/roomba.png",
-    "type": "household"
-  },
-  "rpi2": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.rpi2/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.rpi2/master/admin/rpi2.png",
-    "type": "hardware"
-  },
-  "rssfeed": {
-    "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.rssfeed/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.rssfeed/main/admin/rssfeed.png",
-    "type": "misc-data"
-  },
-  "s7": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.s7/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.s7/master/admin/s7.png",
-    "type": "iot-systems"
-  },
-  "sainlogic": {
-    "meta": "https://raw.githubusercontent.com/phifogg/ioBroker.sainlogic/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/phifogg/ioBroker.sainlogic/master/admin/sainlogic.png",
-    "type": "weather"
-  },
-  "samsung": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.samsung/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.samsung/master/admin/samsung.png",
-    "type": "multimedia"
-  },
-  "samsung_tizen": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.samsung_tizen/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.samsung_tizen/master/admin/samsung.png",
-    "type": "multimedia"
-  },
-  "sanext": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.sanext/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.sanext/master/admin/sanext.png",
-    "type": "energy"
-  },
-  "sayit": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.sayit/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.sayit/master/admin/sayit.png",
-    "type": "multimedia"
-  },
-  "sbfspot": {
-    "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.sbfspot/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.sbfspot/master/admin/sbfspot.png",
-    "type": "hardware"
-  },
-  "sbms": {
-    "meta": "https://raw.githubusercontent.com/buffoletti/ioBroker.sbms/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/buffoletti/ioBroker.sbms/main/admin/sbms.png",
-    "type": "energy"
-  },
-  "scenes": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.scenes/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.scenes/master/admin/scenes.png",
-    "type": "logic"
-  },
-  "schedule-switcher": {
-    "meta": "https://raw.githubusercontent.com/Lucky-ESA/ioBroker.schedule-switcher/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Lucky-ESA/ioBroker.schedule-switcher/main/admin/schedule-switcher.png",
-    "type": "date-and-time"
-  },
-  "scheduler": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.scheduler/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.scheduler/master/admin/scheduler.png",
-    "type": "logic"
-  },
-  "schlueter-thermostat": {
-    "meta": "https://raw.githubusercontent.com/patricknitsch/ioBroker.schlueter-thermostat/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/patricknitsch/ioBroker.schlueter-thermostat/main/admin/schlueter-thermostat.png",
-    "type": "climate-control"
-  },
-  "schoolfree": {
-    "meta": "https://raw.githubusercontent.com/simatec/ioBroker.schoolfree/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/simatec/ioBroker.schoolfree/master/admin/schoolfree.png",
-    "type": "date-and-time"
-  },
-  "schwoerer-ventcube": {
-    "meta": "https://raw.githubusercontent.com/Excodibur/ioBroker.schwoerer-ventcube/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Excodibur/ioBroker.schwoerer-ventcube/master/admin/schwoerer-ventcube.png",
-    "type": "climate-control"
-  },
-  "script-restore": {
-    "meta": "https://raw.githubusercontent.com/ipod86/ioBroker.script-restore/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ipod86/ioBroker.script-restore/main/admin/script-restore.svg",
-    "type": "utility"
-  },
-  "seko": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.seko/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.seko/main/admin/seko.png",
-    "type": "climate-control"
-  },
-  "selverf": {
-    "meta": "https://raw.githubusercontent.com/Rintrium/ioBroker.selverf/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Rintrium/ioBroker.selverf/master/admin/selverf.png",
-    "type": "iot-systems"
-  },
-  "semp": {
-    "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.semp/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.semp/master/admin/semp.png",
-    "type": "energy"
-  },
-  "senec": {
-    "meta": "https://raw.githubusercontent.com/nobl/ioBroker.senec/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/nobl/ioBroker.senec/master/admin/senec.png",
-    "type": "energy"
-  },
-  "sensebox": {
-    "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.sensebox/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.sensebox/master/admin/sensebox.svg?sanitize=true",
-    "type": "weather"
-  },
-  "seplos-v3-sniffer": {
-    "meta": "https://raw.githubusercontent.com/DpunktS/ioBroker.seplos-v3-sniffer/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/DpunktS/ioBroker.seplos-v3-sniffer/main/admin/seplos-v3-sniffer.jpg",
-    "type": "iot-systems"
-  },
-  "seq": {
-    "meta": "https://raw.githubusercontent.com/arteck/ioBroker.seq/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/arteck/ioBroker.seq/master/admin/seq.png",
-    "type": "logic"
-  },
-  "serial-gps": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.serial-gps/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.serial-gps/main/admin/serial-gps.svg",
-    "type": "utility"
-  },
-  "shelly": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.shelly/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.shelly/master/admin/shelly.png",
-    "type": "iot-systems"
-  },
-  "shrdzm": {
-    "meta": "https://raw.githubusercontent.com/mcm4iob/ioBroker.shrdzm/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/mcm4iob/ioBroker.shrdzm/main/admin/shrdzm.png",
-    "type": "energy"
-  },
-  "shuttercontrol": {
-    "meta": "https://raw.githubusercontent.com/simatec/ioBroker.shuttercontrol/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/simatec/ioBroker.shuttercontrol/master/admin/shuttercontrol.png",
-    "type": "climate-control"
-  },
-  "sia": {
-    "meta": "https://raw.githubusercontent.com/schmupu/ioBroker.sia/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/schmupu/ioBroker.sia/master/admin/sia.png",
-    "type": "alarm"
-  },
-  "siegenia": {
-    "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.siegenia/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.siegenia/master/admin/siegenia.png",
-    "type": "climate-control"
-  },
-  "sigenergy": {
-    "meta": "https://raw.githubusercontent.com/ssbingo/ioBroker.sigenergy/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ssbingo/ioBroker.sigenergy/main/admin/sigenergy.png",
-    "type": "energy"
-  },
-  "signal-cmb": {
-    "meta": "https://raw.githubusercontent.com/derAlff/ioBroker.signal-cmb/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/derAlff/ioBroker.signal-cmb/master/admin/signal-cmb.png",
-    "type": "messaging"
-  },
-  "signifylights": {
-    "meta": "https://raw.githubusercontent.com/disaster123/ioBroker.signifylights/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/disaster123/ioBroker.signifylights/main/admin/signifylights.png",
-    "type": "lighting"
-  },
-  "simple-api": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.simple-api/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.simple-api/master/admin/simple-api.png",
-    "type": "communication"
-  },
-  "simple-proxy-manager": {
-    "meta": "https://raw.githubusercontent.com/lubepi/ioBroker.simple-proxy-manager/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/lubepi/ioBroker.simple-proxy-manager/main/admin/simple-proxy-manager.png",
-    "type": "network"
-  },
-  "skiinfo": {
-    "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.skiinfo/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.skiinfo/main/admin/skiinfo.png",
-    "type": "misc-data"
-  },
-  "slideshow": {
-    "meta": "https://raw.githubusercontent.com/gaudes/ioBroker.slideshow/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/gaudes/ioBroker.slideshow/main/admin/slideshow.png",
-    "type": "visualization"
-  },
-  "sma-em": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.sma-em/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.sma-em/master/admin/sma-em.png",
-    "type": "energy"
-  },
-  "smappee": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.smappee/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.smappee/master/admin/smappee.png",
-    "type": "energy"
-  },
-  "smart-eq": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.smart-eq/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.smart-eq/master/admin/smart-eq.png",
-    "type": "vehicle"
-  },
-  "smartcontrol": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.smartcontrol/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.smartcontrol/master/admin/smartcontrol.png",
-    "type": "logic"
-  },
-  "smartfriends": {
-    "meta": "https://raw.githubusercontent.com/Black-Thunder/ioBroker.smartfriends/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Black-Thunder/ioBroker.smartfriends/master/admin/smartfriends.png",
-    "type": "iot-systems"
-  },
-  "smartgarden": {
-    "meta": "https://raw.githubusercontent.com/jpgorganizer/ioBroker.smartgarden/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/jpgorganizer/ioBroker.smartgarden/master/admin/smartgarden.png",
-    "type": "garden"
-  },
-  "smartloadmanager": {
-    "meta": "https://raw.githubusercontent.com/quorle/ioBroker.smartloadmanager/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/quorle/ioBroker.smartloadmanager/main/admin/smartloadmanager.png",
-    "type": "logic"
-  },
-  "smartm": {
-    "meta": "https://raw.githubusercontent.com/strulli85/ioBroker.smartm/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/strulli85/ioBroker.smartm/main/admin/smartm.svg",
-    "type": "energy"
-  },
-  "smartmeter": {
-    "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.smartmeter/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.smartmeter/master/admin/smartmeter.png",
-    "type": "energy"
-  },
-  "smartthings": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.smartthings/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.smartthings/master/admin/smartthings.png",
-    "type": "household"
-  },
-  "smoothed": {
-    "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.smoothed/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.smoothed/main/admin/smoothed.png",
-    "type": "logic"
-  },
-  "snips": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snips/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snips/master/admin/snips.png",
-    "type": "iot-systems"
-  },
-  "snmp": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snmp/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.snmp/master/admin/snmp.png",
-    "type": "infrastructure"
-  },
-  "socketio": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.socketio/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.socketio/master/admin/socketio.png",
-    "type": "communication"
-  },
-  "sofarcloud": {
-    "meta": "https://raw.githubusercontent.com/ltspicer/ioBroker.sofarcloud/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ltspicer/ioBroker.sofarcloud/main/admin/sofarcloud.jpg",
-    "type": "energy"
-  },
-  "solaredge": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solaredge/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solaredge/master/admin/solaredge.png",
-    "type": "energy"
-  },
-  "solarlog": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solarlog/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solarlog/master/admin/solarlog.png",
-    "type": "energy"
-  },
-  "solarmanpv": {
-    "meta": "https://raw.githubusercontent.com/raschy/ioBroker.solarmanpv/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/raschy/ioBroker.solarmanpv/main/admin/solarmanpv.png",
-    "type": "energy"
-  },
-  "solarprognose": {
-    "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.solarprognose/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.solarprognose/main/admin/solarprognose.png",
-    "type": "weather"
-  },
-  "solarviewdatareader": {
-    "meta": "https://raw.githubusercontent.com/afuerhoff/ioBroker.solarviewdatareader/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/afuerhoff/ioBroker.solarviewdatareader/master/admin/solarviewdatareader.png",
-    "type": "energy"
-  },
-  "solarwetter": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solarwetter/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solarwetter/master/admin/solarwetter.png",
-    "type": "weather"
-  },
-  "solax": {
-    "meta": "https://raw.githubusercontent.com/simatec/ioBroker.solax/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/simatec/ioBroker.solax/master/admin/solax.png",
-    "type": "energy"
-  },
-  "solectrus-influxdb": {
-    "meta": "https://raw.githubusercontent.com/patricknitsch/ioBroker.solectrus-influxdb/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/patricknitsch/ioBroker.solectrus-influxdb/main/admin/solectrus-influxdb.png",
-    "type": "communication"
-  },
-  "soliscloud": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.soliscloud/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.soliscloud/main/admin/solis.png",
-    "type": "energy"
-  },
-  "sonnen": {
-    "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.sonnen/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/foxriver76/ioBroker.sonnen/master/admin/sonnen.png",
-    "type": "energy"
-  },
-  "sonnen-charger": {
-    "meta": "https://raw.githubusercontent.com/ChrisWbb/ioBroker.sonnen-charger/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ChrisWbb/ioBroker.sonnen-charger/main/admin/sonnen-charger.png",
-    "type": "energy"
-  },
-  "sonoff": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.sonoff/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.sonoff/master/admin/sonoff.png",
-    "type": "lighting"
-  },
-  "sonos": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.sonos/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.sonos/master/admin/sonos.png",
-    "type": "multimedia"
-  },
-  "sonus": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.sonus/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.sonus/master/admin/sonus.png",
-    "type": "multimedia"
-  },
-  "sony-bravia": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.sony-bravia/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.sony-bravia/master/admin/sony-bravia.png",
-    "type": "multimedia"
-  },
-  "sourceanalytix": {
-    "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.sourceanalytix/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.sourceanalytix/main/admin/sourceanalytix.png",
-    "type": "energy"
-  },
-  "speedport": {
-    "meta": "https://raw.githubusercontent.com/hacki11/ioBroker.speedport/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/hacki11/ioBroker.speedport/master/admin/speedport.png",
-    "type": "infrastructure"
-  },
-  "spotify-premium": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.spotify-premium/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.spotify-premium/master/admin/spotify-premium.png",
-    "type": "multimedia"
-  },
-  "sprinklecontrol": {
-    "meta": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/admin/sprinklecontrol.png",
-    "type": "garden"
-  },
-  "sql": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.sql/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.sql/master/admin/sql.png",
-    "type": "storage"
-  },
-  "squeezeboxrpc": {
-    "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.squeezeboxrpc/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.squeezeboxrpc/main/admin/squeezeboxrpc.png",
-    "type": "multimedia"
-  },
-  "srm": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.srm/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.srm/main/admin/srm.png",
-    "type": "hardware"
-  },
-  "starline": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.starline/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.starline/master/admin/starline.png",
-    "type": "vehicle"
-  },
-  "statistics": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.statistics/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.statistics/master/admin/statistics.png",
-    "type": "misc-data"
-  },
-  "steam": {
-    "meta": "https://raw.githubusercontent.com/bloop16/ioBroker.steam/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/bloop16/ioBroker.steam/main/admin/steam.png",
-    "type": "multimedia"
-  },
-  "stiebel-isg": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.stiebel-isg/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.stiebel-isg/master/admin/stiebel-isg.png",
-    "type": "climate-control"
-  },
-  "stockmarket": {
-    "meta": "https://raw.githubusercontent.com/waoler/ioBroker.stockmarket/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/waoler/ioBroker.stockmarket/master/admin/stockmarket.png",
-    "type": "misc-data"
-  },
-  "sun2000": {
-    "meta": "https://raw.githubusercontent.com/bolliy/ioBroker.sun2000/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/bolliy/ioBroker.sun2000/main/admin/sun2000.png",
-    "type": "energy"
-  },
-  "sun2000-modbus": {
-    "meta": "https://raw.githubusercontent.com/daolis/ioBroker.sun2000-modbus/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/daolis/ioBroker.sun2000-modbus/main/admin/sun2000-modbus.png",
-    "type": "energy"
-  },
-  "sureflap": {
-    "meta": "https://raw.githubusercontent.com/Sickboy78/ioBroker.sureflap/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Sickboy78/ioBroker.sureflap/master/admin/sureflap.png",
-    "type": "iot-systems"
-  },
-  "swiss-weather-api": {
-    "meta": "https://raw.githubusercontent.com/baerengraben/ioBroker.swiss-weather-api/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/baerengraben/ioBroker.swiss-weather-api/master/admin/swiss-weather-api.png",
-    "type": "weather"
-  },
-  "synochat": {
-    "meta": "https://raw.githubusercontent.com/phoeluga/ioBroker.synochat/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/phoeluga/ioBroker.synochat/master/admin/synochat.png",
-    "type": "messaging"
-  },
-  "synology": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.synology/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.synology/master/admin/synology.png",
-    "type": "infrastructure"
-  },
-  "systeminfo": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.systeminfo/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.systeminfo/master/admin/systeminfo.png",
-    "type": "misc-data"
-  },
-  "ta-blnet": {
-    "meta": "https://raw.githubusercontent.com/weberk/ioBroker.ta-blnet/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/weberk/ioBroker.ta-blnet/main/admin/ta-blnet.png",
-    "type": "climate-control"
-  },
-  "tado": {
-    "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.tado/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.tado/main/admin/tado.png",
-    "type": "climate-control"
-  },
-  "tagesschau": {
-    "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.tagesschau/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.tagesschau/main/admin/tagesschau.png",
-    "type": "misc-data"
-  },
-  "tahoma": {
-    "meta": "https://raw.githubusercontent.com/Excodibur/ioBroker.tahoma/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Excodibur/ioBroker.tahoma/master/admin/tahoma.png",
-    "type": "iot-systems"
-  },
-  "tankerkoenig": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tankerkoenig/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tankerkoenig/master/admin/tankerkoenig.png",
-    "type": "vehicle"
-  },
-  "tapo": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.tapo/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.tapo/main/admin/tapo.png",
-    "type": "iot-systems"
-  },
-  "tedee": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.tedee/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.tedee/main/admin/tedee.png",
-    "type": "hardware"
-  },
-  "telegram": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.telegram/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.telegram/master/admin/telegram.png",
-    "type": "messaging"
-  },
-  "telegram-menu": {
-    "meta": "https://raw.githubusercontent.com/MiRo1310/ioBroker.telegram-menu/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/MiRo1310/ioBroker.telegram-menu/main/admin/telegram-menu.png",
-    "type": "messaging"
-  },
-  "teltonika": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.teltonika/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.teltonika/master/admin/teltonika.svg",
-    "type": "network"
-  },
-  "terminal": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.terminal/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.terminal/master/admin/terminal.png",
-    "type": "utility"
-  },
-  "tesla-motors": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tesla-motors/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tesla-motors/master/admin/tesla-motors.png",
-    "type": "vehicle"
-  },
-  "tesla-wallconnector3": {
-    "meta": "https://raw.githubusercontent.com/nobl/ioBroker.tesla-wallconnector3/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/nobl/ioBroker.tesla-wallconnector3/main/admin/tesla-wallconnector3.png",
-    "type": "vehicle"
-  },
-  "teslafi": {
-    "meta": "https://raw.githubusercontent.com/hombach/ioBroker.teslafi/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/hombach/ioBroker.teslafi/master/admin/teslafi.png",
-    "type": "vehicle"
-  },
-  "text2command": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.text2command/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.text2command/master/admin/text2command.png",
-    "type": "logic"
-  },
-  "tibberlink": {
-    "meta": "https://raw.githubusercontent.com/hombach/ioBroker.tibberlink/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/hombach/ioBroker.tibberlink/master/admin/tibberlink.png",
-    "type": "energy"
-  },
-  "tidy": {
-    "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.tidy/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.tidy/main/admin/tidy.svg",
-    "type": "storage"
-  },
-  "tileboard": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.tileboard/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.tileboard/master/admin/tileboard.png",
-    "type": "visualization"
-  },
-  "time-switch": {
-    "meta": "https://raw.githubusercontent.com/walli545/ioBroker.time-switch/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/walli545/ioBroker.time-switch/master/admin/time-switch.png",
-    "type": "date-and-time"
-  },
-  "tinker": {
-    "meta": "https://raw.githubusercontent.com/simatec/ioBroker.tinker/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/simatec/ioBroker.tinker/master/admin/tinker.png",
-    "type": "hardware"
-  },
-  "tino": {
-    "meta": "https://raw.githubusercontent.com/bowao/ioBroker.tino/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/bowao/ioBroker.tino/master/admin/tino.png",
-    "type": "hardware"
-  },
-  "tinymqttbroker": {
-    "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.tinymqttbroker/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/HGlab01/ioBroker.tinymqttbroker/main/admin/tinymqttbroker.png",
-    "type": "protocols"
-  },
-  "tinyrx4": {
-    "meta": "https://raw.githubusercontent.com/bowao/ioBroker.tinyrx4/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/bowao/ioBroker.tinyrx4/master/admin/tinyRX4.png",
-    "type": "hardware"
-  },
-  "toyota": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.toyota/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.toyota/master/admin/toyota.png",
-    "type": "vehicle"
-  },
-  "tr-064": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tr-064/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tr-064/master/admin/tr-064.png",
-    "type": "infrastructure"
-  },
-  "traccar": {
-    "meta": "https://raw.githubusercontent.com/arteck/ioBroker.traccar/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/arteck/ioBroker.traccar/master/admin/traccar.png",
-    "type": "geoposition"
-  },
-  "tractive-gps": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tractive-gps/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tractive-gps/main/admin/tractive-gps.png",
-    "type": "geoposition"
-  },
-  "tradfri": {
-    "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.tradfri/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.tradfri/master/admin/tradfri.png",
-    "type": "lighting"
-  },
-  "trashschedule": {
-    "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.trashschedule/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.trashschedule/master/admin/trashschedule.png",
-    "type": "date-and-time"
-  },
-  "trivum": {
-    "meta": "https://raw.githubusercontent.com/TheBam1990/ioBroker.trivum/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TheBam1990/ioBroker.trivum/main/admin/trivum.png",
-    "type": "multimedia"
-  },
-  "tronity": {
-    "meta": "https://raw.githubusercontent.com/tronity/ioBroker.tronity/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/tronity/ioBroker.tronity/main/admin/tronity.png",
-    "type": "vehicle"
-  },
-  "tunnelbroker-endpoint-updater": {
-    "meta": "https://raw.githubusercontent.com/wattnpapa/ioBroker.tunnelbroker-endpoint-updater/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/wattnpapa/ioBroker.tunnelbroker-endpoint-updater/master/admin/tunnelbroker-endpoint-updater.png",
-    "type": "network"
-  },
-  "tuya": {
-    "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.tuya/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.tuya/master/admin/tuya.png",
-    "type": "iot-systems"
-  },
-  "tvprogram": {
-    "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.tvprogram/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.tvprogram/master/admin/tvprogram.png",
-    "type": "misc-data"
-  },
-  "tvspielfilm": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tvspielfilm/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.tvspielfilm/master/admin/tvspielfilm.png",
-    "type": "misc-data"
-  },
-  "twinkly": {
-    "meta": "https://raw.githubusercontent.com/patrickbs96/ioBroker.twinkly/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/patrickbs96/ioBroker.twinkly/master/admin/twinkly.png",
-    "type": "lighting"
-  },
-  "ultrahuman": {
-    "meta": "https://raw.githubusercontent.com/SmarterPapa/ioBroker.ultrahuman/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/SmarterPapa/ioBroker.ultrahuman/main/admin/ultrahuman.png",
-    "type": "health"
-  },
-  "unifi": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.unifi/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.unifi/master/admin/unifi.png",
-    "type": "network"
-  },
-  "unifi-network": {
-    "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.unifi-network/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.unifi-network/main/admin/unifi-network.png",
-    "type": "network"
-  },
-  "unifi-protect": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.unifi-protect/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.unifi-protect/master/admin/unifi-protect.png",
-    "type": "alarm"
-  },
-  "unraid": {
-    "meta": "https://raw.githubusercontent.com/ingel81/ioBroker.unraid/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ingel81/ioBroker.unraid/master/admin/unraid.png",
-    "type": "infrastructure"
-  },
-  "upnp": {
-    "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.upnp/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.upnp/master/admin/upnp.png",
-    "type": "network"
-  },
-  "uv-protect": {
-    "meta": "https://raw.githubusercontent.com/simatec/ioBroker.uv-protect/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/simatec/ioBroker.uv-protect/master/admin/uv-protect.png",
-    "type": "weather"
-  },
-  "vaillant": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.vaillant/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.vaillant/master/admin/vaillant.png",
-    "type": "climate-control"
-  },
-  "valloxmv": {
-    "meta": "https://raw.githubusercontent.com/hacki11/ioBroker.valloxmv/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/hacki11/ioBroker.valloxmv/master/admin/valloxmv.png",
-    "type": "climate-control"
-  },
-  "valuetrackerovertime": {
-    "meta": "https://raw.githubusercontent.com/Omega236/ioBroker.valuetrackerovertime/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Omega236/ioBroker.valuetrackerovertime/master/admin/valuetrackerovertime.png",
-    "type": "misc-data"
-  },
-  "vbus-gw": {
-    "meta": "https://raw.githubusercontent.com/pdbjjens/ioBroker.vbus-gw/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/pdbjjens/ioBroker.vbus-gw/main/admin/vbus-gw.png",
-    "type": "network"
-  },
-  "vds2465-server": {
-    "meta": "https://raw.githubusercontent.com/Hirsch-DE/ioBroker.vds2465-server/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Hirsch-DE/ioBroker.vds2465-server/main/admin/vds2465-server.png",
-    "type": "alarm"
-  },
-  "vedirect": {
-    "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.vedirect/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.vedirect/main/admin/Vedirect_Adapterimage.png",
-    "type": "energy"
-  },
-  "velux": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.velux/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.velux/master/admin/velux.png",
-    "type": "household"
-  },
-  "vesync": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.vesync/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.vesync/main/admin/vesync.png",
-    "type": "climate-control"
-  },
-  "victron-cerbo": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.victron-cerbo/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.victron-cerbo/main/admin/victron-cerbo.svg",
-    "type": "energy"
-  },
-  "viessmann": {
-    "meta": "https://raw.githubusercontent.com/misanorot/ioBroker.viessmann/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/misanorot/ioBroker.viessmann/master/admin/viessmann.png",
-    "type": "climate-control"
-  },
-  "viessmannapi": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.viessmannapi/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.viessmannapi/master/admin/viessmannapi.png",
-    "type": "climate-control"
-  },
-  "virtualpowermeter": {
-    "meta": "https://raw.githubusercontent.com/Omega236/ioBroker.virtualpowermeter/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Omega236/ioBroker.virtualpowermeter/master/admin/virtualpowermeter.png",
-    "type": "energy"
-  },
-  "vis": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis/master/admin/vis.png",
-    "type": "visualization"
-  },
-  "vis-2": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2/master/packages/iobroker.vis-2/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2/master/packages/iobroker.vis-2/admin/vis-2.svg",
-    "type": "visualization"
-  },
-  "vis-2-widgets-collection": {
-    "meta": "https://raw.githubusercontent.com/Steiger04/ioBroker.vis-2-widgets-collection/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Steiger04/ioBroker.vis-2-widgets-collection/main/admin/vis-2-widgets-collection.png",
-    "type": "visualization-widgets"
-  },
-  "vis-2-widgets-energy": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-energy/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-energy/main/admin/vis-2-widgets-energy.png",
-    "type": "visualization-widgets"
-  },
-  "vis-2-widgets-gauges": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-gauges/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-gauges/main/admin/vis-2-widgets-gauges.png",
-    "type": "visualization-widgets"
-  },
-  "vis-2-widgets-icontwo": {
-    "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-icontwo/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-icontwo/main/admin/vis-2-widgets-icontwo.png",
-    "type": "visualization-icons"
-  },
-  "vis-2-widgets-inventwo": {
-    "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-inventwo/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-2-widgets-inventwo/main/admin/vis-2-widgets-inventwo.png",
-    "type": "visualization-widgets"
-  },
-  "vis-2-widgets-jaeger-design": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-jaeger-design/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-jaeger-design/main/admin/vis-2-widgets-jaeger-design.png",
-    "type": "visualization-widgets"
-  },
-  "vis-2-widgets-material": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-material/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-material/main/admin/vis-2-widgets-material.png",
-    "type": "visualization-widgets"
-  },
-  "vis-2-widgets-ovarious": {
-    "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-2-widgets-ovarious/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-2-widgets-ovarious/main/admin/vis-2-widgets-ovarious.png",
-    "type": "visualization-widgets"
-  },
-  "vis-2-widgets-radar-trap": {
-    "meta": "https://raw.githubusercontent.com/Steiger04/ioBroker.vis-2-widgets-radar-trap/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Steiger04/ioBroker.vis-2-widgets-radar-trap/main/admin/vis-2-widgets-radar-trap.png",
-    "type": "visualization-widgets"
-  },
-  "vis-2-widgets-rssfeed": {
-    "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-2-widgets-rssfeed/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-2-widgets-rssfeed/main/admin/vis-2-widgets-rssfeed.png",
-    "type": "visualization-widgets"
-  },
-  "vis-2-widgets-sigenergy": {
-    "meta": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-sigenergy/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-sigenergy/main/admin/vis-2-widgets-sigenergy.png",
-    "type": "visualization-widgets"
-  },
-  "vis-2-widgets-sweethome3d": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-sweethome3d/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-sweethome3d/main/admin/vis-2-widgets-sweethome3d.png",
-    "type": "visualization-widgets"
-  },
-  "vis-2-widgets-tibberlink": {
-    "meta": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-tibberlink/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-tibberlink/main/admin/vis-2-widgets-tibberlink.png",
-    "type": "visualization-widgets"
-  },
-  "vis-2-widgets-weather-and-heating": {
-    "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-2-widgets-weather-and-heating/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-2-widgets-weather-and-heating/master/admin/vis-2-widgets-weather-and-heating.png",
-    "type": "visualization-widgets"
-  },
-  "vis-3dmodel": {
-    "meta": "https://raw.githubusercontent.com/Excodibur/ioBroker.vis-3dmodel/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Excodibur/ioBroker.vis-3dmodel/master/admin/vis-3dmodel.png",
-    "type": "visualization-widgets"
-  },
-  "vis-bars": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-bars/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-bars/master/admin/bars.png",
-    "type": "visualization-widgets"
-  },
-  "vis-canvas-gauges": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-canvas-gauges/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-canvas-gauges/master/admin/vis-canvas-gauges.png",
-    "type": "visualization-widgets"
-  },
-  "vis-colorpicker": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-colorpicker/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-colorpicker/master/admin/colorpicker.png",
-    "type": "visualization-widgets"
-  },
-  "vis-fancyswitch": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-fancyswitch/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-fancyswitch/master/admin/fancyswitch.png",
-    "type": "visualization-widgets"
-  },
-  "vis-google-fonts": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-google-fonts/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-google-fonts/master/admin/vis-google-fonts.png",
-    "type": "visualization-widgets"
-  },
-  "vis-history": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-history/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-history/master/admin/vis-history.png",
-    "type": "visualization-widgets"
-  },
-  "vis-homekittiles": {
-    "meta": "https://raw.githubusercontent.com/Standarduser/ioBroker.vis-homekittiles/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Standarduser/ioBroker.vis-homekittiles/main/admin/vis-homekittiles.png",
-    "type": "visualization-widgets"
-  },
-  "vis-hqwidgets": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-hqwidgets/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-hqwidgets/master/admin/hqwidgets.png",
-    "type": "visualization-widgets"
-  },
-  "vis-icontwo": {
-    "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-icontwo/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-icontwo/master/admin/icontwo.png",
-    "type": "visualization-icons"
-  },
-  "vis-inventwo": {
-    "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-inventwo/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-inventwo/master/admin/inventwo.png",
-    "type": "visualization-widgets"
-  },
-  "vis-jqui-mfd": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-jqui-mfd/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-jqui-mfd/master/admin/jqui-mfd.png",
-    "type": "visualization-widgets"
-  },
-  "vis-jsontemplate": {
-    "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-jsontemplate/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-jsontemplate/main/admin/vis-jsontemplate.png",
-    "type": "visualization-widgets"
-  },
-  "vis-justgage": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-justgage/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-justgage/master/admin/justgage.png",
-    "type": "visualization-widgets"
-  },
-  "vis-keyboard": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-keyboard/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-keyboard/master/admin/keyboard.png",
-    "type": "visualization-widgets"
-  },
-  "vis-lcars": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-lcars/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-lcars/master/admin/lcars.png",
-    "type": "visualization-widgets"
-  },
-  "vis-map": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-map/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-map/master/admin/vis-map.png",
-    "type": "visualization-widgets"
-  },
-  "vis-material": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-material/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-material/master/admin/material.png",
-    "type": "visualization-widgets"
-  },
-  "vis-material-advanced": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-material-advanced/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-material-advanced/master/admin/vis-material-advanced.png",
-    "type": "visualization-widgets"
-  },
-  "vis-material-webfont": {
-    "meta": "https://raw.githubusercontent.com/om2804/ioBroker.vis-material-webfont/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/om2804/ioBroker.vis-material-webfont/master/admin/material-webfont.png",
-    "type": "visualization-widgets"
-  },
-  "vis-materialdesign": {
-    "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.vis-materialdesign/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.vis-materialdesign/master/admin/vis-materialdesign.png",
-    "type": "visualization-widgets"
-  },
-  "vis-metro": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-metro/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-metro/master/admin/metro.png",
-    "type": "visualization-widgets"
-  },
-  "vis-players": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-players/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-players/master/admin/players.png",
-    "type": "visualization-widgets"
-  },
-  "vis-plumb": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-plumb/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-plumb/master/admin/plumb.png",
-    "type": "visualization-widgets"
-  },
-  "vis-rgraph": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-rgraph/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-rgraph/master/admin/rgraph.png",
-    "type": "visualization-widgets"
-  },
-  "vis-timeandweather": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-timeandweather/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-timeandweather/master/admin/timeandweather.png",
-    "type": "visualization-widgets"
-  },
-  "vis-weather": {
-    "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-weather/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-weather/master/admin/vis-weather.png",
-    "type": "visualization-widgets"
-  },
-  "vivitek": {
-    "meta": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.vivitek/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.vivitek/master/admin/vivitek.png",
-    "type": "multimedia"
-  },
-  "vofo-speedtest": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vofo-speedtest/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vofo-speedtest/master/admin/vofo-speedtest.png",
-    "type": "network"
-  },
-  "voltoplus": {
-    "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.voltoplus/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.voltoplus/main/admin/voltoplus.png",
-    "type": "energy"
-  },
-  "volumio": {
-    "meta": "https://raw.githubusercontent.com/a-i-ks/ioBroker.volumio/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/a-i-ks/ioBroker.volumio/master/admin/volumio.png",
-    "type": "multimedia"
-  },
-  "volvo": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.volvo/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.volvo/master/admin/volvo.png",
-    "type": "vehicle"
-  },
-  "vr200": {
-    "meta": "https://raw.githubusercontent.com/Eisbaeeer/ioBroker.vr200/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Eisbaeeer/ioBroker.vr200/master/admin/VR200.png",
-    "type": "household"
-  },
-  "vw-connect": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.vw-connect/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.vw-connect/master/admin/vw-connect.png",
-    "type": "vehicle"
-  },
-  "wallpanel": {
-    "meta": "https://raw.githubusercontent.com/xXBJXx/ioBroker.wallpanel/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/xXBJXx/ioBroker.wallpanel/main/admin/wallpanel.png",
-    "type": "hardware"
-  },
-  "wamo": {
-    "meta": "https://raw.githubusercontent.com/smarthausleben/ioBroker.wamo/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/smarthausleben/ioBroker.wamo/main/admin/wamo.png",
-    "type": "iot-systems"
-  },
-  "warp": {
-    "meta": "https://raw.githubusercontent.com/pottio/ioBroker.warp/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/pottio/ioBroker.warp/main/admin/warp.png",
-    "type": "vehicle"
-  },
-  "waterkotte-easycon": {
-    "meta": "https://raw.githubusercontent.com/theknut/ioBroker.waterkotte-easycon/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/theknut/ioBroker.waterkotte-easycon/main/admin/waterkotte-easycon.png",
-    "type": "climate-control"
-  },
-  "wattcycle": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.wattcycle/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.wattcycle/main/admin/wattcycle.png",
-    "type": "energy"
-  },
-  "weather-warnings": {
-    "meta": "https://raw.githubusercontent.com/ticaki/ioBroker.weather-warnings/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ticaki/ioBroker.weather-warnings/main/admin/weather-warnings.png",
-    "type": "weather"
-  },
-  "weatherflow-tempest-api": {
-    "meta": "https://raw.githubusercontent.com/Scrounger/ioBroker.weatherflow-tempest-api/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Scrounger/ioBroker.weatherflow-tempest-api/main/admin/weatherflow-tempest-api.png",
-    "type": "weather"
-  },
-  "weatherflow_udp": {
-    "meta": "https://raw.githubusercontent.com/woessmich/ioBroker.weatherflow_udp/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/woessmich/ioBroker.weatherflow_udp/master/admin/weatherflow_udp.png",
-    "type": "weather"
-  },
-  "weathersense": {
-    "meta": "https://raw.githubusercontent.com/ltspicer/ioBroker.weathersense/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ltspicer/ioBroker.weathersense/main/admin/weathersense.png",
-    "type": "metering"
-  },
-  "weatherunderground": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.weatherunderground/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.weatherunderground/master/admin/wu.png",
-    "type": "weather"
-  },
-  "web": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.web/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.web/master/admin/web.png",
-    "type": "general"
-  },
-  "web-speedy": {
-    "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.web-speedy/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.web-speedy/main/admin/web-speedy.png",
-    "type": "network"
-  },
-  "webcal": {
-    "meta": "https://raw.githubusercontent.com/dirkhe/ioBroker.webcal/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/dirkhe/ioBroker.webcal/master/admin/webcal.png",
-    "type": "date-and-time"
-  },
-  "weblogin": {
-    "meta": "https://raw.githubusercontent.com/Vertumnus/ioBroker.weblogin/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Vertumnus/ioBroker.weblogin/master/admin/logo-login.png",
-    "type": "utility"
-  },
-  "webui": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.webui/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.webui/master/admin/logo.png",
-    "type": "visualization"
-  },
-  "webuntis": {
-    "meta": "https://raw.githubusercontent.com/Newan/ioBroker.webuntis/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Newan/ioBroker.webuntis/main/admin/webuntis.png",
-    "type": "date-and-time"
-  },
-  "weishaupt-wem": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.weishaupt-wem/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.weishaupt-wem/master/admin/weishaupt-wem.png",
-    "type": "climate-control"
-  },
-  "welcome": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.welcome/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.welcome/main/admin/welcome.png",
-    "type": "general"
-  },
-  "whatsapp-cmb": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.whatsapp-cmb/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.whatsapp-cmb/master/admin/whatsapp-cmb.png",
-    "type": "messaging"
-  },
-  "wiegand-tcpip": {
-    "meta": "https://raw.githubusercontent.com/kBrausew/ioBroker.wiegand-tcpip/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/kBrausew/ioBroker.wiegand-tcpip/master/admin/wiegand-tcpip.png",
-    "type": "hardware"
-  },
-  "wiffi-wz": {
-    "meta": "https://raw.githubusercontent.com/t4qjXH8N/ioBroker.wiffi-wz/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/t4qjXH8N/ioBroker.wiffi-wz/master/admin/wiffi-wz.png",
-    "type": "hardware"
-  },
-  "wifilight": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.wifilight/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.wifilight/master/admin/wifilight.png",
-    "type": "lighting"
-  },
-  "wiobrowser": {
-    "meta": "https://raw.githubusercontent.com/Bettman66/ioBroker.wiobrowser/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Bettman66/ioBroker.wiobrowser/master/admin/wiobrowser.png",
-    "type": "communication"
-  },
-  "wireguard": {
-    "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.wireguard/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.wireguard/main/admin/wireguard.svg",
-    "type": "infrastructure"
-  },
-  "wireless-mbus": {
-    "meta": "https://raw.githubusercontent.com/lvogt/ioBroker.wireless-mbus/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/lvogt/ioBroker.wireless-mbus/master/admin/wireless-mbus.png",
-    "type": "energy"
-  },
-  "wireless-settings": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.wireless-settings/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.wireless-settings/master/admin/wireless-settings.png",
-    "type": "network"
-  },
-  "withings": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.withings/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.withings/master/admin/withings.png",
-    "type": "health"
-  },
-  "witmotion": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.witmotion/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.witmotion/master/admin/witmotion.png",
-    "type": "utility"
-  },
-  "wlanthermo-nano": {
-    "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.wlanthermo-nano/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.wlanthermo-nano/main/admin/wlanthermo-nano.png",
-    "type": "household"
-  },
-  "wled": {
-    "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.wled/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.wled/main/admin/wled.png",
-    "type": "lighting"
-  },
-  "wmswebcontrol": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.wmswebcontrol/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.wmswebcontrol/master/admin/wmswebcontrol.png",
-    "type": "iot-systems"
-  },
-  "wolf": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.wolf/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.wolf/master/admin/wolf.png",
-    "type": "climate-control"
-  },
-  "wolf-smartset": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.wolf-smartset/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.wolf-smartset/master/admin/wolf-smartset.png",
-    "type": "climate-control"
-  },
-  "worx": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.worx/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.worx/master/admin/worx.png",
-    "type": "garden"
-  },
-  "ws": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.ws/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.ws/main/admin/ws.svg",
-    "type": "communication"
-  },
-  "x-touch": {
-    "meta": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.x-touch/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.x-touch/master/admin/x-touch.png",
-    "type": "hardware"
-  },
-  "xbox": {
-    "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.xbox/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/foxriver76/ioBroker.xbox/master/admin/xbox.png",
-    "type": "multimedia"
-  },
-  "xiaomi-gateway3": {
-    "meta": "https://raw.githubusercontent.com/lasthead0/ioBroker.xiaomi-gateway3/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/lasthead0/ioBroker.xiaomi-gateway3/master/admin/xiaomi-gateway3.png",
-    "type": "iot-systems"
-  },
-  "xs1": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.xs1/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.xs1/master/admin/xs1.png",
-    "type": "iot-systems"
-  },
-  "xsense": {
-    "meta": "https://raw.githubusercontent.com/arteck/ioBroker.xsense/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/arteck/ioBroker.xsense/main/admin/xsense.png",
-    "type": "utility"
-  },
-  "xterm": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.xterm/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.xterm/master/admin/xterm.png",
-    "type": "utility"
-  },
-  "yahka": {
-    "meta": "https://raw.githubusercontent.com/jensweigele/ioBroker.yahka/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/jensweigele/ioBroker.yahka/master/admin/yahka.png",
-    "type": "iot-systems"
-  },
-  "yahoo-stock-market": {
-    "meta": "https://raw.githubusercontent.com/Newan/ioBroker.yahoo-stock-market/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Newan/ioBroker.yahoo-stock-market/main/admin/yahoo-stock-market.png",
-    "type": "misc-data"
-  },
-  "yamaha": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.yamaha/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.yamaha/master/admin/yamaha.png",
-    "type": "multimedia"
-  },
-  "yeelight-2": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.yeelight-2/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.yeelight-2/master/admin/yeelight.png",
-    "type": "lighting"
-  },
-  "youtube": {
-    "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.youtube/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.youtube/master/admin/youtube.png",
-    "type": "misc-data"
-  },
-  "yr": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.yr/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.yr/master/admin/yr.png",
-    "type": "weather"
-  },
-  "zehnder-cloud": {
-    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.zehnder-cloud/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.zehnder-cloud/master/admin/zehnder-cloud.png",
-    "type": "climate-control"
-  },
-  "zendure-solarflow": {
-    "meta": "https://raw.githubusercontent.com/nograx/ioBroker.zendure-solarflow/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/nograx/ioBroker.zendure-solarflow/main/admin/zendure-solarflow.png",
-    "type": "energy"
-  },
-  "zigbee": {
-    "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.zigbee/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.zigbee/master/admin/zigbee.png",
-    "type": "hardware"
-  },
-  "zigbee2mqtt": {
-    "meta": "https://raw.githubusercontent.com/arteck/ioBroker.zigbee2mqtt/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/arteck/ioBroker.zigbee2mqtt/main/admin/zigbee2mqtt.png",
-    "type": "hardware"
-  },
-  "zoe2": {
-    "meta": "https://raw.githubusercontent.com/fungus75/ioBroker.zoe2/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/fungus75/ioBroker.zoe2/master/admin/zoe.png",
-    "type": "vehicle"
-  },
-  "zoneminder": {
-    "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.zoneminder/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.zoneminder/master/admin/zoneminder.png",
-    "type": "alarm"
-  },
-  "zont": {
-    "meta": "https://raw.githubusercontent.com/kirovilya/ioBroker.zont/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/kirovilya/ioBroker.zont/master/admin/zont.png",
-    "type": "climate-control"
-  },
-  "zwavews": {
-    "meta": "https://raw.githubusercontent.com/arteck/ioBroker.zwavews/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/arteck/ioBroker.zwavews/main/admin/zwavews.png?sanitize=true",
-    "type": "hardware"
-  },
-  "zwift": {
-    "meta": "https://raw.githubusercontent.com/Flixhummel/ioBroker.zwift/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/Flixhummel/ioBroker.zwift/main/admin/zwift.png",
-    "type": "health"
-  }
 }


### PR DESCRIPTION

## Add ioBroker.agent-dvr to Latest Repository

Adds the `agent-dvr` adapter to `sources-dist.json` (latest repository).

- **Repository:** https://github.com/ipod86/ioBroker.agent-dvr
- **npm:** https://www.npmjs.com/package/iobroker.agent-dvr
- **Type:** alarm

The adapter connects ioBroker to [AgentDVR](https://www.ispyconnect.com): auto-discovers all cameras and microphones, mirrors every device property as data points, provides control buttons (record, arm/disarm, PTZ, snapshot as Base64, profile selector), push-triggered gallery updates on new recordings, and generates responsive HTML gallery widgets per camera.

**Checklist**
- [x] The adapter is published to NPM
- [x] Developer Best practices are known and considered
- [x] All requirements to bring a new adapter into Latest repository are fulfilled
- [x] The adapter was checked by https://adapter-check.iobroker.in/ and no errors shown


[agent-dvr.json](https://github.com/user-attachments/files/29421763/agent-dvr.json)