### PR TITLE
Add siku 0.2.3 to stable

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2847,6 +2847,12 @@
     "type": "lighting",
     "version": "1.0.0"
   },
+  "siku": {
+    "meta": "https://raw.githubusercontent.com/ChrMaass/ioBroker.siku/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/ChrMaass/ioBroker.siku/main/admin/siku.svg",
+    "type": "climate-control",
+    "version": "0.2.3"
+  },
   "simple-api": {
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.simple-api/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.simple-api/master/admin/simple-api.png",


### PR DESCRIPTION
## Aufnahme von `siku` 0.2.3 in Stable

Der Adapter steuert SIKU-RV-V2- und kompatible Oxxify.smart-Lüfter vollständig lokal über UDP. Version 0.2.3 ist seit dem 12. Juli 2026 in Latest und seit dem 26. Juli 2026 auf npm verfügbar.

**Checklist**  
- [x] Der Adapter ist bereits im Latest-Repository enthalten.
- [x] Öffentlicher Testbeitrag: https://forum.iobroker.net/topic/84985/test-adapter-siku-v0.2.x-latest
- [x] `bluefox` ist als npm-Mitinhaber eingetragen.
- [x] Der Repository-Checker 5.21.2 meldet für den aktuellen Stand **keine Fehler und keine Warnungen**.
- [x] CI ist auf Node.js 22, 24 und 26 unter Linux, macOS und Windows vollständig grün: https://github.com/ChrMaass/ioBroker.siku/actions/runs/34211416597
- [x] Version 0.2.3 wurde mit mehreren realen SIKU-Lüftern getestet; Discovery, Polling und Steuerung laufen produktiv.
- [ ] Im Forum gibt es trotz inzwischen 142 Aufrufen noch keine öffentliche Antwort. Die ioBroker-Telemetrie nennt zwei Installationen; der Stable-Bot hat die Aufnahme mit #77 ausdrücklich angestoßen und bereits erinnert.

## Hinweise

- Die Broadcast-Erkennung ist bereits im Adapter selbst implementiert. Die im Stable-Prozess gewünschte zusätzliche Integration in den zentralen Discovery-Adapter kann nach der Stable-Aufnahme als separater PR folgen.
- `common.singletonHost` ist absichtlich gesetzt, da das Geräteprotokoll den festen lokalen UDP-Port 4000 verwendet.
- Der verbleibende Repochecker-Hinweis zu `setTimeout` ist nur eine Suggestion: Es handelt sich um einen gekapselten UDP-Anfrage-Timeout mit explizitem Cleanup, nicht um einen Adapter-Lifecycle-Timer.

Referenz: https://github.com/ChrMaass/ioBroker.siku/issues/77

Die fehlende öffentliche Forum-Antwort möchte ich bewusst transparent machen. Da der Adapter seit fast zwei Monaten in Latest läuft, reale Installationen vorhanden sind, die komplette CI grün ist und der Stable-Bot zur Bearbeitung auffordert, bitte ich dennoch um Aufnahme bzw. um kurze Rückmeldung, falls vorab zwingend ein externer Forums-Testbericht benötigt wird.
