### PR TITLE
Add simple-proxy-manager 1.0.0 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2769,6 +2769,12 @@
     "type": "communication",
     "version": "3.0.7"
   },
+  "simple-proxy-manager": {
+    "meta": "https://raw.githubusercontent.com/lubepi/ioBroker.simple-proxy-manager/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/lubepi/ioBroker.simple-proxy-manager/main/admin/simple-proxy-manager.png",
+    "type": "network",
+    "version": "1.0.0"
+  },
   "skiinfo": {
     "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.skiinfo/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.skiinfo/main/admin/skiinfo.png",


### PR DESCRIPTION
Please update my adapter ioBroker.simple-proxy-manager to version 1.0.0.

*This pull request was created by https://www.iobroker.dev ae24fc9.*