### PR TITLE
Add iometer to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1455,6 +1455,11 @@
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.intex/master/admin/intex.png",
     "type": "household"
   },
+  "iometer": {
+    "meta": "https://raw.githubusercontent.com/torben-iometer/ioBroker.iometer/master/io-package.json",
+    "icon": "https://raw.githubusercontent.com/torben-iometer/ioBroker.iometer/master/admin/iometer.png",
+    "type": "energy"
+  },
   "iopooleco": {
     "meta": "https://raw.githubusercontent.com/mule1972/ioBroker.iopooleco/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/mule1972/ioBroker.iopooleco/main/admin/iopooleco.png",


### PR DESCRIPTION
Aiming to add the iometer adapter to the latest repository

Further information can be found in the README for https://github.com/torben-iometer/ioBroker.iometer