### PR TITLE
Add nuki-local to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2195,6 +2195,11 @@
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.nuki-extended/master/admin/nuki-extended.png",
     "type": "hardware"
   },
+  "nuki-local": {
+  "meta": "https://raw.githubusercontent.com/helfi9999/ioBroker.nuki-local/main/io-package.json",
+  "icon": "https://raw.githubusercontent.com/helfi9999/ioBroker.nuki-local/main/admin/nuki-local.png",
+  "type": "hardware"
+},
   "nut": {
     "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.nut/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.nut/master/admin/nut.png",

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2196,10 +2196,10 @@
     "type": "hardware"
   },
   "nuki-local": {
-  "meta": "https://raw.githubusercontent.com/helfi9999/ioBroker.nuki-local/main/io-package.json",
-  "icon": "https://raw.githubusercontent.com/helfi9999/ioBroker.nuki-local/main/admin/nuki-local.png",
-  "type": "hardware"
-},
+    "meta": "https://raw.githubusercontent.com/helfi9999/ioBroker.nuki-local/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/helfi9999/ioBroker.nuki-local/main/admin/nuki-local.png",
+    "type": "hardware"
+  },
   "nut": {
     "meta": "https://raw.githubusercontent.com/Apollon77/ioBroker.nut/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Apollon77/ioBroker.nut/master/admin/nut.png",


### PR DESCRIPTION
Adds the nuki-local adapter to the latest repository.

Adapter repository:
https://github.com/helfi9999/ioBroker.nuki-local

Current version: 0.1.2