### PR TITLE
Update plenticore-g3 to 1.0.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2443,7 +2443,7 @@
     "meta": "https://raw.githubusercontent.com/FernetMenta/ioBroker.plenticore-g3/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/FernetMenta/ioBroker.plenticore-g3/main/admin/plenticore-g3.png",
     "type": "energy",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "plex": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.plex/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.plenticore-g3 to version 1.0.2.

*This pull request was created by https://www.iobroker.dev ae24fc9.*