### PR TITLE
Update homewizard to 0.13.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1219,7 +1219,7 @@
     "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.homewizard/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.homewizard/main/admin/homewizard.svg",
     "type": "energy",
-    "version": "0.12.2"
+    "version": "0.13.0"
   },
   "hoymiles-ms": {
     "meta": "https://raw.githubusercontent.com/mcm4iob/ioBroker.hoymiles-ms/main/io-package.json",


### PR DESCRIPTION
**Checklist**
- [x] Adapter testing is still green for the current version — CI is green and it runs on the maintainer's own installation (P1 meter) without regressions.
- [ ] User feedback: ioBroker.homewizard 0.13.0 has been in the latest repository since 2026-06-24 with no problem reports on the testing thread (https://forum.iobroker.net/topic/84709/test-adapter-homewizard-0.11) or the issue tracker. No explicit user confirmations were collected — but no negative reports either.

Updates the stable version of ioBroker.homewizard from 0.12.2 to 0.13.0 (current latest).