### PR TITLE
Add esmobil to LATEST

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -851,8 +851,8 @@
     "type": "infrastructure"
   },
   "esmobil": {
-    "meta": "https://raw.githubusercontent.com/beabel/ioBroker.ESmobil/main/io-package.json",
-    "icon": "https://raw.githubusercontent.com/beabel/ioBroker.ESmobil/main/admin/esmobil.png",
+    "meta": "https://raw.githubusercontent.com/beabel/ioBroker.esmobil/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/beabel/ioBroker.esmobil/main/admin/esmobil.png",
     "type": "date-and-time"
   },
   "esphome": {

--- a/sources-dist.json
+++ b/sources-dist.json
@@ -850,6 +850,11 @@
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.epson_stylus_px830/master/admin/epson_stylus_px830.png",
     "type": "infrastructure"
   },
+  "esmobil": {
+    "meta": "https://raw.githubusercontent.com/beabel/ioBroker.ESmobil/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/beabel/ioBroker.ESmobil/main/admin/esmobil.png",
+    "type": "date-and-time"
+  },
   "esphome": {
     "meta": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.esphome/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/DrozmotiX/ioBroker.esphome/main/admin/esphome.png",


### PR DESCRIPTION
Adds the esmobil adapter (school timetable and homework/remarks/grades for the TEGW school group) to the latest repository.

- npm: https://www.npmjs.com/package/iobroker.esmobil (currently 0.5.3, published via npm trusted publishing/provenance)
- Repository: https://github.com/beabel/ioBroker.esmobil
- CI (lint + adapter tests on Node 22.x/24.x across Linux/Windows/macOS): green
- Repository checker (ioBroker-Bot on the adapter repo, https://github.com/beabel/ioBroker.esmobil/issues/1): all errors and warnings resolved
- bluefox has been invited as npm package owner (invite pending acceptance)