### PR TITLE
Add ai-usage 0.6.0 to latest repository

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -70,6 +70,11 @@
     "icon": "https://raw.githubusercontent.com/ToGe3688/ioBroker.ai-toolbox/main/admin/ai-toolbox.png",
     "type": "logic"
   },
+  "ai-usage": {
+    "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.ai-usage/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.ai-usage/main/admin/ai-usage.svg",
+    "type": "infrastructure"
+  },
   "aio": {
     "meta": "https://raw.githubusercontent.com/Newan/ioBroker.aio/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Newan/ioBroker.aio/master/admin/aio.png",


### PR DESCRIPTION
ai-usage reads how much of an AI account is already used up and puts it into ioBroker as datapoints: utilisation per limit window with its reset time, credits, costs. It only reads — it never calls or configures an AI service.

Claude, ChatGPT and Google subscriptions are signed in with the user's own account, guided step by step in the settings page. Key-based accounts (OpenRouter, DeepSeek, and OpenAI/Anthropic as an organisation) come from the admin's central credential storage. Every account gets the same datapoints regardless of the provider behind it, one warn threshold each, and totals across all accounts.

**Checklist**

- [x] The adapter is published to NPM — https://www.npmjs.com/package/iobroker.ai-usage
- [x] Developer Best practices are known and considered
- [x] All requirements to bring a new adapter into Latest repository are fulfilled
- [ ] The adapter was checked and no warnings or errors are shown — see below, the remaining findings are the expected ones
- [x] Forum testing thread: https://forum.iobroker.net/topic/85243/test-adapter-ai-usage-0-6-0

**Checker findings and why they stand**

- `E2001` npm collaborator: bluefox was invited today, acceptance pending.
- `E4033` `admin >= 8.0.1` is not in the stable repository yet. The adapter uses the admin's central credential storage, which exists from Admin 8 on, so the dependency is deliberate.
- `W4001` not in the latest repository — this request.
- `W3050` / `W3052` could not retrieve job logs: the referenced runs finished minutes before the check; the workflow itself is green across six environments including the release run.

Requires js-controller >= 7.2.2, Node >= 22, Admin >= 8.0.1.
