### PR TITLE
Update hueemu to 1.9.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1237,7 +1237,7 @@
     "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.hueemu/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.hueemu/main/admin/hue-emu-logo.svg",
     "type": "lighting",
-    "version": "1.8.1"
+    "version": "1.9.0"
   },
   "huum-sauna": {
     "meta": "https://raw.githubusercontent.com/Chris-656/ioBroker.huum-sauna/main/io-package.json",


### PR DESCRIPTION
**Checklist**
- [x] Adapter testing is still green for the current version — CI is green and it runs on the maintainer's own installation without regressions.
- [ ] User feedback: ioBroker.hueemu 1.9.0 has been in the latest repository since 2026-06-21 with no problem reports on the testing thread (https://forum.iobroker.net/topic/84300/test-adapter-hueemu) or the issue tracker. Niche adapter, so no explicit user confirmations were collected — but no negative reports either.

Updates the stable version of ioBroker.hueemu from 1.8.1 to 1.9.0 (current latest).