### PR TITLE
Add eos to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -775,6 +775,11 @@
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.envertech-pv/master/admin/envertech-pv.png",
     "type": "energy"
   },
+  "eos": {
+    "meta": "https://raw.githubusercontent.com/TheBam1990/ioBroker.eos/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/TheBam1990/ioBroker.eos/main/admin/eos.svg",
+    "type": "energy"
+  },
   "epson_ecotank_et_2750": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.epson_ecotank_et_2750/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.epson_ecotank_et_2750/master/admin/epson_ecotank_et_2750.png",


### PR DESCRIPTION
## New adapter\n\nAdds `eos` (`iobroker.eos`) to the latest repository in the `energy` category.\n\n- Adapter repository: https://github.com/TheBam1990/ioBroker.eos\n- npm package: https://www.npmjs.com/package/iobroker.eos\n- Current version: 0.1.14\n- Package and integration CI covers Node.js 22 and 24 on Linux, macOS, and Windows.\n- Repository checker reports no adapter errors; W4001 is resolved by this PR.