### PR TITLE
Add vis-2-widgets-technic to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -3360,6 +3360,11 @@
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2-widgets-sweethome3d/main/admin/vis-2-widgets-sweethome3d.png",
     "type": "visualization-widgets"
   },
+  "vis-2-widgets-technic": {
+    "meta": "https://raw.githubusercontent.com/Sefina-DS/ioBroker.vis-2-widgets-technic/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Sefina-DS/ioBroker.vis-2-widgets-technic/main/admin/vis-2-widgets-technic.png",
+    "type": "visualization-widgets"
+  },
   "vis-2-widgets-tibberlink": {
     "meta": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-tibberlink/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-tibberlink/main/admin/vis-2-widgets-tibberlink.png",


### PR DESCRIPTION
Restores #6171 which was accidentally closed when I force-pushed my fork's master while preparing PR #6393 (victron-gx → stable). Same content, rebased on current upstream master.