### PR TITLE
Add electrolux-aeg adapter to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -645,6 +645,11 @@
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.ekey/master/admin/ekey.png",
     "type": "hardware"
   },
+  "electrolux-aeg": {
+    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.electrolux-aeg/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.electrolux-aeg/main/admin/electrolux-aeg.png",
+    "type": "household"
+  },
   "elero-usb-transmitter": {
     "meta": "https://raw.githubusercontent.com/marc2016/ioBroker.elero-usb-transmitter/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/marc2016/ioBroker.elero-usb-transmitter/master/admin/elero-usb-transmitter.png",


### PR DESCRIPTION
Adds ioBroker.electrolux-aeg to latest repository.

Repochecker:
FINAL status 'OK'

Current npm version: 0.0.8
Tag workflow for 0.0.8: success