### PR TITLE
Update vis-2-widgets-sigenergy to 1.8.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3445,7 +3445,7 @@
     "meta": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-sigenergy/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-sigenergy/main/admin/vis-2-widgets-sigenergy.png",
     "type": "visualization-widgets",
-    "version": "1.8.2"
+    "version": "1.8.3"
   },
   "vis-2-widgets-tibberlink": {
     "meta": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-tibberlink/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-2-widgets-sigenergy to version 1.8.3 in the stable repository.

- Version 1.8.3 was released on 2026-08-05 (about 4 weeks ago), no open bug reports.
- Repochecker: no errors, no warnings (see ssbingo/ioBroker.vis-2-widgets-sigenergy#39).
- Requested by ioBroker-Bot in ssbingo/ioBroker.vis-2-widgets-sigenergy#37.