### PR TITLE
Add npm cooldown with @iobroker/repochecker excluded

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,8 @@ updates:
       timezone: Europe/Berlin
     open-pull-requests-limit: 5
     versioning-strategy: increase
+    cooldown:
+      default-days: 7
+      # Update @iobroker/repochecker as soon as a new version is available
+      exclude:
+        - "@iobroker/repochecker"


### PR DESCRIPTION
## What changed

Added a `cooldown` block to the npm ecosystem in `.github/dependabot.yml`:

- `default-days: 7` — all npm dependency version updates now wait 7 days after a release before a PR is opened.
- `exclude: ["@iobroker/repochecker"]` — this package is excluded from cooldown and updated as soon as a new version is published.

## Why

`@iobroker/repochecker` should be picked up immediately when a new version is available, while other dependencies benefit from a stabilization window.

## Reviewer note

As of July 2026, Dependabot applies a **default 3-day cooldown** to version updates even when `cooldown` is not configured. Listing a package under `cooldown.exclude` opts it out of cooldown entirely — bypassing both the configured 7-day window and the built-in 3-day default — so `@iobroker/repochecker` updates immediately. The default cooldown never applies to security updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)