### PR TITLE
Revert "Add vis2-materialdesign to latest"

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -3610,11 +3610,6 @@
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-weather/master/admin/vis-weather.png",
     "type": "visualization-widgets"
   },
-  "vis2-materialdesign": {
-    "meta": "https://raw.githubusercontent.com/typhosj/ioBroker.vis2-materialdesign/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/typhosj/ioBroker.vis2-materialdesign/master/admin/vis-materialdesign.png",
-    "type": "visualization-widgets"
-  },
   "vivitek": {
     "meta": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.vivitek/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.vivitek/master/admin/vivitek.png",


### PR DESCRIPTION
Reverts ioBroker/ioBroker.repositories#6364

This PR is a placeholder to remin that issues must be enabled at adapter vis2-materialdesign