### PR TITLE
Improve wording of maintainer verification reasons

### DIFF
--- a/lib/check.js
+++ b/lib/check.js
@@ -201,19 +201,19 @@ async function verifyAuthorLegitimacy(owner, adapter, username) {
 
     // 1. Whitelisted (globally or for this repository).
     if (isWhitelisted(owner, adapter, username)) {
-        return 'whitelisted';
+        return 'is listed on the maintainer whitelist';
     }
 
     // 2. Author owns the repository.
     if (owner.toLowerCase() === username.toLowerCase()) {
-        return 'repository owner';
+        return 'is the owner of the repository';
     }
 
     // 3. Repository owned by an organization the author publicly belongs to.
     try {
         const ownerInfo = await getGithub(`https://api.github.com/users/${encodeURIComponent(owner)}`);
         if (ownerInfo && ownerInfo.type === 'Organization' && (await isPublicOrgMember(owner, username))) {
-            return 'public organization member';
+            return 'is a public member of the owning organization';
         }
     } catch (e) {
         console.error(`Cannot determine owner type of ${owner}: ${e}`);
@@ -221,7 +221,7 @@ async function verifyAuthorLegitimacy(owner, adapter, username) {
 
     // 4. Author has merged a recent pull request of the repository.
     if (await hasMergedRecentPr(owner, adapter, username)) {
-        return 'has merged a pull request of the repository';
+        return 'has merged a recent pull request of the repository';
     }
 
     return null;
@@ -540,7 +540,7 @@ async function doIt() {
                 `PR author ${prAuthor} verified as legitimate maintainer of ${owner}/${adapter}: ${legitimacyReason}`,
             );
             verificationLines.push(
-                `:white_check_mark: PR creator @${prAuthor} has been verified as legitimate maintainer of [${adapter}](${link}) because the user is: **${legitimacyReason}**.`,
+                `:white_check_mark: PR creator @${prAuthor} has been verified as legitimate maintainer of [${adapter}](${link}) because the user **${legitimacyReason}**.`,
             );
         } else {
             console.log(


### PR DESCRIPTION
## What changed

Follow-up to the merged maintainer-validation change (#6478). Rewords the verification reason strings in `lib/check.js` so the line appended to the automated-checker comment reads as a complete sentence.

Before:
> …verified as legitimate maintainer of <adapter> because the user is: **has merged a pull request of the repository**.

After:
> …verified as legitimate maintainer of <adapter> because the user **has merged a recent pull request of the repository**.

The template changed from `because the user is: **<reason>**` to `because the user **<reason>**`, and each reason is now a full verb clause:

| check | reason clause |
|---|---|
| whitelist | `is listed on the maintainer whitelist` |
| repo owner | `is the owner of the repository` |
| org member | `is a public member of the owning organization` |
| merged PR | `has merged a recent pull request of the repository` |

Wording only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)