### PR TITLE
Add cisco-checkpresence 0.1.0 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -411,6 +411,12 @@
     "type": "multimedia",
     "version": "4.2.0"
   },
+  "cisco-checkpresence": {
+    "meta": "https://raw.githubusercontent.com/NurPech/ioBroker.cisco-checkpresence/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/NurPech/ioBroker.cisco-checkpresence/main/admin/cisco-checkpresence.png",
+    "type": "infrastructure",
+    "version": "0.1.0"
+  },
   "cloud": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.cloud/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.cloud/master/admin/cloud.png",


### PR DESCRIPTION
Please update my adapter ioBroker.cisco-checkpresence to version 0.1.0.

*This pull request was created by https://www.iobroker.dev ae24fc9.*