### PR TITLE
Update volumio version to 0.11.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3637,7 +3637,7 @@
     "meta": "https://raw.githubusercontent.com/a-i-ks/ioBroker.volumio/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/a-i-ks/ioBroker.volumio/master/admin/volumio.png",
     "type": "multimedia",
-    "version": "0.9.0"
+    "version": "0.11.0"
   },
   "volvo": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.volvo/master/io-package.json",


### PR DESCRIPTION
Bumps the stable version pointer for `a-i-ks/ioBroker.volumio` from 0.9.0 to 0.11.0, as requested in a-i-ks/ioBroker.volumio#110.

`npx @iobroker/repochecker a-i-ks/ioBroker.volumio` reports no errors for the current master (only non-blocking warnings/suggestions, which are being addressed in a-i-ks/ioBroker.volumio#112).

🤖 Generated with [Claude Code](https://claude.com/claude-code)