### PR TITLE
Add f1 0.1.11 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -801,6 +801,12 @@
     "type": "hardware",
     "version": "0.3.0"
   },
+  "f1": {
+    "meta": "https://raw.githubusercontent.com/bloop16/ioBroker.f1/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/bloop16/ioBroker.f1/main/admin/f1.png",
+    "type": "misc-data",
+    "version": "0.1.11"
+  },
   "fakeroku": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fakeroku/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.fakeroku/master/admin/fakeroku.png",


### PR DESCRIPTION
Please update my adapter ioBroker.f1 to version 0.1.11.

*This pull request was created by https://www.iobroker.dev ae24fc9.*