### PR TITLE
Update birthdays to 6.1.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -277,7 +277,7 @@
     "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.birthdays/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.birthdays/master/admin/birthdays.png",
     "type": "date-and-time",
-    "version": "5.0.0"
+    "version": "6.1.0"
   },
   "ble": {
     "meta": "https://raw.githubusercontent.com/AlCalzone/ioBroker.ble/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.birthdays to version 6.1.0.

*This pull request was created by https://www.iobroker.dev 61636ea.*