### PR TITLE
Add heatpump-modbus to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -1210,6 +1210,11 @@
     "icon": "https://raw.githubusercontent.com/rg-engineering/ioBroker.heatingcontrol/master/admin/heatingcontrol.png",
     "type": "climate-control"
   },
+  "heatpump-modbus": {
+    "meta": "https://raw.githubusercontent.com/helgekaiser/ioBroker.heatpump-modbus/main/io-package.json",
+    "icon": "https://github.com/helgekaiser/ioBroker.heatpump-modbus/raw/main/admin/heatpump-modbus.png",
+    "type": "climate-control"
+  },
   "heishamon": {
     "meta": "https://raw.githubusercontent.com/TobiasHanss/ioBroker.heishamon/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/TobiasHanss/ioBroker.heishamon/main/admin/heishamon.png",


### PR DESCRIPTION
Add heatpump-modbus to the latest repository.
npm package iobroker.heatpump-modbus@0.0.3 is published.
Repository tests passed locally.