### PR TITLE
Add adapter miele-lokal

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1890,6 +1890,11 @@
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.miele/master/admin/xmiele.png",
     "type": "household"
   },
+  "miele-lokal": {
+    "meta": "https://raw.githubusercontent.com/SmarthomeElektroniker/ioBroker.miele-lokal/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/SmarthomeElektroniker/ioBroker.miele-lokal/main/admin/miele-lokal.png",
+    "type": "household"
+  },
   "mielecloudservice": {
     "meta": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.mielecloudservice/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Grizzelbee/ioBroker.mielecloudservice/master/admin/mielecloudservice.svg",


### PR DESCRIPTION
Adds the new adapter **iobroker.miele-lokal** — local, cloud-free access to modern Miele@Home appliances (MieleH256/DOP2).

- Repository: https://github.com/SmarthomeElektroniker/ioBroker.miele-lokal
- npm: https://www.npmjs.com/package/iobroker.miele-lokal (0.1.1, published via GitHub Actions with npm provenance / trusted publishing)
- License: MIT
- Type: household
- Tested end-to-end against three real appliances (washing machine, dishwasher, oven).

Checks:
- `@iobroker/repochecker` passes; the only remaining message is **E2001** — the npm collaborator invite for `bluefox` has been sent and is currently **pending acceptance**.
- CI "Test and Release" is green (check-and-lint + adapter-tests on Node 22/24, Ubuntu/Windows/macOS).
- Admin UI and io-package.json translations in 11 languages, README in English.