### PR TITLE
Update alarm to 4.0.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -85,7 +85,7 @@
     "meta": "https://raw.githubusercontent.com/misanorot/ioBroker.alarm/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/misanorot/ioBroker.alarm/master/admin/alarm.png",
     "type": "alarm",
-    "version": "3.7.6"
+    "version": "4.0.5"
   },
   "alexa-shoppinglist": {
     "meta": "https://raw.githubusercontent.com/MiRo1310/ioBroker.alexa-shoppinglist/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.alarm to version 4.0.5.

*This pull request was created by https://www.iobroker.dev 61636ea.*