### PR TITLE
Add leapmotor 0.6.2 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1551,6 +1551,12 @@
     "type": "iot-systems",
     "version": "3.0.1"
   },
+  "leapmotor": {
+    "meta": "https://raw.githubusercontent.com/backfisch88/ioBroker.leapmotor/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/backfisch88/ioBroker.leapmotor/main/admin/leapmotor.png",
+    "type": "vehicle",
+    "version": "0.6.2"
+  },
   "legrand-ecocompteur": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.legrand-ecocompteur/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.legrand-ecocompteur/master/admin/legrand-ecocompteur.png",


### PR DESCRIPTION
Please update my adapter ioBroker.leapmotor to version 0.6.2.

*This pull request was created by https://www.iobroker.dev ae24fc9.*