### PR TITLE
check: report the release a stable PR actually pins (instead of npm latest)

### DIFF
--- a/lib/check.js
+++ b/lib/check.js
@@ -276,9 +276,14 @@ async function detectChangedAdaptersInFile(filename, baseRef, headRef) {
         if (!meta) {
             return null;
         }
-        return meta
-            .replace(/\/master\/io-package\.json$/, '')
-            .replace(/\/main\/io-package\.json$/, '');
+        return {
+            url: meta
+                .replace(/\/master\/io-package\.json$/, '')
+                .replace(/\/main\/io-package\.json$/, ''),
+            // The version pinned by the entry. Only sources-dist-stable.json entries
+            // carry one - for sources-dist.json entries this stays undefined.
+            version: headJson[name].version,
+        };
     }).filter(Boolean);
 }
 
@@ -329,10 +334,18 @@ async function detectAffectedAdapter(prID) {
 
     for (const filename of sourceFiles) {
         const changed = await detectChangedAdaptersInFile(filename, mergeBase, headRef);
-        changed.forEach(c => !adapters.includes(c) && adapters.push(c));
+        changed.forEach(c => {
+            const existing = adapters.find(a => a.url === c.url);
+            if (!existing) {
+                adapters.push(c);
+            } else if (!existing.version && c.version) {
+                // The same adapter changed in latest AND stable - keep the pinned stable version.
+                existing.version = c.version;
+            }
+        });
     }
 
-    console.log(`Detected changed adapters: ${adapters.join(', ')}`);
+    console.log(`Detected changed adapters: ${adapters.map(a => a.url + (a.version ? `@${a.version}` : '')).join(', ')}`);
     return adapters;
 }
 
@@ -520,7 +533,7 @@ async function doIt() {
     let maintainerMissing = false;
 
     for (let i = 0; i < links.length; i++) {
-        const data = await executeOneAdapterCheck(links[i]);
+        const data = await executeOneAdapterCheck(links[i].url);
         const parts = data.adapter.split('/');
         const adapter = parts.pop().replace('iobroker.', 'ioBroker.');
         const adapterName = adapter.split('.')[1];
@@ -639,6 +652,9 @@ async function doIt() {
             const now = new Date();
             const totalUser = statistic['adapters'][adapterName];
             const latestRelease = latest[adapterName].version;
+            // The release this PR actually pins in sources-dist-stable.json. Falls back
+            // to the current latest release when the changed entry could not be parsed.
+            const submittedRelease = links[i].version || latestRelease;
             const latestTime = new Date(latest[adapterName].versionDate);
             const latestTimeStr = `${latestTime.getDate()}.${latestTime.getMonth() + 1}.${latestTime.getFullYear()}`;
             const latestDaysOld = Math.floor((now.getTime() - latestTime.getTime()) / ONE_DAY);
@@ -649,15 +665,31 @@ async function doIt() {
 
             comments.push({ text: ``, noDecorate: true });
             comments.push({
-                text: `**History and usage information for release ${latestRelease}:**`,
+                text: `**History and usage information for submitted release ${submittedRelease}:**`,
                 noDecorate: true,
             });
             comments.push({ text: ``, noDecorate: true });
-            comments.push({
-                text: `${latestRelease} created ${latestTimeStr} (${latestDaysOld} days old)`,
-                noDecorate: true,
-            });
-            comments.push({ text: `${latestUser} users (${latestUserPercent}%)`, noDecorate: true });
+            if (submittedRelease === latestRelease) {
+                comments.push({
+                    text: `${latestRelease} created ${latestTimeStr} (${latestDaysOld} days old)`,
+                    noDecorate: true,
+                });
+                comments.push({ text: `${latestUser} users (${latestUserPercent}%)`, noDecorate: true });
+            } else {
+                const submittedUser = statistic['versions'][adapterName]
+                    ? statistic['versions'][adapterName][submittedRelease] || 0
+                    : 0;
+                const submittedUserPercent = ((submittedUser / totalUser) * 100).toFixed(2);
+
+                comments.push({
+                    text: `${submittedRelease} (submitted) - ${submittedUser} users (${submittedUserPercent}%)`,
+                    noDecorate: true,
+                });
+                comments.push({
+                    text: `${latestRelease} (latest) created ${latestTimeStr} (${latestDaysOld} days old) - ${latestUser} users (${latestUserPercent}%)`,
+                    noDecorate: true,
+                });
+            }
 
             if (stable[adapterName]) {
                 const stableRelease = latest[adapterName].stable;
@@ -682,8 +714,20 @@ async function doIt() {
             }
 
             comments.push({ text: ``, noDecorate: true });
+            if (submittedRelease !== latestRelease) {
+                comments.push({
+                    text:
+                        `:warning: This PR does **not** submit the current latest release (${latestRelease}) ` +
+                        `but the older release **${submittedRelease}**. ` +
+                        `Note that the repository check results above always describe the default branch ` +
+                        `of the repository and the npm latest release - they do not necessarily apply ` +
+                        `to the submitted release.`,
+                    noDecorate: true,
+                });
+                comments.push({ text: ``, noDecorate: true });
+            }
             comments.push({
-                text: `**Please verify that this PR really tries to update to release ${latestRelease}!**\n`,
+                text: `**Please verify that this PR really tries to update to release ${submittedRelease}!**\n`,
                 noDecorate: true,
             });
         } else {


### PR DESCRIPTION
## What happened

When a stable PR pins a release that is not the current npm latest, the "Automated adapter checker" comment reports misleading information: the "History and usage information" block and the final "**Please verify that this PR really tries to update to release X!**" line always show the **npm latest** release. The check flow reads only the `meta` URL of the changed sources entry — the `version` value submitted in `sources-dist-stable.json` is never parsed.

Real-world example: #6470 pinned `2.22.0`, but the checker comment asked to verify an update to release `2.23.1` and showed that release's statistics. Combined with the repochecker findings — which always describe the default branch of the adapter repository — the report suggested the PR would bring an admin-8 dependency into stable, although the pinned 2.22.0 requires admin 7 only. The PR was declined based on that report.

## What this PR changes (`lib/check.js` only)

- The changed-adapter detection now also captures the `version` pinned in `sources-dist-stable.json`. Entries in `sources-dist.json` carry no version — nothing changes for latest PRs.
- The "History and usage information" block is headed by the **submitted** release. If it equals npm latest, the output stays as today. If it differs, the block lists the submitted release with its user count plus the current latest release (with date and user count) for comparison.
- In that case an explicit warning is added: this PR does not submit the current latest release, and the repository check results above describe the default branch / npm latest — they do not necessarily apply to the submitted release.
- The final "Please verify…" line now names the submitted release.

For the common case (pinned version == npm latest) the comment stays effectively unchanged.

## How it was tested

`node --check` passes. The modified detection was executed read-only against three real PRs:

- #6470 (stable, pinned older release) → `{url: …/ioBroker.govee-smart, version: "2.22.0"}`
- #6469 (stable, pinned == latest at submission time) → `{url: …/ioBroker.hueemu, version: "1.12.1"}`
- #6373 (latest only) → `{url: …/ioBroker.nut2}` (no version — unchanged code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)