### PR TITLE
Add hoymiles 0.4.1 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1219,7 +1219,7 @@
     "meta": "https://raw.githubusercontent.com/Eistee82/ioBroker.hoymiles/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Eistee82/ioBroker.hoymiles/main/admin/hoymiles.png",
     "type": "energy",
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
   "hoymiles-ms": {
     "meta": "https://raw.githubusercontent.com/mcm4iob/ioBroker.hoymiles-ms/main/io-package.json",

--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1215,6 +1215,12 @@
     "type": "energy",
     "version": "0.13.0"
   },
+  "hoymiles": {
+    "meta": "https://raw.githubusercontent.com/Eistee82/ioBroker.hoymiles/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Eistee82/ioBroker.hoymiles/main/admin/hoymiles.png",
+    "type": "energy",
+    "version": "0.4.0"
+  },
   "hoymiles-ms": {
     "meta": "https://raw.githubusercontent.com/mcm4iob/ioBroker.hoymiles-ms/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/mcm4iob/ioBroker.hoymiles-ms/main/admin/hoymiles-ms.png",


### PR DESCRIPTION
Please update my adapter ioBroker.hoymiles to version 0.4.1.

Updated from 0.4.0 to 0.4.1, which contains the removal of the npm `prepare` script requested by @mcm1957 in the review above.