### PR TITLE
Add kanban to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1545,6 +1545,11 @@
     "icon": "https://raw.githubusercontent.com/arteck/ioBroker.judoisoft/master/admin/judo.png",
     "type": "household"
   },
+  "kanban": {
+    "meta": "https://raw.githubusercontent.com/bmueller77/ioBroker.kanban/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/bmueller77/ioBroker.kanban/main/admin/kanban.png",
+    "type": "misc-data"
+  },
   "kecontact": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.kecontact/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.kecontact/master/admin/kecontact.png",


### PR DESCRIPTION
Adds `iobroker.kanban` to the latest repository.

A Kanban board as a dedicated ioBroker adapter. It brings its own web server, serves a single-page app and keeps every open view in sync over a WebSocket. Cards carry title, Markdown description, assignees, due date with optional time, labels, colour, priority, checklist, link, location and calendar invite. Recurring tasks include nth working day with public-holiday calculation and free cron expressions. Notifications go out by e-mail through the `email` adapter, and every event is written to `lastEvent` and to optional outbound webhooks, so other services can be reached from a short script.

- npm: https://www.npmjs.com/package/iobroker.kanban
- Repository: https://github.com/bmueller77/ioBroker.kanban
- Forum: https://forum.iobroker.net/topic/85030/neuer-adapter-kanban-board (German), https://forum.iobroker.net/topic/85031/new-adapter-kanban-board (English)
- Documentation: [English](https://github.com/bmueller77/ioBroker.kanban/blob/main/docs/en/README.md), [German](https://github.com/bmueller77/ioBroker.kanban/blob/main/docs/de/README.md)

Current release is 0.3.0, published with provenance through trusted publishing. Requirements are js-controller >= 6.0.11 and Node.js >= 22. Licence MIT, type `misc-data`, connection type `local`, data source `push`. The UI ships in eleven languages.

The repository checker was run before opening this PR. Three items are still open: **E2001**, the collaborator invitation for bluefox has been sent and is awaiting acceptance; **E3032**, which needs the next tagged release to produce a workflow run; and **W4001**, which this PR resolves. Unit tests and adapter tests run in CI on Node 22 and 24 across Linux, Windows and macOS.