### PR TITLE
Add victron-gx 0.9.4 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3225,6 +3225,12 @@
     "type": "household",
     "version": "0.0.8"
   },
+  "victron-gx": {
+    "meta": "https://raw.githubusercontent.com/Sefina-DS/ioBroker.victron-gx/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Sefina-DS/ioBroker.victron-gx/main/admin/victron-gx.png",
+    "type": "energy",
+    "version": "0.9.4"
+  },
   "viessmann": {
     "meta": "https://raw.githubusercontent.com/misanorot/ioBroker.viessmann/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/misanorot/ioBroker.viessmann/master/admin/viessmann.png",


### PR DESCRIPTION
**Checklist**

- [x] All requirements to bring a new adapter into Stable repository are fulfilled (see https://github.com/ioBroker/ioBroker.repositories#requirements-for-adapter-to-get-added-to-the-stable-repository)
- [x] Forum thread: https://forum.iobroker.net/topic/84991

**Notes for reviewer**

Nominating **v0.9.4** as the initial Stable version rather than the current Latest v0.10.0 by design:

- v0.10.0 introduces a **breaking change** (removal of the `control.*` branch, writable datapoints moved under `devices.*`, config key `controlEnabled` → `modbusControlEnabled`) and has only been in Latest for 2 days. Not appropriate as a first-contact Stable version.
- v0.9.4 is the last release of the 0.9.x line and includes all bugfixes from 0.9.1–0.9.4 (EV charger control race, evcharger writability, initial-object-creation race, semantic control gating). No follow-up fix release was needed on the 0.9.x line.
- The adapter has been in Latest since PR #6051 (merged ~June 13, 2026), i.e. ~7 weeks. Live-tested on Cerbo GX with MultiPlus-II, ESS control, Shelly integration and Node-RED virtual devices.
- Once v0.10.x has stabilised in Latest (~4–6 weeks from now), a follow-up Stable bump will be requested.

Thanks!