### PR TITLE
Update victron-gx to v0.10.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3337,7 +3337,7 @@
     "meta": "https://raw.githubusercontent.com/Sefina-DS/ioBroker.victron-gx/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Sefina-DS/ioBroker.victron-gx/main/admin/victron-gx.png",
     "type": "energy",
-    "version": "0.9.4"
+    "version": "0.10.0"
   },
   "viessmann": {
     "meta": "https://raw.githubusercontent.com/misanorot/ioBroker.viessmann/master/io-package.json",


### PR DESCRIPTION
**Stable version bump: 0.9.4 → 0.10.0**

- v0.10.0 has been in Latest for 20 days without any follow-up fix release (no 0.10.1 needed)
- Initial Stable inclusion (v0.9.4) was PR #6393 — this is the follow-up bump as previously announced
- v0.10.0 does contain a documented **breaking change** (removal of `control.*` branch, writable states moved under `devices.*`, config key `controlEnabled` → `modbusControlEnabled`) — auto-migration is in place and has proven itself in the Latest user base over the past 3 weeks
- Forum thread: https://forum.iobroker.net/topic/84991
- Live-running on Cerbo GX (production) plus community testing (Samson71 et al.)

Thanks!