### PR TITLE
Add public-holidays 0.11.0 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2391,6 +2391,12 @@
     "type": "network",
     "version": "1.3.2"
   },
+  "public-holidays": {
+    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.public-holidays/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.public-holidays/main/admin/public-holidays.svg",
+    "type": "date-and-time",
+    "version": "0.11.0"
+  },
   "public-transport": {
     "meta": "https://raw.githubusercontent.com/tt-tom17/ioBroker.public-transport/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/tt-tom17/ioBroker.public-transport/main/admin/public-transport.png",


### PR DESCRIPTION
**Checklist**
- [x] All requirements to bring a new adapter into the stable repository are fulfilled (https://github.com/ioBroker/ioBroker.repositories#requirements-for-adapter-to-get-added-to-the-stable-repository) — in the latest repository since 2026-07-04, no blocking issues.
- [x] Forum testing thread: https://forum.iobroker.net/topic/84918/test-adapter-public-holidays

Adds ioBroker.public-holidays 0.11.0 (current latest) to the stable repository.
