### PR TITLE
Update volumio to 0.11.0 in stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3601,7 +3601,7 @@
     "meta": "https://raw.githubusercontent.com/a-i-ks/ioBroker.volumio/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/a-i-ks/ioBroker.volumio/master/admin/volumio.png",
     "type": "multimedia",
-    "version": "0.9.0"
+    "version": "0.10.0"
   },
   "volvo": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.volvo/master/io-package.json",


### PR DESCRIPTION
Bumps the pinned stable version of the `volumio` adapter from 0.9.0 to 0.11.0.

Changes: https://github.com/a-i-ks/ioBroker.volumio/releases/tag/v0.11.0 (and https://github.com/a-i-ks/ioBroker.volumio/releases/tag/v0.10.0)

The adapter has been available in the Latest (beta) repository since the 0.10.0 release. Opening this as a draft now and will mark it ready for review / merge after the usual few-day soak period in Latest with no new issues reported.