### PR TITLE
Add nut2 to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2075,6 +2075,11 @@
     "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.nut/master/admin/nut.png",
     "type": "hardware"
   },
+  "nut2": {
+    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.nut2/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.nut2/main/admin/nut2.svg",
+    "type": "hardware"
+  },
   "oasecontrol": {
     "meta": "https://raw.githubusercontent.com/mr-suw/ioBroker.oasecontrol/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/mr-suw/ioBroker.oasecontrol/main/admin/oasecontrol.png",


### PR DESCRIPTION
## New adapter: ioBroker.nut2

Monitors UPS devices via the Network UPS Tools (NUT) protocol. Persistent TCP connection, all UPS devices on a NUT server discovered automatically via `LIST UPS`, states created dynamically from `LIST VAR`.

- **GitHub:** https://github.com/krobipd/ioBroker.nut2
- **npm:** [iobroker.nut2](https://www.npmjs.com/package/iobroker.nut2) (v0.5.3, published via trusted publishing with provenance)
- **Forum tester topic:** https://forum.iobroker.net/topic/85063/nut2-complete-new-nut-adapter
- **Type:** hardware
- **License:** MIT
- **529 tests** (472 vitest + 57 package)
- **Node.js:** &gt;= 22
- **js-controller:** &gt;= 7.2.2
- **Admin:** &gt;= 7.8.23

### Relation to the existing `nut` adapter

This is a standalone adapter, not a continuation of `iobroker.nut`. It shares no code with it — the NUT client is our own implementation (`node-nut` has been unmaintained since 2018).

A separate name was chosen deliberately: object tree, data types and state names all differ, so an in-place major version would have silently broken every script and visualisation in existing installations. Under its own name the old instance keeps running and users switch over when they choose to. This follows the established pattern of parallel adapters for the same target in the repository (e.g. `vis`/`vis-2`, `pi-hole`/`pi-hole2`).

### Features

- Automatic discovery of all UPS devices on a NUT server, multiple UPS per instance
- Proper data types instead of plain strings: numbers with units (V, Hz, A, Ah, %, W, VA, s, °C), yes/no as booleans, enums with readable labels
- `ups.status` parsed into 19 individual booleans plus a computed severity and a human-readable status line
- Instant commands (INSTCMD) and writable variables (SET VAR), both behind an opt-in safety switch
- STARTTLS support, network interface selector, connection test button in the admin UI
- Admin UI and state names in 11 languages