### PR TITLE
Add rdCheckedPrInfo workflow for rd-checked labels

### DIFF
--- a/.github/workflows/rdCheckedPrInfo.yml
+++ b/.github/workflows/rdCheckedPrInfo.yml
@@ -1,0 +1,34 @@
+# This workflow will triage pull requests and add or remove informational
+# comments based on the 'rd-checked ✔' and 'rd-checked ❌' labels.
+
+name: RD Checked PR Info
+
+#
+# WARNING:
+#    ** Do NOT run untrusted code when using pull_request_target **
+# pull_request_target is needed as pull_request does not provide secrets and so no
+# labeling of PR is possible.
+#
+on:
+  pull_request_target:
+    types: [labeled, unlabeled]
+
+jobs:
+  rdCheckedPrInfo:
+    name: rd checked PR info
+    if: |
+      github.repository == 'ioBroker/ioBroker.repositories'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        # safe operation as no ref is specified and so base branch is checked out
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - run: npm i
+      - run: npm run rdCheckedPrInfo
+        env:
+          OWN_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lib/rdCheckedPrInfo.js
+++ b/lib/rdCheckedPrInfo.js
@@ -1,0 +1,145 @@
+'use strict';
+const fs = require('node:fs');
+const { addComment, deleteComment, deleteLabel, getLabels, getAllComments } = require('./common');
+
+const LABEL_OK = 'rd-checked ✔';
+const LABEL_FAILED = 'rd-checked ❌';
+
+// hidden markers used to identify comments created by this workflow
+const MARKER_OK = '<!-- rd-checked-ok -->';
+const MARKER_FAILED = '<!-- rd-checked-failed -->';
+
+function getPullRequestNumber() {
+    if (process.env.GITHUB_REF && process.env.GITHUB_REF.match(/refs\/pull\/\d+\/merge/)) {
+        const result = /refs\/pull\/(\d+)\/merge/g.exec(process.env.GITHUB_REF);
+        if (!result) {
+            throw new Error('Reference not found.');
+        }
+        return result[1];
+    }
+    if (process.env.GITHUB_EVENT_PATH) {
+        const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+        return event.pull_request ? event.pull_request.number : event.issue ? event.issue.number : '';
+    }
+
+    throw new Error('Reference not found. process.env.GITHUB_REF and process.env.GITHUB_EVENT_PATH are not set!');
+}
+
+async function checkLabel(prID, label) {
+    const lbls = await getLabels(prID);
+    for (const lbl of lbls) {
+        console.log(`checking "${lbl.name}"`);
+        if (lbl.name === label) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function getOkBody() {
+    let body = `${MARKER_OK}\n`;
+    body += `:white_check_mark: Responsive check for adminUI was successful.\n`;
+    return body;
+}
+
+function getFailedBody() {
+    let body = `${MARKER_FAILED}\n`;
+    body += `:x: Responsive check for adminUI was not successful.\n\n`;
+    body += `Please check and correct responsive design of adminUI. `;
+    body += `A guide can be found at the following repository: `;
+    body += `https://github.com/iobroker-community-adapters/responsive-design-initiative. `;
+    body += `Testing is described here: `;
+    body += `https://github.com/iobroker-community-adapters/responsive-design-initiative/blob/main/developer_guide_optimizing_responsive_design.md\n`;
+    return body;
+}
+
+async function doIt() {
+    const prID = getPullRequestNumber();
+
+    console.log(`Process PR ${prID}`);
+
+    if (!prID) {
+        console.error('Cannot find PR');
+        return Promise.reject('Cannot find PR');
+    }
+
+    const okLabelIsSet = await checkLabel(prID, LABEL_OK);
+    const failedLabelIsSet = await checkLabel(prID, LABEL_FAILED);
+    console.log(`label "${LABEL_OK}" is ${okLabelIsSet ? '' : 'NOT '}set.`);
+    console.log(`label "${LABEL_FAILED}" is ${failedLabelIsSet ? '' : 'NOT '}set.`);
+
+    const gitComments = await getAllComments(prID);
+    const okComment = gitComments.find(comment => comment.body.includes(MARKER_OK));
+    const failedComment = gitComments.find(comment => comment.body.includes(MARKER_FAILED));
+    console.log(`RD-OK comment ${okComment ? 'exists' : 'does NOT exist'}.`);
+    console.log(`RD-FAILED comment ${failedComment ? 'exists' : 'does NOT exist'}.`);
+
+    async function removeComment(comment, name) {
+        if (!comment) {
+            return;
+        }
+        try {
+            console.log(`deleting ${name} comment ${comment.id} from PR ${prID}`);
+            await deleteComment(prID, comment.id);
+        } catch (e) {
+            console.error(`warning: cannot delete ${name} comment from PR ${prID}:`);
+            console.log(`           ${e}`);
+        }
+    }
+
+    async function createComment(body, name) {
+        try {
+            console.log(`adding ${name} comment to PR ${prID}`);
+            await addComment(prID, body);
+        } catch (e) {
+            console.error(`warning: cannot add ${name} comment to PR ${prID}:`);
+            console.log(`           ${e}`);
+        }
+    }
+
+    async function removeLabel(label) {
+        try {
+            console.log(`removing label "${label}" from PR ${prID}`);
+            await deleteLabel(prID, encodeURIComponent(label));
+        } catch (e) {
+            console.error(`warning: cannot remove label "${label}" from PR ${prID}:`);
+            console.log(`           ${e}`);
+        }
+    }
+
+    if (okLabelIsSet) {
+        // 'rd-checked ✔' present: ensure RD-OK comment, drop RD-FAILED comment and 'rd-checked ❌' label
+        await removeComment(failedComment, 'RD-FAILED');
+        if (!okComment) {
+            await createComment(getOkBody(), 'RD-OK');
+        }
+        if (failedLabelIsSet) {
+            await removeLabel(LABEL_FAILED);
+        }
+    } else if (failedLabelIsSet) {
+        // 'rd-checked ❌' present (and 'rd-checked ✔' not): ensure RD-FAILED comment, drop RD-OK comment
+        await removeComment(okComment, 'RD-OK');
+        if (!failedComment) {
+            await createComment(getFailedBody(), 'RD-FAILED');
+        }
+    } else {
+        // none of the labels present: remove any existing comments
+        await removeComment(okComment, 'RD-OK');
+        await removeComment(failedComment, 'RD-FAILED');
+    }
+
+    return 'done';
+}
+
+// activate for debugging purposes
+// process.env.GITHUB_REF = 'refs/pull/2725/merge';
+// process.env.OWN_GITHUB_TOKEN = 'insert token';
+// process.env.GITHUB_EVENT_PATH = __dirname + '/../event.json';
+
+console.log(`process.env.GITHUB_REF        = ${process.env.GITHUB_REF}`);
+console.log(`process.env.GITHUB_EVENT_PATH = ${process.env.GITHUB_EVENT_PATH}`);
+console.log(`process.env.OWN_GITHUB_TOKEN  = ${(process.env.OWN_GITHUB_TOKEN || '').length}`);
+
+doIt()
+    .then(result => console.log(result))
+    .catch(e => console.error(e));

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "checkNpm": "node lib/checkNpm.js",
     "manualAction": "node lib/manualAction.js",
     "newAtLatestPrInfo": "node lib/newAtLatestPrInfo.js",
+    "rdCheckedPrInfo": "node lib/rdCheckedPrInfo.js",
     "objJsonMissingPrInfo": "node lib/objJsonMissingPrInfo.js",
     "setLabels": "node lib/setLabels.js",
     "setStableTag": "node lib/setStableTag.js",


### PR DESCRIPTION
## What changed

Adds a new workflow `rdCheckedPrInfo.yml` (modeled on `newAtLatestPrInfo.yml`) and its backing script `lib/rdCheckedPrInfo.js`, plus an `rdCheckedPrInfo` npm script.

The workflow reacts to `pull_request_target` `labeled` / `unlabeled` events for the labels `rd-checked ✔` and `rd-checked ❌` and manages two info comments (RD-OK / RD-FAILED):

- **`rd-checked ✔` present:** delete any RD-FAILED comment, add an RD-OK comment if none exists, and remove the `rd-checked ❌` label.
- **`rd-checked ❌` present and `rd-checked ✔` absent:** delete any RD-OK comment, add an RD-FAILED comment if none exists.
- **Neither label present:** delete both RD-OK and RD-FAILED comments.

## Notes for reviewers

- Comments are identified by hidden HTML markers (`<!-- rd-checked-ok -->` / `<!-- rd-checked-failed -->`) rather than full-text matching.
- Label removal encodes the label name (`encodeURIComponent`) because it contains a space and emoji and is placed directly in the API URL path.
- RD-FAILED text uses "was not successful."

🤖 Generated with [Claude Code](https://claude.com/claude-code)