### PR TITLE
Add rockwell_ethernetip to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2555,6 +2555,11 @@
     "icon": "https://raw.githubusercontent.com/copystring/ioBroker.roborock/main/admin/roborock.png",
     "type": "household"
   },
+  "rockwell_ethernetip": {
+    "meta": "https://raw.githubusercontent.com/gokturk413/ioBroker.rockwell_ethernetip/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/gokturk413/ioBroker.rockwell_ethernetip/main/admin/rockwell_ethernetip.png",
+    "type": "protocols"
+  },
   "roomba": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.roomba/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.roomba/master/admin/roomba.png",


### PR DESCRIPTION
Adds **iobroker.rockwell_ethernetip** — an adapter for Rockwell CompactLogix / ControlLogix PLCs over EtherNet/IP (incl. PlantPAx v4/v5): tiered polling, PLC change-driven push (works with FactoryTalk Logix Echo too), tag-based `@Alarms` and extended properties.

- npm: https://www.npmjs.com/package/iobroker.rockwell_ethernetip (v0.0.14)
- repo: https://github.com/gokturk413/ioBroker.rockwell_ethernetip
- @GermanBluefox is an npm owner; his single-package request (#13) is implemented in v0.0.14.

### Notes on the adapter checker
- **E4021 (name uses `_`)**: the package is already published on npm as `iobroker.rockwell_ethernetip` and in use; renaming would break existing installs. Underscore adapter names already exist in the latest repo (e.g. `frontier_silicon`, `samsung_tizen`, `hyperion_ng`).
- **E3012 / E2008 (deploy job / npm provenance)**: this is a commercial adapter (CC BY-NC 4.0) whose native protocol engine is closed-source and built in a private pipeline that publishes to npm; a public-repo deploy job / provenance attestation is therefore not applicable. The JS / admin layer is fully open in this repo.
- The remaining react / TypeScript devDependency majors are pinned by `@iobroker/adapter-react-v5` (react 18 peer).