### PR TITLE
Update rct to 1.2.28

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2461,7 +2461,7 @@
     "meta": "https://raw.githubusercontent.com/aruttkamp/ioBroker.rct/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/aruttkamp/ioBroker.rct/main/admin/rct-logo.square.png",
     "type": "energy",
-    "version": "1.2.26"
+    "version": "1.2.28"
   },
   "refoss": {
     "meta": "https://raw.githubusercontent.com/Refoss/ioBroker.refoss/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.rct to version 1.2.28.

*This pull request was created by https://www.iobroker.dev 61636ea.*