### PR TITLE
Update dreame to 0.4.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -589,7 +589,7 @@
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.dreame/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.dreame/main/admin/dreame.png",
     "type": "household",
-    "version": "0.3.24"
+    "version": "0.4.1"
   },
   "drops-weather": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.drops-weather/main/io-package.json",


### PR DESCRIPTION
Bumping dreame from 0.3.24 to 0.4.1 in sources-dist-stable.json.

- 0.4.1 released on 2026-08-03, active in latest for 18 days
- No breaking changes for existing users
- Repochecker: OK (see recent runs)

Changelog: https://github.com/TA2k/ioBroker.dreame/releases/tag/v0.4.1