### PR TITLE
Update google-sharedlocations2 to 0.4.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -967,7 +967,7 @@
     "meta": "https://raw.githubusercontent.com/Garfonso/ioBroker.google-sharedlocations2/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Garfonso/ioBroker.google-sharedlocations2/main/admin/google-sharedlocations2.png",
     "type": "geoposition",
-    "version": "0.3.6"
+    "version": "0.4.0"
   },
   "google-spreadsheet": {
     "meta": "https://raw.githubusercontent.com/ThomasPohl/ioBroker.google-spreadsheet/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.google-sharedlocations2 to version 0.4.0.

*This pull request was created by https://www.iobroker.dev ae24fc9.*