### PR TITLE
Add lamarzocco to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1525,6 +1525,11 @@
     "icon": "https://raw.githubusercontent.com/hombach/ioBroker.kostal-piko-ba/master/admin/picoba.png",
     "type": "energy"
   },
+  "lamarzocco": {
+    "meta": "https://raw.githubusercontent.com/mrandreschmitz/ioBroker.lamarzocco/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/mrandreschmitz/ioBroker.lamarzocco/main/admin/lamarzocco.png",
+    "type": "household"
+  },
   "lametric": {
     "meta": "https://raw.githubusercontent.com/klein0r/ioBroker.lametric/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/klein0r/ioBroker.lametric/master/admin/lametric.png",


### PR DESCRIPTION
Unofficial cloud integration for La Marzocco espresso machines, in particular the Linea Micra.

- npm: https://www.npmjs.com/package/iobroker.lamarzocco (0.7.1, MIT)
- Repository: https://github.com/mrandreschmitz/ioBroker.lamarzocco
- bluefox has been added as an npm collaborator.
- The adapter checker reports no errors apart from the provenance hint, which the release workflow will settle with the next tagged version.
- The liability disclaimer has to be accepted in the instance configuration before the adapter contacts the cloud at all; statistics, notifications and the local HTTP endpoint are off by default.

Tested against a real Linea Micra with js-controller 7 and Node.js 22 and 24.