### PR TITLE
Update beszel to 0.8.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -265,7 +265,7 @@
     "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.beszel/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.beszel/main/admin/beszel.svg",
     "type": "hardware",
-    "version": "0.7.2"
+    "version": "0.8.0"
   },
   "bidirectional-counter": {
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.bidirectional-counter/main/io-package.json",


### PR DESCRIPTION
**Checklist**
- [x] Adapter testing is still green for the current version — CI is green and it runs on the maintainer's own installation without regressions.
- [ ] User feedback: ioBroker.beszel 0.8.0 has been in the latest repository since 2026-06-24 with no problem reports on the testing thread (https://forum.iobroker.net/topic/84710/test-adapter-beszel-0.6) or the issue tracker. Niche adapter, so no explicit user confirmations were collected — but no negative reports either.

Updates the stable version of ioBroker.beszel from 0.7.2 to 0.8.0 (current latest).