### PR TITLE
Update nextcloud-monitoring to 2.1.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1999,7 +1999,7 @@
     "meta": "https://raw.githubusercontent.com/H5N1v2/ioBroker.nextcloud-monitoring/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/H5N1v2/ioBroker.nextcloud-monitoring/main/admin/nextcloud_monitoring.png",
     "type": "network",
-    "version": "2.1.0"
+    "version": "2.1.1"
   },
   "nextcloudtalk": {
     "meta": "https://raw.githubusercontent.com/Rello/ioBroker.nextcloudtalk/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.nextcloud-monitoring to version 2.1.1.

*This pull request was created by https://www.iobroker.dev ae24fc9.*