### PR TITLE
Update vis-2-widgets-sigenergy to 1.8.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3277,7 +3277,7 @@
     "meta": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-sigenergy/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-sigenergy/main/admin/vis-2-widgets-sigenergy.png",
     "type": "visualization-widgets",
-    "version": "1.8.1"
+    "version": "1.8.2"
   },
   "vis-2-widgets-weather-and-heating": {
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-2-widgets-weather-and-heating/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-2-widgets-sigenergy to version 1.8.2.

*This pull request was created by https://www.iobroker.dev 61636ea.*