### PR TITLE
Update dreame to 0.3.24

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -571,7 +571,7 @@
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.dreame/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.dreame/main/admin/dreame.png",
     "type": "household",
-    "version": "0.3.19"
+    "version": "0.3.24"
   },
   "drops-weather": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.drops-weather/main/io-package.json",


### PR DESCRIPTION
Stable is currently pinned at 0.3.19 (from the initial addition PR #6200), while 0.3.24 has been available in Latest for 13 days and 0.3.22 for 16 days — well past the usual 7-14 day maturity window. No new automatic bump issue has appeared for this adapter, so opening this manually.

No known open errors/warnings from the repochecker for the current version (see TA2k/ioBroker.dreame#81, resolved).