### PR TITLE
Add blustream-acm to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -315,6 +315,11 @@
     "icon": "https://raw.githubusercontent.com/Uwe1958/ioBroker.bluesound/main/admin/bluesound.png",
     "type": "multimedia"
   },
+  "blustream-acm": {
+    "meta": "https://raw.githubusercontent.com/AlanSRU/ioBroker.blustream-acm/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/AlanSRU/ioBroker.blustream-acm/main/admin/blustream-acm.png",
+    "type": "multimedia"
+  },
   "blustream-mfp": {
     "meta": "https://raw.githubusercontent.com/AlanSRU/ioBroker.blustream-mfp/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlanSRU/ioBroker.blustream-mfp/main/admin/blustream.png",


### PR DESCRIPTION
**Checklist**
- [x] The adapter is published to NPM (iobroker.blustream-acm@0.3.1)
- [x] Developer Best practices are known and considered
- [x] All requirements to bring a new adapter into Latest repository are fulfilled
- [x] Checked with `@iobroker/repochecker` — clean apart from `W4001` (not yet in latest, i.e. this PR)
- [x] `bluefox` added as an npm collaborator
- [x] Forum testing thread: https://forum.iobroker.net/topic/84592/new-blustream-acm200-hdmi-matrix-controller-adapter

> **Note:** This PR **supersedes #6002** and is opened fresh at @mcm1957's request because the adapter was **renamed `blustream-acm200` → `blustream-acm`** to reflect multi-model support. The old npm package `iobroker.blustream-acm200` has been deprecated and the GitHub repo renamed accordingly. #6002 will be closed with a pointer here.

This PR adds the **Blustream ACM** matrix controller adapter to the latest repository.

**About the adapter**
- Controls Blustream ACM matrix controllers for AV-over-IP distribution, with a configurable **Controller Model** (ACM200 / ACM210 / ACM500 / ACM1000) — states and commands are model-aware via a capability table
- Discovers connected transmitters and receivers via the controller's telnet interface
- Video/audio routing (combined and independent per stream) plus route-to-all-displays bulk commands
- Breakaway routing (IR / RS232 / USB / CEC), output power/mute, Dante/analogue/HDMI audio matrix and ARC control (model-gated)
- Transmitter audio source selection (AUTO/HDMI/ANA)
- Built on @iobroker/adapter-core 3.4.x, requires js-controller 6.0.11+, admin 7.6.20+
- Admin UI uses jsonConfig; **no credentials** — the telnet interface requires no login (`protectedNative`/`encryptedNative` empty)
- CI uses ioBroker/testing-action-* and **npm trusted publishing (OIDC)** — 0.3.1 published with provenance

**Prior review findings (from #6002, v0.2.4) are addressed in 0.3.1**
- Per-device `connected` states use `indicator.reachable`; `.id` states use role `text`
- Orphaned `username`/`password` i18n keys removed across all 11 languages; preview-URL separator `?time=` → `&time=` fixed

**Links**
- GitHub: https://github.com/AlanSRU/ioBroker.blustream-acm
- npm: https://www.npmjs.com/package/iobroker.blustream-acm

Same author also maintains iobroker.blustream-mfp (PR #6001). A fresh object dump (with a device, serials masked) and **READY FOR RE-REVIEW** will follow.
