### PR TITLE
Add iec104 to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1345,6 +1345,11 @@
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.icons-ultimate-png/master/admin/icons-ultimate-png.png",
     "type": "visualization-icons"
   },
+  "iec104": {
+    "meta": "https://raw.githubusercontent.com/TheBam1990/ioBroker.iec104/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/TheBam1990/ioBroker.iec104/main/admin/iec104.svg",
+    "type": "protocols"
+  },
   "ikettle2": {
     "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.ikettle2/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.ikettle2/master/admin/ikettle2.png",


### PR DESCRIPTION
Please add my adapter ioBroker.iec104 to latest.

*This pull request was created by https://www.iobroker.dev 61636ea.*