### PR TITLE
Add puppeteer-enhanced to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2415,6 +2415,11 @@
     "icon": "https://raw.githubusercontent.com/foxriver76/ioBroker.puppeteer/main/admin/puppeteer.png",
     "type": "utility"
   },
+  "puppeteer-enhanced": {
+    "meta": "https://raw.githubusercontent.com/gokturk413/ioBroker.puppeteer-enhanced/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/gokturk413/ioBroker.puppeteer-enhanced/main/admin/puppeteer.png",
+    "type": "utility"
+  },
   "pushbullet": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pushbullet/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.pushbullet/master/admin/pushbullet.png",


### PR DESCRIPTION
Add ioBroker.puppeteer-enhanced to the latest repository.

- npm: https://www.npmjs.com/package/iobroker.puppeteer-enhanced (v0.5.7)
- GitHub: https://github.com/gokturk413/ioBroker.puppeteer-enhanced
- Adapter passes ioBroker.repochecker

This supersedes the previously closed #6354.