### PR TITLE
Update public-holidays to 0.14.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2473,7 +2473,7 @@
     "meta": "https://raw.githubusercontent.com/krobipd/ioBroker.public-holidays/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/krobipd/ioBroker.public-holidays/main/admin/public-holidays.svg",
     "type": "date-and-time",
-    "version": "0.13.2"
+    "version": "0.14.0"
   },
   "public-transport": {
     "meta": "https://raw.githubusercontent.com/tt-tom17/ioBroker.public-transport/main/io-package.json",


### PR DESCRIPTION
**Checklist**
- [x] Adapter testing is still green for the current version — CI is green and it runs on the maintainer's own installation without regressions.
- [ ] User feedback: ioBroker.public-holidays 0.14.0 has been in the latest repository since 2026-09-01 with no problem reports on the testing thread (https://forum.iobroker.net/topic/84918/test-adapter-public-holidays) or the issue tracker. No explicit user confirmations were collected — but no negative reports either.

Updates the stable version of ioBroker.public-holidays from 0.13.2 to 0.14.0 (current latest).


Note: this version requires Admin >= 8.0.1 (the configuration UI is an Admin 8 component). With Admin 8.0.11 now in the stable repository, that requirement is satisfiable on the stable track; installations still on Admin 7 are protected by the install-side dependency check and simply keep their current version.
