### PR TITLE
Add victoriametrics to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -3415,6 +3415,11 @@
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.vesync/main/admin/vesync.png",
     "type": "climate-control"
   },
+  "victoriametrics": {
+    "meta": "https://raw.githubusercontent.com/seaspotter/ioBroker.victoriametrics/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/seaspotter/ioBroker.victoriametrics/main/admin/victoriametrics.png",
+    "type": "storage"
+  },
   "victron-cerbo": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.victron-cerbo/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.victron-cerbo/main/admin/victron-cerbo.svg",


### PR DESCRIPTION
## Adapter
[ioBroker.victoriametrics](https://github.com/seaspotter/ioBroker.victoriametrics) - writes ioBroker datapoint history natively to VictoriaMetrics via its JSON-lines import API, with real Prometheus labels instead of field-name suffixes. Also implements the `getHistory()` read path so vis chart widgets can query it directly, with server-side PromQL pushdown for standard aggregations.

Published on npm as `iobroker.victoriametrics`, currently at 0.4.2