### PR TITLE
Update govee-smart to 2.22.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1039,7 +1039,7 @@
     "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.govee-smart/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.govee-smart/main/admin/govee-smart.svg",
     "type": "lighting",
-    "version": "2.21.0"
+    "version": "2.22.0"
   },
   "gree-hvac": {
     "meta": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/io-package.json",


### PR DESCRIPTION
**Checklist**\n- [x] Adapter testing is still green for the current version — CI is green and it runs on the maintainer's own installation without regressions.\n- [ ] User feedback: ioBroker.govee-smart 2.22.0 has been in the latest repository since 2026-08-04 with no problem reports on the testing thread (https://forum.iobroker.net/topic/84712/test-adapter-govee-smart-2.14.1) or the issue tracker. No explicit user confirmations were collected — but no negative reports either.\n\nUpdates the stable version of ioBroker.govee-smart from 2.21.0 to 2.22.0 (not the current latest 2.23.1 — later versions contain an Admin 8 migration that is intentionally held back from stable for now).