### PR TITLE
Add lox2hue to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1740,6 +1740,11 @@
     "icon": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lowpass-filter/main/admin/lowpass-filter.png",
     "type": "misc-data"
   },
+  "lox2hue": {
+    "meta": "https://raw.githubusercontent.com/Infi001/ioBroker.lox2hue/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Infi001/ioBroker.lox2hue/main/admin/lox2hue.png",
+    "type": "lighting"
+  },
   "loxone": {
     "meta": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.loxone/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/UncleSamSwiss/ioBroker.loxone/master/admin/loxone.png",


### PR DESCRIPTION
Adds `lox2hue` to the latest repository.

- Repo: https://github.com/Infi001/ioBroker.lox2hue
- npm: https://www.npmjs.com/package/iobroker.lox2hue
- Mirrors Loxone LightControllerV2 light-control moods onto Philips Hue lamps, with a per-room/per-mood Hue bridge scene cache for near-simultaneous switching.
- `@iobroker/repochecker` passes with `FINAL status 'OK'`.
- `bluefox` has been added and accepted as an npm co-owner.
- Entry generated with `npm run addToLatest -- --name lox2hue --type lighting`.