### PR TITLE
Add liebherr to LATEST

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1650,6 +1650,11 @@
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.libre/main/admin/libre.png",
     "type": "health"
   },
+  "liebherr": {
+    "meta": "https://raw.githubusercontent.com/Gaspode69/ioBroker.liebherr/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Gaspode69/ioBroker.liebherr/main/admin/liebherr.png",
+    "type": "household"
+  },
   "life360ng": {
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.life360ng/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.life360ng/main/admin/Life360_s.svg",


### PR DESCRIPTION
Add the `liebherr` adapter to the ioBroker latest repository.

- Adapter repository: https://github.com/Gaspode69/ioBroker.liebherr
- npm package: https://www.npmjs.com/package/iobroker.liebherr
- Category: household
- Adapter checker: FINAL status OK
 
