### PR TITLE
Add shoppingroute to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2765,6 +2765,11 @@
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.shelly/master/admin/shelly.png",
     "type": "iot-systems"
   },
+  "shoppingroute": {
+    "meta": "https://raw.githubusercontent.com/RaviniZib/ioBroker.shoppingroute/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/RaviniZib/ioBroker.shoppingroute/main/admin/shoppingroute.png",
+    "type": "logic"
+  },
   "shrdzm": {
     "meta": "https://raw.githubusercontent.com/mcm4iob/ioBroker.shrdzm/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/mcm4iob/ioBroker.shrdzm/main/admin/shrdzm.png",


### PR DESCRIPTION
Adds ioBroker.shoppingroute to the official latest repository.

Adapter repository: https://github.com/RaviniZib/ioBroker.shoppingroute

Current stable version: 0.2.0
Adapter type: logic
Repository checker: no errors
npm package: iobroker.shoppingroute