### PR TITLE
Update daswetter to 4.5.9

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -493,7 +493,7 @@
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.daswetter/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.daswetter/master/admin/daswettercom.png",
     "type": "weather",
-    "version": "4.5.3"
+    "version": "4.5.9"
   },
   "deconz": {
     "meta": "https://raw.githubusercontent.com/Jey-Cee/ioBroker.deconz/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.daswetter to version 4.5.9.

*This pull request was created by https://www.iobroker.dev ae24fc9.*