### PR TITLE
Add vis-2-widgets-automatic-feeder to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -3240,6 +3240,11 @@
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2/master/packages/iobroker.vis-2/admin/vis-2.svg",
     "type": "visualization"
   },
+  "vis-2-widgets-automatic-feeder": {
+    "meta": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-automatic-feeder/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-automatic-feeder/main/admin/vis-2-widgets-automatic-feeder.svg",
+    "type": "visualization-widgets"
+  },
   "vis-2-widgets-collection": {
     "meta": "https://raw.githubusercontent.com/Steiger04/ioBroker.vis-2-widgets-collection/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Steiger04/ioBroker.vis-2-widgets-collection/main/admin/vis-2-widgets-collection.png",


### PR DESCRIPTION
Please add my adapter ioBroker.vis-2-widgets-automatic-feeder to latest.

*This pull request was created by https://www.iobroker.dev 61636ea.*