### PR TITLE
Update bluesound to 1.5.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -307,7 +307,7 @@
     "meta": "https://raw.githubusercontent.com/Uwe1958/ioBroker.bluesound/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Uwe1958/ioBroker.bluesound/main/admin/bluesound.png",
     "type": "multimedia",
-    "version": "1.3.1"
+    "version": "1.5.0"
   },
   "bmw": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.bmw/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.bluesound to version 1.5.0.

*This pull request was created by https://www.iobroker.dev ae24fc9.*