### PR TITLE
Add iobroker.meteonomiqs to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1860,6 +1860,11 @@
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.meteoalarm/master/admin/meteoalarm.png",
     "type": "weather"
   },
+  "meteonomiqs": {
+    "meta": "https://raw.githubusercontent.com/Schimi1983/ioBroker.meteonomiqs/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Schimi1983/ioBroker.meteonomiqs/main/admin/meteonomiqs.png",
+    "type": "weather"
+  },
   "meteoswiss": {
     "meta": "https://raw.githubusercontent.com/deMynchi/ioBroker.meteoswiss/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/deMynchi/ioBroker.meteoswiss/master/admin/meteoswiss.png",


### PR DESCRIPTION
### What it does

Weather forecast from wetter.com via the Meteonomiqs Public Weather API v4.0: up to 14 days,
day sections, hourly values, weather warnings, sun and moon data — all from a single API call
per fetch.

The free Meteonomiqs plan allows 100 calls per month, and the adapter is built around that
limit rather than ignoring it. Each of the three daily fetches carries a priority tier; when
the remaining budget gets tight the lowest tier drops out first and the nightly fetch falls
back to every other day, so the adapter degrades gradually instead of stalling mid-month.
The fetch times additionally carry a per-installation offset derived from the ioBroker
installation UUID, so not every installation calls the API in the same minute.

- Repository: https://github.com/Schimi1983/ioBroker.meteonomiqs
- npm: https://www.npmjs.com/package/iobroker.meteonomiqs (0.1.6, published with provenance
  attestation via npm trusted publishing)
- Forum thread: https://forum.iobroker.net/topic/85179/test-adapter-iobroker.meteonomiqs-wetter.com

### Checklist

- [x] Repository named `ioBroker.meteonomiqs`, topics set
- [x] `common.titleLang` and `common.desc` in 11 languages, `common.authors` set
- [x] `common.type` (`weather`), `connectionType` (`cloud`), `dataSource` (`poll`) set
- [x] MIT license in `io-package.json`, `README.md` and as `LICENSE` file
- [x] English README with description and a link to the API provider
- [x] GitHub Actions: type check, lint, package tests, unit tests and integration tests on
      Node 22/24 across Ubuntu, Windows and macOS
- [x] All states carry specific roles, no generic `state`
- [x] Published on npm, `bluefox` added as owner
- [x] JSON Config admin UI
- [x] No unused `www` / `widgets` / `docs` directories
- [x] `info.connection` implemented

### Two things I would like to flag up front

**`[E0063]` — `mocha`, `chai`, `@types/mocha` and `@types/chai` in devDependencies.**
The adapter has its own unit tests in `src/lib/helpers.test.ts` which import `chai` directly,
and the `test:ts` script invokes the `mocha` binary. Removing the packages breaks `npm test`
with "mocha: command not found", because npm only links the binaries of direct dependencies
into `node_modules/.bin`. The rule fits adapters that rely solely on the standard suites from
`@iobroker/testing`; this one does not. For what it is worth, `ioBroker.zwave2` declares the
same four packages with the same script layout. Happy to change it if you prefer a different
solution.

**Overlap with `iobroker.wettercom`.** That adapter (by @eifel-tech, not currently in the
repository) uses the same API. I only became aware of it when npm rejected my original package
name as too similar — hence the name "meteonomiqs" after the actual API provider rather than
the consumer brand. The focus here is on budget management, day sections, weather warnings and
a `current` folder that is refreshed hourly without spending an API call. I am happy to
coordinate if that is preferred.

### Note on the committed build output

This is a TypeScript adapter and `build/` is committed, as required by `[E5019]` for adapters
whose `package.json` main points into the build output.