### PR TITLE
parcelapp: fix adapter type (infrastructure -> misc-data)

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2226,7 +2226,7 @@
   "parcelapp": {
     "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.parcelapp/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.parcelapp/main/admin/parcelapp.svg",
-    "type": "infrastructure",
+    "type": "misc-data",
     "version": "0.9.0"
   },
   "parser": {

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2213,7 +2213,7 @@
   "parcelapp": {
     "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.parcelapp/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.parcelapp/main/admin/parcelapp.svg",
-    "type": "infrastructure"
+    "type": "misc-data"
   },
   "parser": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.parser/master/io-package.json",


### PR DESCRIPTION
parcelapp is a parcel-tracking adapter (parcel.app API) and was listed under `infrastructure`, which is meant for network/system infrastructure. `misc-data` matches the domain — the existing parcel-tracking adapter `parcel` is categorized the same way.

This PR updates the `type` field of the parcelapp entry in both sources-dist.json and sources-dist-stable.json. The adapter's io-package.json switches to `misc-data` with its upcoming v0.10.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)