### PR TITLE
Revert "Add go-e-charger to latest repo (#6249)"

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -960,11 +960,6 @@
     "icon": "https://raw.githubusercontent.com/MK-2001/ioBroker.go-e/main/admin/go-echarger.png",
     "type": "vehicle"
   },
-  "go-e-charger": {
-    "meta": "https://raw.githubusercontent.com/hombach/ioBroker.go-e-charger/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/hombach/ioBroker.go-e-charger/master/admin/go-eCharger.png",
-    "type": "vehicle"
-  },
   "google-sharedlocations2": {
     "meta": "https://raw.githubusercontent.com/Garfonso/ioBroker.google-sharedlocations2/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Garfonso/ioBroker.google-sharedlocations2/main/admin/google-sharedlocations2.png",


### PR DESCRIPTION
This reverts commit 2b9773b28d38d517fd93d9e79d4a11dfb18eee38.