### PR TITLE
Add autism-support adapter to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -180,6 +180,11 @@
     "icon": "https://raw.githubusercontent.com/chrmenne/ioBroker.aurora-nowcast/main/admin/aurora-nowcast.png",
     "type": "weather"
   },
+  "autism-support": {
+    "meta": "https://raw.githubusercontent.com/MatthiasUlrich1/ioBroker.autism-support/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/MatthiasUlrich1/ioBroker.autism-support/main/admin/autism-support.png",
+    "type": "general"
+  },
   "autodarts": {
     "meta": "https://raw.githubusercontent.com/inventwo/ioBroker.autodarts/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/inventwo/ioBroker.autodarts/main/admin/autodarts.svg",


### PR DESCRIPTION
## Summary
- Adds `autism-support` (Visual Countdown, daily/weekly schedules, pictograms) to the latest repository.
- Adapter repo: https://github.com/MatthiasUlrich1/ioBroker.autism-support
- npm: `iobroker.autism-support@0.2.1`
- Type: `general`

## Test plan
- [ ] Repochecker bot comment on this PR is green
- [ ] Entry appears in ioBroker Admin adapter list after merge + repo refresh
