### PR TITLE
Reclassify object-structure warnings W1001/W3001 as errors E6001/E8001

### DIFF
--- a/lib/checkObjectStructure.js
+++ b/lib/checkObjectStructure.js
@@ -371,9 +371,9 @@ const ERROR_EXPLANATIONS = {
           + '**Lösung:** Ändere `common.type` auf einen dieser gültigen Werte.',
     },
 
-    // ── W1xxx  i18n warnings ──────────────────────────────────────────────
+    // ── E6xxx  i18n errors (reclassified from checker warning W1001) ──────
 
-    W1001: {
+    E6001: {
         en: 'An i18n object (e.g. `common.name` or `common.desc`) is missing one or more *recommended*'
           + ' language keys. The required languages `en` and `de` are already present, but ioBroker'
           + ' recommends also providing translations for: `ru`, `pt`, `nl`, `fr`, `it`, `es`, `pl`, `uk`, `zh-cn`.'
@@ -388,9 +388,9 @@ const ERROR_EXPLANATIONS = {
           + ' Falls nicht alle Sprachen praktikabel sind, stelle mindestens sicher, dass `en` und `de` vorhanden sind.',
     },
 
-    // ── W3xxx  Object id warnings ─────────────────────────────────────────
+    // ── E8xxx  Object id errors (reclassified from checker warning W3001) ─
 
-    W3001: {
+    E8001: {
         en: 'The object id contains characters outside the recommended set `[a-zA-Z0-9_,-]`.'
           + ' While these characters are not strictly forbidden, they can cause problems in certain'
           + ' ioBroker adapters, scripts, and visualisations that do not expect special characters in ids.\n\n'
@@ -402,6 +402,44 @@ const ERROR_EXPLANATIONS = {
           + '**Lösung:** Erwäge, das Objekt umzubenennen und dabei nur alphanumerische Zeichen, Unterstriche, Kommas und Bindestriche zu verwenden.',
     },
 };
+
+// ── Warning → error reclassification ─────────────────────────────────────────
+//
+// Some checker warnings are considered blocking in this repository and are
+// therefore promoted to errors. The key is the original warning code as emitted
+// by objectStructure.js; the value is the new error code (original + 5000 offset).
+// Only these codes are promoted — every other warning keeps being reported as a
+// warning, so general warning handling stays intact for future warning codes.
+const WARNING_TO_ERROR = {
+    W1001: 'E6001',
+    W3001: 'E8001',
+};
+
+/**
+ * Move the warnings listed in WARNING_TO_ERROR from `result.warnings` to
+ * `result.errors`, rewriting their `code` to the mapped error code.
+ * The object is mutated in place. Warnings whose code is not in the map are
+ * left untouched and remain in `result.warnings`.
+ *
+ * @param {{ errors: {code: string, message: string}[], warnings: {code: string, message: string}[] }} result
+ */
+function reclassifyWarningsAsErrors(result) {
+    if (!result || !Array.isArray(result.warnings) || !Array.isArray(result.errors)) {
+        return;
+    }
+
+    const remaining = [];
+    for (const warning of result.warnings) {
+        const mappedCode = WARNING_TO_ERROR[warning.code];
+        if (mappedCode) {
+            console.log(`  Reclassifying warning ${warning.code} as error ${mappedCode}.`);
+            result.errors.push({ ...warning, code: mappedCode });
+        } else {
+            remaining.push(warning);
+        }
+    }
+    result.warnings = remaining;
+}
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -758,6 +796,14 @@ async function doIt() {
     console.log(`Running checkObjectStructure for adapter: "${adapter}"`);
 
     const result = checkObjectStructure(objects, adapter);
+
+    // ── 9a. Reclassify selected warnings as errors ────────────────────────
+    //        Certain checker warnings are treated as hard errors in this repo.
+    //        Each such warning is moved from result.warnings to result.errors
+    //        and its code is shifted by +5000 (W1001 → E6001, W3001 → E8001).
+    //        General warning handling is intentionally kept for any other
+    //        warning codes the checker may emit now or in the future.
+    reclassifyWarningsAsErrors(result);
 
     console.log(`\nResult – errors: ${result.errors.length}, warnings: ${result.warnings.length}`);
     if (result.errors.length > 0) {


### PR DESCRIPTION
## What changed

`lib/checkObjectStructure.js` now promotes two checker warnings to hard errors:

- `W1001` (missing recommended i18n language keys) → **`E6001`**
- `W3001` (object id outside recommended charset) → **`E8001`**

The new code is the original number + a 5000 offset. A new `reclassifyWarningsAsErrors()` step runs right after `checkObjectStructure()`, moving these entries from `result.warnings` into `result.errors` (rewriting their `code`) so they render in the ❌ Errors table of the PR comment.

The bilingual help texts previously keyed `W1001`/`W3001` in `ERROR_EXPLANATIONS` were re-keyed to `E6001`/`E8001`, so explanations still attach to the reclassified codes.

## Why

These structural issues are considered blocking in this repository and should be surfaced as errors rather than warnings.

## Reviewer notes

- General warning handling is deliberately left intact — the warnings table, output, and labels still work; only the two mapped codes are promoted, and any other/future warning codes continue to be reported as warnings.
- Promotion is driven by a small `WARNING_TO_ERROR` map, so adding more mappings later is trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)