### PR TITLE
Add sky-remote to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2690,6 +2690,11 @@
     "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.skiinfo/main/admin/skiinfo.png",
     "type": "misc-data"
   },
+  "sky-remote": {
+    "meta": "https://raw.githubusercontent.com/AlanSRU/ioBroker.sky-remote/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/AlanSRU/ioBroker.sky-remote/main/admin/sky-remote.png",
+    "type": "multimedia"
+  },
   "slideshow": {
     "meta": "https://raw.githubusercontent.com/gaudes/ioBroker.slideshow/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/gaudes/ioBroker.slideshow/main/admin/slideshow.png",


### PR DESCRIPTION
**Checklist**
- [x] The adapter is published to NPM (iobroker.sky-remote@1.0.3)
- [x] Developer Best practices are known and considered
- [x] All requirements to bring a new adapter into Latest repository are fulfilled
- [x] The adapter was checked by https://adapter-check.iobroker.in/ — only W4001 (not yet in latest) remains
- [x] Forum testing thread: https://forum.iobroker.net/topic/84916/new-sky-remote-remote-control-for-sky

**About the adapter**
ioBroker adapter for network control of Sky Q set-top boxes over HTTP (port 49160). It exposes the full set of remote-control buttons as states and a `sendSequence` state for comma-separated command sequences (e.g. channel tuning). Connection health is monitored via a lightweight TCP check that does not trigger the on-screen display.

- Type: `multimedia`
- Admin UI: jsonConfig
- Node >= 22, js-controller >= 6.0.11, admin >= 7.6.20

**Links**
- GitHub: https://github.com/AlanSRU/ioBroker.sky-remote
- npm: https://www.npmjs.com/package/iobroker.sky-remote
- Forum (testing): https://forum.iobroker.net/topic/84916/new-sky-remote-remote-control-for-sky