### PR TITLE
Add tesla-wallconnector3 1.1.0 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3063,6 +3063,12 @@
     "type": "vehicle",
     "version": "3.2.1"
   },
+  "tesla-wallconnector3": {
+    "meta": "https://raw.githubusercontent.com/nobl/ioBroker.tesla-wallconnector3/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/nobl/ioBroker.tesla-wallconnector3/main/admin/tesla-wallconnector3.png",
+    "type": "vehicle",
+    "version": "1.1.0"
+  },
   "teslafi": {
     "meta": "https://raw.githubusercontent.com/hombach/ioBroker.teslafi/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/hombach/ioBroker.teslafi/master/admin/teslafi.png",


### PR DESCRIPTION
Please update my adapter ioBroker.tesla-wallconnector3 to version 1.1.0.

*This pull request was created by https://www.iobroker.dev 61636ea.*