### PR TITLE
Add samsungtv to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2590,6 +2590,11 @@
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.samsung_tizen/master/admin/samsung.png",
     "type": "multimedia"
   },
+  "samsungtv": {
+    "meta": "https://raw.githubusercontent.com/softwarecrash/ioBroker.samsungtv/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/softwarecrash/ioBroker.samsungtv/main/admin/samsung.png",
+    "type": "multimedia"
+  },
   "sanext": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.sanext/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.sanext/master/admin/sanext.png",


### PR DESCRIPTION
## Summary

Add the `samsungtv` adapter to the latest repository.

## Adapter

- npm: `iobroker.samsungtv@0.0.26`
- Repository: `softwarecrash/ioBroker.samsungtv`
- Type: `multimedia`
- Supports automatic Samsung TV discovery and multiple TVs in one adapter instance

## Validation

- ioBroker package checks and lint pass
- Adapter tests pass on Node.js 22 and 24 on Linux, macOS, and Windows
- npm package was published through Trusted Publishing with provenance
