### PR TITLE
Update homewizard to 0.16.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1261,7 +1261,7 @@
     "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.homewizard/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.homewizard/main/admin/homewizard.svg",
     "type": "energy",
-    "version": "0.15.0"
+    "version": "0.16.0"
   },
   "hoymiles": {
     "meta": "https://raw.githubusercontent.com/Eistee82/ioBroker.hoymiles/main/io-package.json",


### PR DESCRIPTION
**Checklist**
- [x] Adapter testing is still green for the current version — CI is green and it runs on the maintainer's own installation without regressions.
- [ ] User feedback: ioBroker.homewizard 0.16.0 has been in the latest repository since 2026-08-27 with no problem reports on the testing thread (https://forum.iobroker.net/topic/84709/test-adapter-homewizard-0.11) or the issue tracker. No explicit user confirmations were collected — but no negative reports either.

Updates the stable version of ioBroker.homewizard from 0.15.0 to 0.16.0 (current latest).
