### PR TITLE
Log adapter id/URL on meta request failure in compare types test

### DIFF
--- a/.github/workflows/checkRepositoryFiles.yml
+++ b/.github/workflows/checkRepositoryFiles.yml
@@ -33,4 +33,10 @@ jobs:
       - run: npm i
       - run: npm run test
         env:
+          # NOTE: on `pull_request` events triggered by a PR from a fork, GitHub deliberately
+          # withholds repository secrets, so OWN_GITHUB_TOKEN is empty here. The meta requests in
+          # src/test/testRepo.mts then run unauthenticated and can hit GitHub's low anonymous rate
+          # limit (HTTP 429) - which is why fork-PR runs sometimes fail with a 429.
+          # Not a misconfiguration: it is inherent to `pull_request` + forks. Switching to
+          # `pull_request_target` would expose the secret but must not execute PR-supplied code.
           OWN_GITHUB_TOKEN: ${{ secrets.OWN_GITHUB_TOKEN }}

--- a/src/test/testRepo.mts
+++ b/src/test/testRepo.mts
@@ -89,8 +89,15 @@ describe('Test Repository', () => {
             if (Object.prototype.hasOwnProperty.call(latest, id) && id !== '_repoInfo') {
                 assert.equal(id, id.toLowerCase(), `Adapter id ${id} is not lowercase`);
                 if (latest[id].meta?.match(/io-package\.json$/)) {
-                    const response = await request(latest[id].meta);
-                    console.log(`[${i}/${len}] Check ${id}`);
+                    console.log(`[${i}/${len}] Check ${id} (${latest[id].meta})`);
+                    let response;
+                    try {
+                        response = await request(latest[id].meta);
+                    } catch (e: any) {
+                        throw new Error(
+                            `Error requesting meta for "${id}" (${latest[id].meta}): ${e.message || e}`,
+                        );
+                    }
                     const pack = response.data;
                     if (pack?.common && pack.common.type !== latest[id].type) {
                         console.error(`Types in "${id}" are not equal: ${pack.common.type} !== ${latest[id].type}`);

--- a/src/test/testRepo.mts
+++ b/src/test/testRepo.mts
@@ -9,12 +9,17 @@ let latest: Record<string, any>;
 let stable: Record<string, any>;
 // let axiosCounter = 0;
 
-console.log(`OWN_GITHUB_TOKEN: ${process.env.OWN_GITHUB_TOKEN}`);
 // axios.defaults.headers = {
 //     'Authorization': process.env.OWN_GITHUB_TOKEN ? `token ${process.env.OWN_GITHUB_TOKEN}` : 'none',
 // };
 if (process.env.OWN_GITHUB_TOKEN) {
     axios.defaults.headers.common.Authorization = `Bearer ${process.env.OWN_GITHUB_TOKEN}`;
+    console.log('OWN_GITHUB_TOKEN is set: requests are authenticated (higher rate limit).');
+} else {
+    console.warn(
+        'OWN_GITHUB_TOKEN is NOT set: requests are unauthenticated and may hit GitHub rate limits (HTTP 429). ' +
+            'Note: for pull_request events from forks GitHub does not expose repository secrets.',
+    );
 }
 
 async function request(url: string) {


### PR DESCRIPTION
## What

Improve error logging in the `Test Repository: compare types` test (`src/test/testRepo.mts`).

## Why

In [workflow run 34235357814](https://github.com/ioBroker/ioBroker.repositories/actions/runs/34235357814/job/102091535389) the test failed with a bare `AxiosError: Request failed with status code 429`, but the log did not identify which adapter's `meta` request triggered it.

The cause: the line logging which adapter was being checked ran *after* the awaited request:

```js
const response = await request(latest[id].meta);
console.log(`[${i}/${len}] Check ${id}`);
```

So when the request threw, the culprit adapter was never printed (the last log line was the previous, successful adapter), and the AxiosError carried no id or URL.

## Change

- Move the `console.log` before the request, and include the `meta` URL in it.
- Wrap the request in a try/catch that re-throws with the adapter id and meta URL, so the failure message itself names the repository.

## Notes for reviewer

- The underlying 429 was a GitHub rate limit; `OWN_GITHUB_TOKEN` was empty in that run. This PR only improves diagnosability — setting a token for the job would address the rate limit itself.
- Only added type syntax is `catch (e: any)`, which is erasable (`erasableSyntaxOnly` compatible). `node --check` passes; `npm run typecheck` was not run locally because `node_modules` is not installed in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)