### PR TITLE
Update gree-hvac to 4.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1063,7 +1063,7 @@
     "meta": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/XHunter74/ioBroker.gree-hvac/master/admin/air-conditioner.png",
     "type": "climate-control",
-    "version": "3.0.3"
+    "version": "4.0.0"
   },
   "grohe-smarthome": {
     "meta": "https://raw.githubusercontent.com/patricknitsch/ioBroker.grohe-smarthome/main/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.gree-hvac to version 4.0.0.

*This pull request was created by https://www.iobroker.dev ae24fc9.*