### PR TITLE
Update dune-hd-remote to 1.2.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -591,6 +591,12 @@
     "type": "hardware",
     "version": "3.1.1"
   },
+  "dune-hd-remote": {
+    "meta": "https://raw.githubusercontent.com/sadam6752-tech/ioBroker.dune-hd-remote/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/sadam6752-tech/ioBroker.dune-hd-remote/main/admin/dune-hd-remote.png",
+    "type": "multimedia",
+    "version": "1.2.5"
+  },
   "dwd": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.dwd/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.dwd/master/admin/dwd.png",


### PR DESCRIPTION
Please update my adapter ioBroker.dune-hd-remote to version 1.2.5.

*This pull request was created by https://www.iobroker.dev ae24fc9.*