### PR TITLE
Add skoda-public-api to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -2895,6 +2895,11 @@
     "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.skiinfo/main/admin/skiinfo.png",
     "type": "misc-data"
   },
+  "skoda-public-api": {
+    "meta": "https://raw.githubusercontent.com/tmarthy/ioBroker.skoda-public-api/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/tmarthy/ioBroker.skoda-public-api/main/admin/skoda-public-api.png",
+    "type": "vehicle"
+  },
   "sky-remote": {
     "meta": "https://raw.githubusercontent.com/AlanSRU/ioBroker.sky-remote/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/AlanSRU/ioBroker.sky-remote/main/admin/sky-remote.png",


### PR DESCRIPTION
skoda-public-api reads and controls Škoda vehicles through the official MyŠkoda Public API. It exposes vehicle, range, charging, climate and parking data, supports the available remote commands, and manages the API limit of 20 requests per hour and vehicle. Version 0.0.2 is published through npm Trusted Publishing with SLSA provenance.

**Checklist**

- [x] The adapter is published to NPM — https://www.npmjs.com/package/iobroker.skoda-public-api
- [x] Developer best practices are known and considered
- [x] All requirements to bring a new adapter into the Latest repository are fulfilled
- [x] The adapter was checked and no warnings or errors are shown — Repochecker 5.20.14 reports `FINAL status 'OK'`; the remaining findings are explained below
- [x] Forum testing thread — https://forum.iobroker.net/topic/85303/test-adapter-skoda-public-api-v0.1.x

**Checker findings and why they remain**

- `E2001`: `bluefox` was invited as npm maintainer on 2026-09-05; acceptance is pending.
- `W3050` / `W3052`: the checker could not retrieve individual GitHub Actions logs. The 0.0.2 release workflow itself completed successfully across Node.js 22 and 24 on Linux, Windows and macOS: https://github.com/tmarthy/ioBroker.skoda-public-api/actions/runs/33970273661
- `W4001`: the adapter is not in Latest yet; this pull request addresses it.
- `W5049` / `S1039`: `SKODA_API_BASE_URL` is used exclusively to point mock and integration tests at a local server. Compact mode is therefore explicitly disabled.
- `W6020`: `CHANGELOG_OLD.md` is unnecessary for the single initial changelog entry.

Requires Node.js >= 22, js-controller >= 6.0.11 and Admin >= 7.6.20.
