### PR TITLE
Add fritzwireguard to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -985,6 +985,11 @@
     "icon": "https://raw.githubusercontent.com/foxthefox/ioBroker.fritzdect/master/admin/fritzdect_logo.png",
     "type": "hardware"
   },
+  "fritzwireguard": {
+    "meta": "https://raw.githubusercontent.com/MPunktBPunkt/ioBroker.fritzwireguard/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/MPunktBPunkt/ioBroker.fritzwireguard/main/admin/fritzwireguard.svg",
+    "type": "network"
+  },
   "froeling": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.froeling/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.froeling/master/admin/froeling.png",


### PR DESCRIPTION
## Summary
- Add `fritzwireguard` adapter to the latest (`sources-dist.json`) repository
- Type: `network`
- Meta/icon point to https://github.com/MPunktBPunkt/ioBroker.fritzwireguard

## Adapter
- **Name:** fritzwireguard
- **npm:** iobroker.fritzwireguard
- **GitHub:** https://github.com/MPunktBPunkt/ioBroker.fritzwireguard
- **Type:** network

## Test plan
- [ ] CI checks for repository files pass
- [ ] Adapter appears correctly in latest repository after merge


Made with [Cursor](https://cursor.com)