### PR TITLE
Update mhi-wfrac to 2.3.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1783,7 +1783,7 @@
     "meta": "https://raw.githubusercontent.com/hacki11/ioBroker.mhi-wfrac/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/hacki11/ioBroker.mhi-wfrac/main/admin/mhi-wfrac.png",
     "type": "climate-control",
-    "version": "2.2.0"
+    "version": "2.3.0"
   },
   "micronova": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.micronova/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.mhi-wfrac to version 2.3.0.

*This pull request was created by https://www.iobroker.dev 61636ea.*