### PR TITLE
Add cometvisu to LATEST

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -515,6 +515,11 @@
     "icon": "https://raw.githubusercontent.com/Bannsaenger/ioBroker.codesys-nvl/main/admin/codesys-nvl.png",
     "type": "hardware"
   },
+  "cometvisu": {
+    "meta": "https://raw.githubusercontent.com/joltcoke/ioBroker.cometvisu/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/joltcoke/ioBroker.cometvisu/main/admin/cometvisu.png",
+    "type": "visualization"
+  },
   "comfoair": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.comfoair/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.comfoair/master/admin/comfoair.png",


### PR DESCRIPTION
Adds `cometvisu` to the latest repository.

[CometVisu](https://www.cometvisu.org) is a web based visualisation for home automation, developed
at [CometVisu/CometVisu](https://github.com/CometVisu/CometVisu). The adapter serves a CometVisu
build through `iobroker.web` and connects it to ioBroker as its backend. It has no web server of
its own — delivery, login, session and socket all come from the web instance it is configured for.

Adapter: https://github.com/joltcoke/ioBroker.cometvisu
npm: https://www.npmjs.com/package/iobroker.cometvisu

**Checklist**
- [x] The adapter is published to NPM — `0.0.4`, published by the workflow through trusted publishing
- [x] Developer Best practices are known and considered
- [x] All requirements to bring a new adapter into Latest repository are fulfilled — requirement 16
  (port attribute named `port`) does not apply, the adapter has no server and therefore no port
- [x] The adapter was checked by https://adapter-check.iobroker.in/ — **0 errors**. Remaining
  warnings: `W4001` (which is what this PR is about), `W6020` (suggestion to add
  `CHANGELOG_OLD.md`, there have been four releases so far) and `W3050`/`W3052`
  "could not retrieve log", which appear while a workflow run is still in progress
- [ ] Link to forum testing thread — none yet