### PR TITLE
Add iiyama-prolite to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1275,6 +1275,11 @@
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-ultimate-png/master/admin/icons-ultimate-png.png",
     "type": "visualization-icons"
   },
+  "iiyama-prolite": {
+    "meta": "https://raw.githubusercontent.com/AlanSRU/ioBroker.iiyama-prolite/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/AlanSRU/ioBroker.iiyama-prolite/main/admin/iiyama-prolite.png",
+    "type": "multimedia"
+  },
   "ikettle2": {
     "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.ikettle2/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.ikettle2/master/admin/ikettle2.png",


### PR DESCRIPTION
Adds **iobroker.iiyama-prolite** to the latest repository.

ioBroker adapter for iiyama ProLite professional displays. Controls power, input source, volume, and video/audio settings over TCP/IP (LAN) or RS232 serial, using the official iiyama communication protocol. Includes status polling and Wake-on-LAN support.

- npm: https://www.npmjs.com/package/iobroker.iiyama-prolite
- GitHub: https://github.com/AlanSRU/ioBroker.iiyama-prolite
- Forum testing thread: https://forum.iobroker.net/topic/84928/new-adapter-iiyama-prolite-displays
- Type: `multimedia` — connectionType `local`, dataSource `poll`

**Checklist**
- [x] The adapter is published to NPM (current version 0.1.1, published via GitHub Actions trusted publishing / OIDC with provenance)
- [x] Developer Best practices are known and considered
- [x] All requirements to bring a new adapter into Latest repository are fulfilled
- [x] The adapter was checked with repochecker — no errors
- [x] Forum testing thread: https://forum.iobroker.net/topic/84928/new-adapter-iiyama-prolite-displays

**Notes for reviewers**
- Object-structure JSON dump will be attached as a comment shortly.
- `bluefox` has been invited as an npm owner (acceptance pending).

Thank you!
