### PR TITLE
Update sprinklecontrol to 1.0.11

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2947,7 +2947,7 @@
     "meta": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Dirk-Peter-md/ioBroker.sprinklecontrol/master/admin/sprinklecontrol.png",
     "type": "garden",
-    "version": "1.0.9"
+    "version": "1.0.11"
   },
   "sql": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.sql/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.sprinklecontrol to version 1.0.11.

*This pull request was created by https://www.iobroker.dev ae24fc9.*