### PR TITLE
Add sigenergy 3.2.0 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2823,6 +2823,12 @@
     "type": "climate-control",
     "version": "1.2.1"
   },
+  "sigenergy": {
+    "meta": "https://raw.githubusercontent.com/ssbingo/ioBroker.sigenergy/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/ssbingo/ioBroker.sigenergy/main/admin/sigenergy.png",
+    "type": "energy",
+    "version": "3.2.0"
+  },
   "signal-cmb": {
     "meta": "https://raw.githubusercontent.com/derAlff/ioBroker.signal-cmb/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/derAlff/ioBroker.signal-cmb/master/admin/signal-cmb.png",


### PR DESCRIPTION
**Checklist**  
[x] All technical requirements to bring a new adapter into Stable repository are fulfilled (see https://github.com/ioBroker/ioBroker.repositories#requirements-for-adapter-to-get-added-to-the-stable-repository)
[x] Please add a link to Forum testing thread, if existing.

Forum testing thread: https://forum.iobroker.net/topic/84369/test-adapter-sigenergy-v1.9.x-github-latest

---

**Adapter:** `ioBroker.sigenergy` — Sigenergy solar energy systems (hybrid inverter, battery, AC/DC charger, SigenMicro) via Modbus TCP/RTU.

| | |
|---|---|
| In latest repository since | 2026-04-21 (#5597) |
| Proposed stable version | 3.2.0 |
| Installations | ~20 |
| npm downloads (last month) | ~1,234 |
| Repository checker | no errors |
| `npm audit` | 0 vulnerabilities |
| CI | green on Node 22 + 24 across ubuntu / windows / macOS |

Requirements already met:
* The adapter has been in the latest repository since April 2026.
* `bluefox` is an owner of the npm package.
* Configuration uses `jsonConfig` with file-based i18n in all 11 languages.
* All states use valid roles; `info.connection` is implemented.
* Package and integration tests run in GitHub Actions on every push.
* The open repository checker issue (ssbingo/ioBroker.sigenergy#72) reported no errors; the warning and the two actionable suggestions were fixed in 3.2.0.

Discovery: the system is reached over Modbus TCP (port 502) with a configurable unit id, and the adapter already ships an auto-detect for the device type plus a scan for SigenMicro micro-inverters. A PR for the discovery adapter can follow after stable acceptance, as noted in the requirements.
