### PR TITLE
Update linktap to 1.0.4

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1597,7 +1597,7 @@
     "meta": "https://raw.githubusercontent.com/Smart-Gang/ioBroker.linktap/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Smart-Gang/ioBroker.linktap/master/admin/LinkTap_Logo.png",
     "type": "garden",
-    "version": "1.0.4"
+    "version": "1.0.5"
   },
   "linky": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.linky/main/io-package.json",

--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1597,7 +1597,7 @@
     "meta": "https://raw.githubusercontent.com/Smart-Gang/ioBroker.linktap/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Smart-Gang/ioBroker.linktap/master/admin/LinkTap_Logo.png",
     "type": "garden",
-    "version": "1.0.3"
+    "version": "1.0.4"
   },
   "linky": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.linky/main/io-package.json",

--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1597,7 +1597,7 @@
     "meta": "https://raw.githubusercontent.com/Smart-Gang/ioBroker.linktap/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Smart-Gang/ioBroker.linktap/master/admin/LinkTap_Logo.png",
     "type": "garden",
-    "version": "1.0.5"
+    "version": "1.0.6"
   },
   "linky": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.linky/main/io-package.json",


### PR DESCRIPTION
Adapter requires node.js >= 22 now / removed node-fetch