### PR TITLE
Flag PRs that change more than one adapter

### DIFF
--- a/lib/check.js
+++ b/lib/check.js
@@ -325,7 +325,6 @@ async function doIt() {
 
     const links = await detectAffectedAdapter(prID);
 
-    // Change #1:
     // A PR should only add or update a single adapter. If more than one adapter is
     // changed, flag the PR and ask the author to split it into separate PRs.
     if (links.length > 1) {

--- a/lib/check.js
+++ b/lib/check.js
@@ -8,6 +8,8 @@ let checker;
 
 const TEXT_RECHECK = 'RE-CHECK!';
 const TEXT_COMMENT_TITLE = '## Automated adapter checker';
+const TEXT_MULTIPLE_REPOSITORIES =
+    'Please create seperate PRs for every adpater to add or update. This PR might be closed as it changes or adds more than one adapter.';
 const ONE_DAY = 3600000 * 24;
 
 function getPullRequestNumber() {
@@ -322,6 +324,28 @@ async function doIt() {
     const isStable = fileNames.includes('sources-dist-stable.json');
 
     const links = await detectAffectedAdapter(prID);
+
+    // Change #1:
+    // A PR should only add or update a single adapter. If more than one adapter is
+    // changed, flag the PR and ask the author to split it into separate PRs.
+    if (links.length > 1) {
+        console.log(`PR ${prID} changes ${links.length} adapters - flagging as 'multiple repositories'`);
+        try {
+            await addLabel(prID, ['multiple repositories']);
+        } catch (e) {
+            console.error(`Cannot add label 'multiple repositories': ${e}`);
+        }
+
+        try {
+            const gitComments = await getAllComments(prID);
+            const exists = gitComments.find(comment => comment.body.includes(TEXT_MULTIPLE_REPOSITORIES));
+            if (!exists) {
+                await addComment(prID, TEXT_MULTIPLE_REPOSITORIES);
+            }
+        } catch (e) {
+            console.error(`Cannot add 'multiple repositories' comment: ${e}`);
+        }
+    }
 
     const comments = [{ text: TEXT_COMMENT_TITLE }];
     let someChecked = false;


### PR DESCRIPTION
## What changed

Extends the adapter check in `lib/check.js`: a PR should only add or update a **single** adapter.

If a PR changes or adds more than one adapter, it now:
- gets the label `multiple repositories`
- receives a comment (deduplicated across re-checks):
  > Please create seperate PRs for every adpater to add or update. This PR might be closed as it changes or adds more than one adapter.

## Why
Multi-adapter PRs are hard to review and process. Flagging them automatically nudges authors to split them.

## Reviewer notes
- No workflow YAML change needed — `check.yml` already runs `npm run check`.
- The `multiple repositories` label is created automatically by the GitHub API on assignment if it does not already exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)