### PR TITLE
Update zigbee to 3.5.5

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3847,7 +3847,7 @@
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.zigbee/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.zigbee/master/admin/zigbee.png",
     "type": "hardware",
-    "version": "3.3.5"
+    "version": "3.5.5"
   },
   "zigbee2mqtt": {
     "meta": "https://raw.githubusercontent.com/arteck/ioBroker.zigbee2mqtt/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.zigbee to version 3.5.5.

*This pull request was created by https://www.iobroker.dev ae24fc9.*