### PR TITLE
Update wiegand-tcpip to 1.0.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3595,7 +3595,7 @@
     "meta": "https://raw.githubusercontent.com/kBrausew/ioBroker.wiegand-tcpip/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/kBrausew/ioBroker.wiegand-tcpip/master/admin/wiegand-tcpip.png",
     "type": "hardware",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "wiffi-wz": {
     "meta": "https://raw.githubusercontent.com/t4qjXH8N/ioBroker.wiffi-wz/master/io-package.json",


### PR DESCRIPTION
This PR only updates the stable repository entry for wiegand-tcpip: version 1.0.0 -> 1.0.1 in sources-dist-stable.json. No other files changed.