### PR TITLE
Update viessmann to 2.0.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3217,7 +3217,7 @@
     "meta": "https://raw.githubusercontent.com/misanorot/ioBroker.viessmann/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/misanorot/ioBroker.viessmann/master/admin/viessmann.png",
     "type": "climate-control",
-    "version": "1.7.3"
+    "version": "2.0.5"
   },
   "virtualpowermeter": {
     "meta": "https://raw.githubusercontent.com/Omega236/ioBroker.virtualpowermeter/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.viessmann to version 2.0.5.

*This pull request was created by https://www.iobroker.dev 61636ea.*