### PR TITLE
Update hassemu to 1.38.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1081,7 +1081,7 @@
     "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.hassemu/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.hassemu/main/admin/hassemu.svg",
     "type": "infrastructure",
-    "version": "1.36.0"
+    "version": "1.38.0"
   },
   "hausbus_de": {
     "meta": "https://raw.githubusercontent.com/hausbus/ioBroker.hausbus_de/main/io-package.json",


### PR DESCRIPTION
**Checklist**
- [x] Adapter testing is still green for the current version — CI is green and it runs on the maintainer's own installation without regressions.
- [ ] User feedback: ioBroker.hassemu 1.38.0 has been in the latest repository since 2026-07-12 with no problem reports on the testing thread (https://forum.iobroker.net/topic/84711/test-adapter-hassemu-1.34) or the issue tracker. No explicit user confirmations were collected — but no negative reports either.

Updates the stable version of ioBroker.hassemu from 1.36.0 to 1.38.0 (current latest).
