### PR TITLE
Add bluetti to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -295,6 +295,11 @@
     "icon": "https://raw.githubusercontent.com/Uwe1958/ioBroker.bluesound/main/admin/bluesound.png",
     "type": "multimedia"
   },
+  "bluetti": {
+    "meta": "https://raw.githubusercontent.com/Percy2Live/ioBroker.bluetti/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Percy2Live/ioBroker.bluetti/main/admin/bluetti.png",
+    "type": "energy"
+  },
   "bmw": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.bmw/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.bmw/master/admin/bmw.png",

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -345,6 +345,11 @@
     "icon": "https://raw.githubusercontent.com/Uwe1958/ioBroker.bluesound/main/admin/bluesound.png",
     "type": "multimedia"
   },
+  "bluetti": {
+    "meta": "https://raw.githubusercontent.com/Percy2Live/ioBroker.bluetti/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Percy2Live/ioBroker.bluetti/main/admin/bluetti.png",
+    "type": "energy"
+  },
   "blustream-acm": {
     "meta": "https://raw.githubusercontent.com/AlanSRU/ioBroker.blustream-acm/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlanSRU/ioBroker.blustream-acm/main/admin/blustream-acm.png",


### PR DESCRIPTION
## New adapter: ioBroker.bluetti

**BLUETTI power station telemetry** — cloud-connected adapter for BLUETTI power stations.

- **npm:** https://www.npmjs.com/package/iobroker.bluetti
- **GitHub:** https://github.com/Percy2Live/ioBroker.bluetti
- **Type:** energy
- **Connection type:** cloud
- **Data source:** poll

## Repository entry

Adds `bluetti` to `sources-dist.json` with the adapter metadata and icon from the adapter repository.

## Validation

- Automated adapter checker: **no errors found**
- Object dump: [`bluetti.0.json`](https://github.com/user-attachments/files/29984232/bluetti.0.json)
- Object structure check: **33 objects, 0 errors, 0 warnings**
- PR branch synchronized with the current upstream `master`
- Pull request is mergeable

## Remaining checker notes

- `W4001` is expected until this pull request is merged and resolves the finding.
- `W3017`, `S0052`, and `S8914` are non-blocking warnings or suggestions; there are no remaining hard repochecker errors.
