### PR TITLE
Add hassemu 1.36.0 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1077,6 +1077,12 @@
     "type": "iot-systems",
     "version": "1.4.0"
   },
+  "hassemu": {
+    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.hassemu/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.hassemu/main/admin/hassemu.svg",
+    "type": "infrastructure",
+    "version": "1.36.0"
+  },
   "hausbus_de": {
     "meta": "https://raw.githubusercontent.com/hausbus/ioBroker.hausbus_de/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/hausbus/ioBroker.hausbus_de/main/admin/hausbusde.png",


### PR DESCRIPTION
**Checklist**
- [x] All requirements to bring a new adapter into the stable repository are fulfilled (https://github.com/ioBroker/ioBroker.repositories#requirements-for-adapter-to-get-added-to-the-stable-repository) — in the latest repository since 2026-06-06, no blocking issues.
- [x] Forum testing thread: https://forum.iobroker.net/topic/84711/test-adapter-hassemu-1.34

Adds ioBroker.hassemu 1.36.0 (current latest) to the stable repository.