### PR TITLE
Add solakon-one 1.0.18 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2919,6 +2919,12 @@
     "type": "energy",
     "version": "3.4.3"
   },
+  "solakon-one": {
+    "meta": "https://raw.githubusercontent.com/berto-1974/ioBroker.solakon-one/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/berto-1974/ioBroker.solakon-one/main/admin/solakon.png",
+    "type": "energy",
+    "version": "1.0.18"
+  },
   "solaredge": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solaredge/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.solaredge/master/admin/solaredge.png",


### PR DESCRIPTION
Add adapter **solakon-one** version 1.0.18 to the stable repository.

* Adapter has been available at the latest repository since end of June 2026.
* Version 1.0.18 has been published at npm on 2026-07-24 and has been running at latest without any serious issues since then.
* Test topic in the forum: https://forum.iobroker.net/topic/84950/test-adapter-solakon-one-v1-0-x-latest
* Repository checker (issue #42 at the adapter repository) reports no errors.
* Currently approx. 18 installations reported by iobroker.live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)