### PR TITLE
Add eebus-go to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -685,6 +685,11 @@
     "icon": "https://raw.githubusercontent.com/mrbungle64/ioBroker.ecovacs-deebot/master/admin/ecovacs-deebot.png",
     "type": "household"
   },
+  "eebus-go": {
+    "meta": "https://raw.githubusercontent.com/FernetMenta/ioBroker.eebus-go/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/FernetMenta/ioBroker.eebus-go/main/admin/eebus-go.png",
+    "type": "iot-systems"
+  },
   "egigeozone2": {
     "meta": "https://raw.githubusercontent.com/obakuhl/ioBroker.egigeozone2/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/obakuhl/ioBroker.egigeozone2/master/admin/egigeozone.png",


### PR DESCRIPTION
Please add my adapter ioBroker.eebus-go to latest.

*This pull request was created by https://www.iobroker.dev ae24fc9.*