### PR TITLE
Update vis-icontwo to 2.11.6

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3337,7 +3337,7 @@
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-icontwo/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-icontwo/master/admin/icontwo.png",
     "type": "visualization-icons",
-    "version": "2.11.3"
+    "version": "2.11.6"
   },
   "vis-inventwo": {
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.vis-inventwo/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-icontwo to version 2.11.6.

*This pull request was created by https://www.iobroker.dev 61636ea.*