### PR TITLE
Add blink 0.0.38 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -291,6 +291,12 @@
     "type": "iot-systems",
     "version": "2.2.3"
   },
+  "blink": {
+    "meta": "https://raw.githubusercontent.com/Pischleuder1/ioBroker.blink/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Pischleuder1/ioBroker.blink/main/admin/blink.png",
+    "type": "alarm",
+    "version": "0.0.38"
+  },
   "bluelink": {
     "meta": "https://raw.githubusercontent.com/Newan/ioBroker.bluelink/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Newan/ioBroker.bluelink/master/admin/bluelink.png",


### PR DESCRIPTION
Please update my adapter ioBroker.blink to version 0.0.38.

*This pull request was created by https://www.iobroker.dev 61636ea.*