### PR TITLE
Add eebus-go 1.2.0 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -663,6 +663,12 @@
     "type": "household",
     "version": "1.4.15"
   },
+  "eebus-go": {
+    "meta": "https://raw.githubusercontent.com/FernetMenta/ioBroker.eebus-go/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/FernetMenta/ioBroker.eebus-go/main/admin/eebus-go.png",
+    "type": "iot-systems",
+    "version": "1.2.0"
+  },
   "egigeozone2": {
     "meta": "https://raw.githubusercontent.com/obakuhl/ioBroker.egigeozone2/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/obakuhl/ioBroker.egigeozone2/master/admin/egigeozone.png",


### PR DESCRIPTION
Please update my adapter ioBroker.eebus-go to version 1.2.0.

*This pull request was created by https://www.iobroker.dev ae24fc9.*