### PR TITLE
Update govee-smart to 2.27.1

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1045,7 +1045,7 @@
     "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.govee-smart/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.govee-smart/main/admin/govee-smart.svg",
     "type": "lighting",
-    "version": "2.27.0"
+    "version": "2.27.1"
   },
   "gree-hvac": {
     "meta": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/io-package.json",


### PR DESCRIPTION
**Checklist**
- [x] Adapter testing is still green for the current version — CI is green and it runs on the maintainer's own installation without regressions.
- [ ] User feedback: ioBroker.govee-smart 2.27.1 has been in the latest repository since 2026-09-01 with no problem reports on the testing thread (https://forum.iobroker.net/topic/84712/test-adapter-govee-smart-2.14.1) or the issue tracker. No explicit user confirmations were collected — but no negative reports either.

Updates the stable version of ioBroker.govee-smart from 2.27.0 to 2.27.1 (current latest).


Note: this version requires Admin >= 8.0.1 (the configuration UI is an Admin 8 component). With Admin 8.0.11 now in the stable repository, that requirement is satisfiable on the stable track; installations still on Admin 7 are protected by the install-side dependency check and simply keep their current version.
