### PR TITLE
Update govee-smart to 2.21.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -997,7 +997,7 @@
     "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.govee-smart/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.govee-smart/main/admin/govee-smart.svg",
     "type": "lighting",
-    "version": "2.16.2"
+    "version": "2.21.0"
   },
   "gree-hvac": {
     "meta": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/io-package.json",


### PR DESCRIPTION
**Checklist**
- [x] Adapter testing is still green for the current version — CI is green and it runs on the maintainer's own installation without regressions.
- [ ] User feedback: ioBroker.govee-smart 2.21.0 has been in the latest repository since 2026-07-12 with no problem reports on the testing thread (https://forum.iobroker.net/topic/84712/test-adapter-govee-smart-2.14.1) or the issue tracker. No explicit user confirmations were collected — but no negative reports either.

Updates the stable version of ioBroker.govee-smart from 2.16.2 to 2.21.0 (current latest).
