### PR TITLE
Add apple to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -185,6 +185,11 @@
     "icon": "https://raw.githubusercontent.com/HGlab01/ioBroker.apg-info/main/admin/apg-info.png",
     "type": "general"
   },
+  "apple": {
+    "meta": "https://raw.githubusercontent.com/Musashi1965/ioBroker.apple/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Musashi1965/ioBroker.apple/main/admin/apple.png",
+    "type": "multimedia"
+  },
   "apsystems-ez1": {
     "meta": "https://raw.githubusercontent.com/zhihaining/ioBroker.apsystems-ez1/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/zhihaining/ioBroker.apsystems-ez1/master/admin/apsystems-ez1.png",


### PR DESCRIPTION
Adds the ioBroker Apple adapter to the latest repository.\n\nAdapter: apple\nRepository: https://github.com/Musashi1965/ioBroker.apple\nnpm: https://www.npmjs.com/package/iobroker.apple\nVersion: 0.3.2\nType: multimedia\n\nVerification before submission:\n- npm package published as iobroker.apple@0.3.2\n- GitHub release v0.3.2 exists\n- Adapter tag workflow passed on Linux, macOS, and Windows with Node.js 22, 24, and 26\n- Local adapter full quality gate passed\n- ioBroker repochecker returned FINAL status OK before latest submission; remaining findings were expected publication/latest follow-ups\n- bluefox npm maintainer invitation is pending from the package owner side