### PR TITLE
Add rockwell-enip to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2555,6 +2555,11 @@
     "icon": "https://raw.githubusercontent.com/copystring/ioBroker.roborock/main/admin/roborock.png",
     "type": "household"
   },
+  "rockwell-enip": {
+    "meta": "https://raw.githubusercontent.com/gokturk413/ioBroker.rockwell-enip/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/gokturk413/ioBroker.rockwell-enip/main/admin/rockwell-enip.png",
+    "type": "protocols"
+  },
   "roomba": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.roomba/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.roomba/master/admin/roomba.png",


### PR DESCRIPTION
Adds **iobroker.rockwell-enip** — an ioBroker adapter for Rockwell CompactLogix/ControlLogix PLCs via EtherNet/IP.

- npm: https://www.npmjs.com/package/iobroker.rockwell-enip (latest **0.0.17**, published with npm **provenance** via trusted publishing)
- Repository: https://github.com/gokturk413/ioBroker.rockwell-enip
- Type: `protocols`
- License: **CC-BY-NC-4.0** — commercial adapter with a built-in free tier (all features, up to 1000 tags on instance 0); paid editions raise the limits.
- `bluefox` added as npm owner.

The native PLC protocol engine ships as prebuilt binaries for Windows/Linux/macOS (x64 + arm64); only the binary matching the host is expanded on first start. Passes `@iobroker/repochecker` (all error-level checks resolved).