### PR TITLE
Add goodwe-sems to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -995,6 +995,11 @@
     "icon": "https://raw.githubusercontent.com/hombach/ioBroker.go-e-charger/master/admin/go-eCharger.png",
     "type": "vehicle"
   },
+  "goodwe-sems": {
+    "meta": "https://raw.githubusercontent.com/bueste/ioBroker.goodwe-sems/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/bueste/ioBroker.goodwe-sems/main/admin/goodwe-sems.png",
+    "type": "energy"
+  },
   "google-sharedlocations2": {
     "meta": "https://raw.githubusercontent.com/Garfonso/ioBroker.google-sharedlocations2/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Garfonso/ioBroker.google-sharedlocations2/main/admin/google-sharedlocations2.png",


### PR DESCRIPTION
- meta: https://raw.githubusercontent.com/bueste/ioBroker.goodwe-sems/main/io-package.json
- icon: https://raw.githubusercontent.com/bueste/ioBroker.goodwe-sems/main/admin/goodwe-sems.png
- type: energy

ioBroker.goodwe-sems reads inverter/battery/power-flow data from the GoodWe SEMS Portal cloud for installations without local/LAN access to the inverter. Published on npm as iobroker.goodwe-sems (currently 0.1.8), MIT licensed, CI-tested (ESLint + unit/package tests on Node 18/20/22 + @iobroker/repochecker), bluefox already invited as npm package owner.