### PR TITLE
Update solectrus-influxdb to 1.12.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2863,7 +2863,7 @@
     "meta": "https://raw.githubusercontent.com/patricknitsch/ioBroker.solectrus-influxdb/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/patricknitsch/ioBroker.solectrus-influxdb/main/admin/solectrus-influxdb.png",
     "type": "communication",
-    "version": "1.8.2"
+    "version": "1.12.0"
   },
   "soliscloud": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.soliscloud/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.solectrus-influxdb to version 1.12.0.

*This pull request was created by https://www.iobroker.dev 61636ea.*