### PR TITLE
Add ecovacs-map to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -740,6 +740,11 @@
     "icon": "https://raw.githubusercontent.com/mrbungle64/ioBroker.ecovacs-deebot/master/admin/ecovacs-deebot.png",
     "type": "household"
   },
+  "ecovacs-map": {
+    "meta": "https://raw.githubusercontent.com/helfi9999/ioBroker.ecovacs-map/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/helfi9999/ioBroker.ecovacs-map/main/admin/ecovacs-map.png",
+    "type": "misc"
+  },
   "eebus-go": {
     "meta": "https://raw.githubusercontent.com/FernetMenta/ioBroker.eebus-go/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/FernetMenta/ioBroker.eebus-go/main/admin/eebus-go.png",

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -743,7 +743,7 @@
   "ecovacs-map": {
     "meta": "https://raw.githubusercontent.com/helfi9999/ioBroker.ecovacs-map/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/helfi9999/ioBroker.ecovacs-map/main/admin/ecovacs-map.png",
-    "type": "misc"
+    "type": "household"
   },
   "eebus-go": {
     "meta": "https://raw.githubusercontent.com/FernetMenta/ioBroker.eebus-go/main/io-package.json",


### PR DESCRIPTION
Adds ioBroker.ecovacs-map to the latest repository.

Adapter repository:
https://github.com/helfi9999/ioBroker.ecovacs-map

npm package:
iobroker.ecovacs-map