### PR TITLE
Update public-transport to 0.10.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2419,7 +2419,7 @@
     "meta": "https://raw.githubusercontent.com/tt-tom17/ioBroker.public-transport/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/tt-tom17/ioBroker.public-transport/main/admin/public-transport.png",
     "type": "date-and-time",
-    "version": "0.6.0"
+    "version": "0.10.2"
   },
   "puppeteer": {
     "meta": "https://raw.githubusercontent.com/foxriver76/ioBroker.puppeteer/main/io-package.json",


### PR DESCRIPTION
**Checklist**
  [x] Adapter testing is still green for the current version?
  [x] You got feedback from users that the new version is working as expected?

  * Adapter: iobroker.public-transport
  * Stable: 0.6.0 → 0.10.2
  * npm: https://www.npmjs.com/package/iobroker.public-transport/v/0.10.2 (published 2026-07-17, 18 days in latest)
  * Changelog: https://github.com/tt-tom17/ioBroker.public-transport/blob/main/README.md