### PR TITLE
Validate PR author is a legitimate adapter maintainer

### DIFF
--- a/lib/check.js
+++ b/lib/check.js
@@ -10,9 +10,15 @@ const TEXT_RECHECK = 'RE-CHECK!';
 const TEXT_COMMENT_TITLE = '## Automated adapter checker';
 const ONE_DAY = 3600000 * 24;
 
-// GitHub users which are always allowed to add or update adapters,
-// regardless of their maintainer status of the adapter repository.
-const MAINTAINER_WHITELIST = ['mcm1957'];
+// GitHub users which are always allowed to add or update adapters.
+// Each entry is an object:
+//   { user: '<github-login>' }                          -> whitelisted for ALL repositories
+//   { user: '<github-login>', repos: ['owner/repo'] }   -> whitelisted for the listed repositories only
+// A repo may be given as full name 'owner/ioBroker.adapter' or just the adapter repo
+// name 'ioBroker.adapter' (matched case-insensitively).
+const MAINTAINER_WHITELIST = [
+    { user: 'mcm1957' }, // whitelisted for all repositories
+];
 
 function getPullRequestNumber() {
     if (process.env.GITHUB_REF && process.env.GITHUB_REF.match(/refs\/pull\/\d+\/merge/)) {
@@ -92,6 +98,65 @@ async function isPublicOrgMember(org, username) {
 }
 
 /**
+ * Check whether a user is whitelisted for a given repository.
+ *
+ * An entry without a (non-empty) `repos` list whitelists the user for ALL repositories.
+ * Otherwise the user is only whitelisted for the listed repositories. A repo entry may
+ * be the full name 'owner/ioBroker.adapter' or just the repo name 'ioBroker.adapter'.
+ */
+function isWhitelisted(owner, adapter, username) {
+    const fullName = `${owner}/${adapter}`.toLowerCase();
+    const repoName = adapter.toLowerCase();
+
+    return MAINTAINER_WHITELIST.some(entry => {
+        if (!entry || !entry.user || entry.user.toLowerCase() !== username.toLowerCase()) {
+            return false;
+        }
+        if (!entry.repos || !entry.repos.length) {
+            // No repo restriction -> whitelisted for all repositories.
+            return true;
+        }
+        return entry.repos.some(repo => {
+            const r = String(repo).toLowerCase();
+            return r === fullName || r === repoName;
+        });
+    });
+}
+
+/**
+ * Check whether the user has merged at least one of the last 100 pull requests of the
+ * repository. Only users with write (push) access can merge pull requests, so this is a
+ * reliable - and publicly readable - indication that the user is a maintainer.
+ *
+ * The pull request list endpoint does not include the `merged_by` field, so the merged
+ * pull requests among the last 100 are inspected individually (short-circuiting as soon
+ * as a match is found). This runs only as a fallback after the cheaper checks failed.
+ */
+async function hasMergedRecentPr(owner, adapter, username) {
+    try {
+        const prs = await getGithub(
+            `https://api.github.com/repos/${owner}/${adapter}/pulls?state=closed&per_page=100&sort=updated&direction=desc`,
+        );
+        const merged = (prs || []).filter(pr => pr && pr.merged_at);
+        for (const pr of merged) {
+            try {
+                const detail = await getGithub(
+                    `https://api.github.com/repos/${owner}/${adapter}/pulls/${pr.number}`,
+                );
+                if (detail && detail.merged_by && detail.merged_by.login.toLowerCase() === username.toLowerCase()) {
+                    return true;
+                }
+            } catch (e) {
+                console.error(`Cannot read PR ${owner}/${adapter}#${pr.number}: ${e}`);
+            }
+        }
+    } catch (e) {
+        console.error(`Cannot list pull requests of ${owner}/${adapter}: ${e}`);
+    }
+    return false;
+}
+
+/**
  * Determine whether the PR author is a legitimate maintainer of the adapter repository
  * WITHOUT requiring write (push) access to that repository for the checking token.
  *
@@ -99,37 +164,53 @@ async function isPublicOrgMember(org, username) {
  * access to the target repo, so it cannot be used here - the check must work with a
  * token that only has public/read access to third-party adapter repositories.
  *
- * Instead legitimacy is inferred from publicly readable facts:
- *   1. The author owns the repository (`owner === author`) -> always has write access.
- *   2. The repository is owned by an organization and the author is a *public* member
+ * Legitimacy is inferred from publicly readable facts, in order:
+ *   1. The author is whitelisted (globally or for this repository).
+ *   2. The author owns the repository (`owner === author`) -> always has write access.
+ *   3. The repository is owned by an organization and the author is a *public* member
  *      of that organization.
+ *   4. The author has merged at least one of the last 100 pull requests of the repo
+ *      (only users with write access can merge).
  *
- * This intentionally errs on the side of caution: private org members or plain repo
- * collaborators that are not public org members are not detected and will cause the
- * PR to be flagged with 'maintainer ?' for a manual review. The label is a review hint,
- * not a hard block, so failing "closed" (towards a manual check) is the safe direction.
+ * Returns a short human readable reason string if the author is considered legitimate,
+ * otherwise `null`.
+ *
+ * This intentionally errs on the side of caution: private org members or collaborators
+ * that leave no publicly visible trace are not detected and will cause the PR to be
+ * flagged with 'maintainer ?' for a manual review. The label is a review hint, not a
+ * hard block, so failing "closed" (towards a manual check) is the safe direction.
  */
-async function isLegitimateAuthor(owner, username) {
-    if (!owner || !username) {
-        return false;
+async function verifyAuthorLegitimacy(owner, adapter, username) {
+    if (!owner || !adapter || !username) {
+        return null;
     }
 
-    // 1. Author owns the repository.
+    // 1. Whitelisted (globally or for this repository).
+    if (isWhitelisted(owner, adapter, username)) {
+        return 'whitelisted';
+    }
+
+    // 2. Author owns the repository.
     if (owner.toLowerCase() === username.toLowerCase()) {
-        return true;
+        return 'repository owner';
     }
 
-    // 2. Repository owned by an organization the author publicly belongs to.
+    // 3. Repository owned by an organization the author publicly belongs to.
     try {
         const ownerInfo = await getGithub(`https://api.github.com/users/${encodeURIComponent(owner)}`);
-        if (ownerInfo && ownerInfo.type === 'Organization') {
-            return await isPublicOrgMember(owner, username);
+        if (ownerInfo && ownerInfo.type === 'Organization' && (await isPublicOrgMember(owner, username))) {
+            return 'public organization member';
         }
     } catch (e) {
         console.error(`Cannot determine owner type of ${owner}: ${e}`);
     }
 
-    return false;
+    // 4. Author has merged a recent pull request of the repository.
+    if (await hasMergedRecentPr(owner, adapter, username)) {
+        return 'has merged a pull request of the repository';
+    }
+
+    return null;
 }
 
 /**
@@ -397,6 +478,8 @@ async function doIt() {
     }
 
     const comments = [{ text: TEXT_COMMENT_TITLE }];
+    // Verification result lines appended at the very end of the check result comment.
+    const verificationLines = [];
     let someChecked = false;
     let errorsFound = false;
     let maintainerMissing = false;
@@ -413,22 +496,25 @@ async function doIt() {
         console.log(`checking ${owner}/${adapter}`);
         triggerRepoCheck(owner, adapter);
 
-        // Validate that the creator of the PR is either whitelisted or a legitimate
-        // maintainer of the repository of the adapter which is added / updated by this PR.
-        // The validation only relies on publicly readable information (see isLegitimateAuthor).
-        const whitelisted = MAINTAINER_WHITELIST.some(user => user.toLowerCase() === prAuthor.toLowerCase());
-        if (whitelisted) {
-            console.log(`PR author ${prAuthor} is whitelisted - maintainer check passed for ${owner}/${adapter}`);
+        // Validate that the creator of the PR is a legitimate maintainer of the adapter
+        // repository which is added / updated by this PR. The validation only relies on
+        // publicly readable information (see verifyAuthorLegitimacy).
+        const legitimacyReason = await verifyAuthorLegitimacy(owner, adapter, prAuthor);
+        if (legitimacyReason) {
+            console.log(
+                `PR author ${prAuthor} verified as legitimate maintainer of ${owner}/${adapter}: ${legitimacyReason}`,
+            );
+            verificationLines.push(
+                `:white_check_mark: PR creator @${prAuthor} has been verified as legitimate maintainer of [${adapter}](${link}) because the user is: **${legitimacyReason}**.`,
+            );
         } else {
-            const legit = await isLegitimateAuthor(owner, prAuthor);
-            if (legit) {
-                console.log(`PR author ${prAuthor} is a legitimate maintainer of ${owner}/${adapter} - maintainer check passed`);
-            } else {
-                console.log(
-                    `PR author ${prAuthor} is neither whitelisted nor a verifiable maintainer of ${owner}/${adapter} - flagging 'maintainer ?'`,
-                );
-                maintainerMissing = true;
-            }
+            console.log(
+                `PR author ${prAuthor} could not be verified as maintainer of ${owner}/${adapter} - flagging 'maintainer ?'`,
+            );
+            maintainerMissing = true;
+            verificationLines.push(
+                `:warning: PR creator @${prAuthor} could **not** be verified as legitimate maintainer of [${adapter}](${link}). The user needs to be validated manually.`,
+            );
         }
 
         try {
@@ -665,6 +751,12 @@ async function doIt() {
     }
 
     let comment = comments.map(line => decorateLine(line)).join('\n');
+
+    if (verificationLines.length) {
+        comment += `\n\n---\n`;
+        comment += verificationLines.map(line => `\n${line}`).join('');
+    }
+
     comment += `\n\n\n*Add comment "${TEXT_RECHECK}" to start check anew*`;
 
     console.log('ADD PULL REQUEST COMMENT:');

--- a/lib/check.js
+++ b/lib/check.js
@@ -10,6 +10,10 @@ const TEXT_RECHECK = 'RE-CHECK!';
 const TEXT_COMMENT_TITLE = '## Automated adapter checker';
 const ONE_DAY = 3600000 * 24;
 
+// GitHub users which are always allowed to add or update adapters,
+// regardless of their maintainer status of the adapter repository.
+const MAINTAINER_WHITELIST = ['mcm1957'];
+
 function getPullRequestNumber() {
     if (process.env.GITHUB_REF && process.env.GITHUB_REF.match(/refs\/pull\/\d+\/merge/)) {
         const result = /refs\/pull\/(\d+)\/merge/g.exec(process.env.GITHUB_REF);
@@ -67,6 +71,65 @@ async function fetchJsonAtRef(filename, ref) {
         console.error(`Cannot fetch ${filename} at ref ${ref}: ${e}`);
         return null;
     }
+}
+
+/**
+ * Check whether a GitHub user is a public member of an organization.
+ *
+ * Uses "GET /orgs/{org}/public_members/{username}" which is readable without any
+ * special access rights (it exposes publicly visible membership only):
+ *   - 204 No Content -> the user is a public member
+ *   - 404 Not Found  -> the user is not a public member (or membership is private)
+ */
+async function isPublicOrgMember(org, username) {
+    try {
+        // getGithub resolves on 2xx (204 -> empty body) and throws on 404.
+        await getGithub(`https://api.github.com/orgs/${encodeURIComponent(org)}/public_members/${encodeURIComponent(username)}`);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Determine whether the PR author is a legitimate maintainer of the adapter repository
+ * WITHOUT requiring write (push) access to that repository for the checking token.
+ *
+ * The GitHub "collaborator permission" API requires the caller itself to have push
+ * access to the target repo, so it cannot be used here - the check must work with a
+ * token that only has public/read access to third-party adapter repositories.
+ *
+ * Instead legitimacy is inferred from publicly readable facts:
+ *   1. The author owns the repository (`owner === author`) -> always has write access.
+ *   2. The repository is owned by an organization and the author is a *public* member
+ *      of that organization.
+ *
+ * This intentionally errs on the side of caution: private org members or plain repo
+ * collaborators that are not public org members are not detected and will cause the
+ * PR to be flagged with 'maintainer ?' for a manual review. The label is a review hint,
+ * not a hard block, so failing "closed" (towards a manual check) is the safe direction.
+ */
+async function isLegitimateAuthor(owner, username) {
+    if (!owner || !username) {
+        return false;
+    }
+
+    // 1. Author owns the repository.
+    if (owner.toLowerCase() === username.toLowerCase()) {
+        return true;
+    }
+
+    // 2. Repository owned by an organization the author publicly belongs to.
+    try {
+        const ownerInfo = await getGithub(`https://api.github.com/users/${encodeURIComponent(owner)}`);
+        if (ownerInfo && ownerInfo.type === 'Organization') {
+            return await isPublicOrgMember(owner, username);
+        }
+    } catch (e) {
+        console.error(`Cannot determine owner type of ${owner}: ${e}`);
+    }
+
+    return false;
 }
 
 /**
@@ -323,9 +386,20 @@ async function doIt() {
 
     const links = await detectAffectedAdapter(prID);
 
+    // Determine the creator (author) of this PR - required to validate maintainer access.
+    let prAuthor = '';
+    try {
+        const pr = await getGithub(`https://api.github.com/repos/ioBroker/ioBroker.repositories/pulls/${prID}`);
+        prAuthor = (pr.user && pr.user.login) || '';
+        console.log(`PR ${prID} created by ${prAuthor}`);
+    } catch (e) {
+        console.error(`Cannot determine author of PR ${prID}: ${e}`);
+    }
+
     const comments = [{ text: TEXT_COMMENT_TITLE }];
     let someChecked = false;
     let errorsFound = false;
+    let maintainerMissing = false;
 
     for (let i = 0; i < links.length; i++) {
         const data = await executeOneAdapterCheck(links[i]);
@@ -338,6 +412,24 @@ async function doIt() {
         console.log(``);
         console.log(`checking ${owner}/${adapter}`);
         triggerRepoCheck(owner, adapter);
+
+        // Validate that the creator of the PR is either whitelisted or a legitimate
+        // maintainer of the repository of the adapter which is added / updated by this PR.
+        // The validation only relies on publicly readable information (see isLegitimateAuthor).
+        const whitelisted = MAINTAINER_WHITELIST.some(user => user.toLowerCase() === prAuthor.toLowerCase());
+        if (whitelisted) {
+            console.log(`PR author ${prAuthor} is whitelisted - maintainer check passed for ${owner}/${adapter}`);
+        } else {
+            const legit = await isLegitimateAuthor(owner, prAuthor);
+            if (legit) {
+                console.log(`PR author ${prAuthor} is a legitimate maintainer of ${owner}/${adapter} - maintainer check passed`);
+            } else {
+                console.log(
+                    `PR author ${prAuthor} is neither whitelisted nor a verifiable maintainer of ${owner}/${adapter} - flagging 'maintainer ?'`,
+                );
+                maintainerMissing = true;
+            }
+        }
 
         try {
             const latestSVG = await getUrl(
@@ -560,6 +652,15 @@ async function doIt() {
             }
         } catch (e) {
             console.error(`Cannot add label: ${e}`);
+        }
+
+        if (maintainerMissing) {
+            try {
+                console.log(`setting label 'maintainer ?' for PR ${prID}`);
+                await addLabel(prID, ['maintainer ?']);
+            } catch (e) {
+                console.error(`Cannot add label 'maintainer ?': ${e}`);
+            }
         }
     }
 

--- a/lib/check.js
+++ b/lib/check.js
@@ -124,20 +124,32 @@ function isWhitelisted(owner, adapter, username) {
 }
 
 /**
- * Check whether the user has merged at least one of the last 100 pull requests of the
- * repository. Only users with write (push) access can merge pull requests, so this is a
- * reliable - and publicly readable - indication that the user is a maintainer.
+ * Check whether the user has merged at least one of the last 25 pull requests of the
+ * repository that were not created by dependabot. Only users with write (push) access
+ * can merge pull requests, so this is a reliable - and publicly readable - indication
+ * that the user is a maintainer.
  *
- * The pull request list endpoint does not include the `merged_by` field, so the merged
- * pull requests among the last 100 are inspected individually (short-circuiting as soon
- * as a match is found). This runs only as a fallback after the cheaper checks failed.
+ * Dependabot pull requests are excluded because they are frequently merged automatically
+ * and would otherwise dominate the recent history. The pull request list endpoint does
+ * not include the `merged_by` field, so the merged pull requests among the scanned 25
+ * are inspected individually (short-circuiting as soon as a match is found). This runs
+ * only as a fallback after the cheaper checks failed.
  */
+const RECENT_PR_SCAN_LIMIT = 25;
+
+function isDependabotPr(pr) {
+    const login = (pr && pr.user && pr.user.login) || '';
+    return login.toLowerCase().startsWith('dependabot');
+}
+
 async function hasMergedRecentPr(owner, adapter, username) {
     try {
         const prs = await getGithub(
             `https://api.github.com/repos/${owner}/${adapter}/pulls?state=closed&per_page=100&sort=updated&direction=desc`,
         );
-        const merged = (prs || []).filter(pr => pr && pr.merged_at);
+        const merged = (prs || [])
+            .filter(pr => pr && pr.merged_at && !isDependabotPr(pr))
+            .slice(0, RECENT_PR_SCAN_LIMIT);
         for (const pr of merged) {
             try {
                 const detail = await getGithub(


### PR DESCRIPTION
## What changed

Extends the adapter check in `lib/check.js`: for each checked adapter, the PR creator is verified as a legitimate maintainer of that adapter's repository, using **read-only / public** information only. The verification reason is reported in the check result comment; unverifiable authors get the `maintainer ?` label.

## Verification order

`verifyAuthorLegitimacy(owner, adapter, author)` returns the first matching reason, else `null`:

1. **Whitelisted** — `MAINTAINER_WHITELIST` entries are objects:
   - `{ user: 'mcm1957' }` → whitelisted for **all** repositories
   - `{ user: 'x', repos: ['owner/ioBroker.foo'] }` → whitelisted for the **listed** repos only (repo may be full name `owner/ioBroker.foo` or just `ioBroker.foo`)
   - initialized with `{ user: 'mcm1957' }`
2. **Repository owner** — `owner === author`.
3. **Public organization member** — owner is an org and the author is a public member (`GET /orgs/{org}/public_members/{author}`).
4. **Merged a recent PR** — the author has merged at least one of the **last 25 pull requests not created by dependabot**. Only users with write access can merge, so this is a reliable maintainer signal. Dependabot PRs are excluded (often auto-merged) and the scan is capped at 25 to bound API calls. (The pulls list omits `merged_by`, so the merged PRs are inspected individually, short-circuiting on the first match; runs only as a fallback after 1–3 fail.)

## Result comment

A line is appended at the end of the automated-checker comment for each checked adapter:
- verified: `✅ PR creator @user has been verified as legitimate maintainer of <adapter> because the user is: **<reason>**.`
- not verified: `⚠️ PR creator @user could not be verified as legitimate maintainer of <adapter>. The user needs to be validated manually.`

If not verified, the `maintainer ?` label is also attached.

## Why read-only verification

GitHub's *repository permissions for a user* API requires the **calling token to have push access** to the target repo, which the workflow token does not have on third-party adapter repos. All checks above rely on publicly readable data instead.

## Known limitations (acceptable)

Cannot detect private org members or collaborators who left no public trace and never merged a recent non-dependabot PR — those get flagged `maintainer ?` for manual review. `maintainer ?` is a review hint, not a hard block, so failing toward a human check is the safe direction. There are no false "passes" that silently admit an unauthorized author.

## Reviewer notes
- No workflow YAML change needed — `check.yml` already runs `npm run check`.
- The `maintainer ?` label is created automatically by the GitHub API on assignment if it does not already exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)