### PR TITLE
Update Yamaha adapter icon to SVG format

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -3927,7 +3927,7 @@
   },
   "yamaha": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.yamaha/master/io-package.json",
-    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.yamaha/master/admin/yamaha.png",
+    "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.yamaha/master/admin/yamaha.svg",
     "type": "multimedia"
   },
   "yeelight-2": {


### PR DESCRIPTION
Changed icon format from PNG to SVG for Yamaha adapter.