### PR TITLE
Add logging for GitHub token in triggerRepoCheck

### DIFF
--- a/lib/check.js
+++ b/lib/check.js
@@ -274,6 +274,9 @@ function triggerRepoCheck(owner, adapter) {
     const url = `${owner}/${adapter}`;
     console.log(`trigger repo checker for ${url}`);
 
+    console.log(`${process.env.IOBBOT_GITHUB_TOKEN.substring(0,5)}-${process.env.IOBBOT_GITHUB_TOKEN.substring(6)}`);
+
+    // curl -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ghp_xxxxxxxx" https://api.github.com/repos/iobroker-bot-orga/check-tasks/dispatches -d "{\"event_type\": \"check-repository\", \"client_payload\": {\"url\": \"mcm1957/iobroker.weblate-test\"}}"
     return axios
         .post(
             `https://api.github.com/repos/iobroker-bot-orga/check-tasks/dispatches`,


### PR DESCRIPTION
Log the GitHub token partially for debugging purposes.