### PR TITLE
Add jetframe 1.3.3 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1485,6 +1485,12 @@
     "type": "hardware",
     "version": "1.2.8"
   },
+  "jetframe": {
+    "meta": "https://raw.githubusercontent.com/backfisch88/ioBroker.jetframe/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/backfisch88/ioBroker.jetframe/main/admin/jetframe.png",
+    "type": "visualization",
+    "version": "1.3.3"
+  },
   "js-controller": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.js-controller/master/packages/controller/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.js-controller/master/iobroker.png",


### PR DESCRIPTION
Please update my adapter ioBroker.jetframe to version 1.3.3.

*This pull request was created by https://www.iobroker.dev ae24fc9.*