### PR TITLE
Update vis-2-widgets-rssfeed to 1.2.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3427,7 +3427,7 @@
     "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-2-widgets-rssfeed/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-2-widgets-rssfeed/main/admin/vis-2-widgets-rssfeed.png",
     "type": "visualization-widgets",
-    "version": "1.2.2"
+    "version": "1.2.3"
   },
   "vis-2-widgets-sigenergy": {
     "meta": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-sigenergy/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-2-widgets-rssfeed to version 1.2.3.

*This pull request was created by https://www.iobroker.dev ae24fc9.*