### PR TITLE
Update zendure-solarflow to 4.1.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3853,7 +3853,7 @@
     "meta": "https://raw.githubusercontent.com/nograx/ioBroker.zendure-solarflow/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/nograx/ioBroker.zendure-solarflow/main/admin/zendure-solarflow.png",
     "type": "energy",
-    "version": "4.1.0"
+    "version": "4.1.2"
   },
   "zigbee": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.zigbee/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.zendure-solarflow to version 4.1.2.

*This pull request was created by https://www.iobroker.dev ae24fc9.*