### PR TITLE
Update senec to 2.15.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2761,7 +2761,7 @@
     "meta": "https://raw.githubusercontent.com/nobl/ioBroker.senec/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/nobl/ioBroker.senec/master/admin/senec.png",
     "type": "energy",
-    "version": "2.14.1"
+    "version": "2.15.0"
   },
   "seplos-v3-sniffer": {
     "meta": "https://raw.githubusercontent.com/DpunktS/ioBroker.seplos-v3-sniffer/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.senec to version 2.15.0.

*This pull request was created by https://www.iobroker.dev ae24fc9.*