### PR TITLE
Update parcelapp to 0.10.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2233,7 +2233,7 @@
     "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.parcelapp/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.parcelapp/main/admin/parcelapp.svg",
     "type": "misc-data",
-    "version": "0.9.0"
+    "version": "0.10.1"
   },
   "parser": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.parser/master/io-package.json",


### PR DESCRIPTION
**Checklist**
- [x] Adapter testing is still green for the current version — CI is green and it runs on the maintainer's own installation without regressions.
- [ ] User feedback: ioBroker.parcelapp 0.10.1 has been in the latest repository since 2026-07-13 with no problem reports on the testing thread (https://forum.iobroker.net/topic/84304/test-adapter-parcelapp) or the issue tracker. No explicit user confirmations were collected — but no negative reports either.

Updates the stable version of ioBroker.parcelapp from 0.9.0 to 0.10.1 (current latest).
