### PR TITLE
Add bosch-smart-home-camera v1.8.3 to stable repository

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -315,6 +315,12 @@
     "type": "vehicle",
     "version": "5.0.0"
   },
+  "bosch-smart-home-camera": {
+    "meta": "https://raw.githubusercontent.com/mosandlt/ioBroker.bosch-smart-home-camera/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/mosandlt/ioBroker.bosch-smart-home-camera/main/admin/bosch-camera.png",
+    "type": "multimedia",
+    "version": "1.8.3"
+  },
   "boschindego": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.boschindego/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.boschindego/main/admin/boschindego.png",


### PR DESCRIPTION
**Checklist**
[ ] All requirements to bring a new adapter into Stable repository are fulfilled (see https://github.com/ioBroker/ioBroker.repositories#requirements-for-adapter-to-get-added-to-the-stable-repository)
[ ] Please add a link to Forum testing thread, if existing.

**What will happen after creating this request?**
* We will do a short additional review of your adapter
* After this we add the adapter to the stable repository

Thank you for your new adapter in ioBroker!

---

Status notes: adapter has been in the latest repository since 2026-07 (v1.8.x), repochecker reports zero errors/warnings (only a suggestion pointing back at this same request and a reminder about the forum thread below). No forum testing thread exists yet — that's tracked separately at mosandlt/ioBroker.bosch-smart-home-camera#47 and I haven't checked box 1/2 above since that requirement genuinely isn't met yet. Opening this now per the maintainer bot's own auto-generated request (mosandlt/ioBroker.bosch-smart-home-camera#67); happy to have this parked until the forum thread exists if that's preferred.