### PR TITLE
Add sunenergyxt500 0.2.10 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3081,6 +3081,12 @@
     "type": "energy",
     "version": "0.1.3"
   },
+  "sunenergyxt500": {
+    "meta": "https://raw.githubusercontent.com/Creekhail/ioBroker.sunenergyxt500/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Creekhail/ioBroker.sunenergyxt500/main/admin/sunenergyxt500.png",
+    "type": "energy",
+    "version": "0.2.10"
+  },
   "sureflap": {
     "meta": "https://raw.githubusercontent.com/Sickboy78/ioBroker.sureflap/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/Sickboy78/ioBroker.sureflap/master/admin/sureflap.png",


### PR DESCRIPTION
Please add my adapter ioBroker.sunenergyxt500 version 0.2.10 to the stable repository.

Requested by the check-and-service bot in Creekhail/ioBroker.sunenergyxt500#17 — latest has been available for 31 days with 9 of 13 installations already on it.

`npx @iobroker/repochecker Creekhail/ioBroker.sunenergyxt500` reports `FINAL status 'OK'` with no errors and no warnings.