### PR TITLE
Update valloxmv to 1.6.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3199,7 +3199,7 @@
     "meta": "https://raw.githubusercontent.com/hacki11/ioBroker.valloxmv/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/hacki11/ioBroker.valloxmv/master/admin/valloxmv.png",
     "type": "climate-control",
-    "version": "1.5.0"
+    "version": "1.6.1"
   },
   "valuetrackerovertime": {
     "meta": "https://raw.githubusercontent.com/Omega236/ioBroker.valuetrackerovertime/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.valloxmv to version 1.6.1.

*This pull request was created by https://www.iobroker.dev ae24fc9.*