### PR TITLE
Authenticate repository test with automatic GITHUB_TOKEN

### DIFF
--- a/.github/workflows/checkRepositoryFiles.yml
+++ b/.github/workflows/checkRepositoryFiles.yml
@@ -25,6 +25,8 @@ jobs:
       github.repository == 'ioBroker/ioBroker.repositories'
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -33,10 +35,9 @@ jobs:
       - run: npm i
       - run: npm run test
         env:
-          # NOTE: on `pull_request` events triggered by a PR from a fork, GitHub deliberately
-          # withholds repository secrets, so OWN_GITHUB_TOKEN is empty here. The meta requests in
-          # src/test/testRepo.mts then run unauthenticated and can hit GitHub's low anonymous rate
-          # limit (HTTP 429) - which is why fork-PR runs sometimes fail with a 429.
-          # Not a misconfiguration: it is inherent to `pull_request` + forks. Switching to
-          # `pull_request_target` would expose the secret but must not execute PR-supplied code.
-          OWN_GITHUB_TOKEN: ${{ secrets.OWN_GITHUB_TOKEN }}
+          # Use the automatic GITHUB_TOKEN instead of a repository secret. Repository secrets are
+          # withheld from `pull_request` events triggered by forks, so OWN_GITHUB_TOKEN was empty on
+          # such runs and the meta requests in src/test/testRepo.mts hit GitHub's low anonymous rate
+          # limit (HTTP 429). github.token IS provided on fork PRs; read access is sufficient here
+          # and it raises the API rate limit from 60 to 1000 requests/hour.
+          OWN_GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## What

Source `OWN_GITHUB_TOKEN` for the `check repository files` job from the automatic `github.token` instead of the `OWN_GITHUB_TOKEN` repository secret, and add an explicit `contents: read` permission.

## Why

Repository secrets are **withheld from `pull_request` events triggered by forks**. Adapter add/update PRs come from forks, so `secrets.OWN_GITHUB_TOKEN` resolved to empty on those runs. The `meta` requests in `src/test/testRepo.mts` then ran unauthenticated and hit GitHub's low anonymous API rate limit (60 requests/hour), failing with `HTTP 429` — e.g. [run 34235357814](https://github.com/ioBroker/ioBroker.repositories/actions/runs/34235357814/job/102091535389).

The automatic `github.token` **is** provided on fork `pull_request` runs. Read-only access is sufficient for these public API reads, and authenticating raises the rate limit from 60 to 1000 requests/hour.

## Notes for reviewer

- No test-code change needed: the test already reads the `OWN_GITHUB_TOKEN` env var and adds the `Authorization` header when set; only the *source* of the value changes.
- `pull_request_target` was rejected as an alternative: it would expose the full secret but requires extra effort to access the modified PR files, and carries the risk of running PR-supplied code.
- `contents: read` is added explicitly so the job's token permissions are minimal and self-documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)