### PR TITLE
Add davis to latest repository

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -570,6 +570,11 @@
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.daswetter/master/admin/daswettercom.png",
     "type": "weather"
   },
+  "davis": {
+    "meta": "https://raw.githubusercontent.com/steinwedel/ioBroker.davis/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/steinwedel/ioBroker.davis/main/admin/davis.png",
+    "type": "weather"
+  },
   "deconz": {
     "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.deconz/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.deconz/master/admin/deconz.png",


### PR DESCRIPTION
Adds `iobroker.davis` (ioBroker.davis, WeatherLink Live 6100 weather station adapter) to the latest repository via `npm run addToLatest -- --name davis --type weather`.

- npm: https://www.npmjs.com/package/iobroker.davis (currently 0.0.15, `iobroker`/`bluefox` added as npm co-owner)
- Repo: https://github.com/steinwedel/ioBroker.davis
- CI (adapter tests + integration tests + npm trusted publishing on tag push): https://github.com/steinwedel/ioBroker.davis/actions
- License: MIT
- Type: weather, connectionType: local, dataSource: poll