### PR TITLE
Update vis-2-widgets-weather-and-heating to 1.4.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3313,7 +3313,7 @@
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-2-widgets-weather-and-heating/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-2-widgets-weather-and-heating/master/admin/vis-2-widgets-weather-and-heating.png",
     "type": "visualization-widgets",
-    "version": "1.3.0"
+    "version": "1.4.2"
   },
   "vis-bars": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-bars/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-2-widgets-weather-and-heating to version 1.4.2.

*This pull request was created by https://www.iobroker.dev 61636ea.*