### PR TITLE
Add tint to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -3260,6 +3260,11 @@
     "icon": "https://raw.githubusercontent.com/bowao/ioBroker.tino/master/admin/tino.png",
     "type": "hardware"
   },
+  "tint": {
+    "meta": "https://raw.githubusercontent.com/ssbingo/ioBroker.tint/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/ssbingo/ioBroker.tint/main/admin/tint.png",
+    "type": "hardware"
+  },
   "tinymqttbroker": {
     "meta": "https://raw.githubusercontent.com/HGlab01/ioBroker.tinymqttbroker/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/HGlab01/ioBroker.tinymqttbroker/main/admin/tinymqttbroker.png",


### PR DESCRIPTION
Please add my adapter ioBroker.tint to latest.

- Repository: https://github.com/ssbingo/ioBroker.tint
- npm: https://www.npmjs.com/package/iobroker.tint (current version 0.5.2)
- Type: `hardware` (Müller Licht tint Zigbee lights via deCONZ/ConBee)

**Checklist**
- [x] The adapter is published to NPM (`bluefox` is npm owner)
- [x] Developer Best practices are known and considered (see https://github.com/ioBroker/ioBroker.repositories#development-and-coding-best-practices)
- [x] All requirements to bring a new adapter into Latest repository are fulfilled (see https://github.com/ioBroker/ioBroker.repositories#requirements-for-adapter-to-get-added-to-the-latest-repository)
- [x] The adapter was checked by the repository checker: no errors; the only warning is W4001 ("not in latest repository"), which this PR resolves
- [ ] Forum testing thread: none yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)
