### PR TITLE
Update gira-iot to 0.7.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -961,7 +961,7 @@
     "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.gira-iot/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.gira-iot/master/admin/gira-iot.png",
     "type": "iot-systems",
-    "version": "0.5.0"
+    "version": "0.7.0"
   },
   "go-e": {
     "meta": "https://raw.githubusercontent.com/MK-2001/ioBroker.go-e/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.gira-iot to version 0.7.0.

*This pull request was created by https://www.iobroker.dev ae24fc9.*