### PR TITLE
Add omoda to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2115,6 +2115,11 @@
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.omnicomm-lls/master/admin/omnicomm-lls.png",
     "type": "metering"
   },
+  "omoda": {
+    "meta": "https://raw.githubusercontent.com/AlanSRU/ioBroker.omoda/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/AlanSRU/ioBroker.omoda/main/admin/omoda.png",
+    "type": "vehicle"
+  },
   "omron-fins": {
     "meta": "https://raw.githubusercontent.com/TheBam1990/ioBroker.omron-fins/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/TheBam1990/ioBroker.omron-fins/master/admin/omron-fins.png",


### PR DESCRIPTION
## Add adapter: omoda (Omoda / Jaecoo vehicles)

This PR adds **ioBroker.omoda** to the `latest` repository.

- **Repo:** https://github.com/AlanSRU/ioBroker.omoda
- **npm:** https://www.npmjs.com/package/iobroker.omoda (published with provenance via trusted publishing)
- **Forum:** https://forum.iobroker.net/topic/85006/new-adapter-omoda-jaecoo-vehicles
- **Type:** `vehicle`

### What it does
Monitors and controls **Omoda / Jaecoo (Chery)** vehicles via the manufacturer's cloud backend:
vehicle status (doors, windows, lock, climate, tyres), GPS location, battery & charging, and
remote **lock/unlock** and **climate on/off** with a target temperature. One device per VIN.

### Notes
- It is **unofficial and reverse-engineered** — not affiliated with or endorsed by Omoda /
  Jaecoo / Chery. The README carries a clear disclaimer and it's intended for use on one's own vehicle.
- It is a port of the Home Assistant integration
  [omoda-jaecoo-ha](https://github.com/JackRonan/omoda-jaecoo-ha) by **Caslinovich** and
  **JackRonan**, credited in the README and LICENSE (both MIT).

### Checklist
- [x] Adapter published to npm (0.1.1, with provenance)
- [x] `@iobroker/repochecker` run locally — no outstanding errors (bar this PR adding it to `latest`)
- [x] MIT license; English README with disclaimer + manufacturer link
- [x] Admin UI translated to all 11 languages
- [x] CI (test-and-release) green on `main`
- [x] Forum announcement posted (link above)
- [ ] Object-structure dump — _sanitised `omoda.0` object tree to be attached_
