### PR TITLE
Retry meta requests on GitHub rate limit in repo test

### DIFF
--- a/src/test/testRepo.mts
+++ b/src/test/testRepo.mts
@@ -22,13 +22,69 @@ if (process.env.OWN_GITHUB_TOKEN) {
     );
 }
 
+const delay = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+// Fallback wait times (in ms) between retries when the response carries no hint: 5 min, then 10 min.
+const RETRY_FALLBACK_DELAYS = [5 * 60 * 1000, 10 * 60 * 1000, 10 * 60 * 1000];
+
+// GitHub signals rate limiting with HTTP 429 (and sometimes 403 once the limit is exhausted).
+function isRateLimit(status: number): boolean {
+    return status === 429 || status === 403;
+}
+
+// Determine how long to wait from the response headers, honouring `Retry-After`
+// (seconds or an HTTP date) or `x-ratelimit-reset` (epoch seconds). Returns undefined if no hint.
+function getRetryDelayFromResponse(response: any): number | undefined {
+    const headers = response?.headers || {};
+    const retryAfter = headers['retry-after'];
+    if (retryAfter !== undefined) {
+        const seconds = Number(retryAfter);
+        if (!Number.isNaN(seconds)) {
+            return seconds * 1000;
+        }
+        const date = new Date(retryAfter).getTime();
+        if (!Number.isNaN(date)) {
+            return Math.max(0, date - Date.now());
+        }
+    }
+    const reset = headers['x-ratelimit-reset'];
+    if (reset !== undefined && !Number.isNaN(Number(reset))) {
+        return Math.max(0, Number(reset) * 1000 - Date.now());
+    }
+    return undefined;
+}
+
 async function request(url: string) {
     // axiosCounter++;
     // if (axiosCounter % 5) {
     //     await new Promise(resolve => setTimeout(resolve, 300));
     // }
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    return axios(url);
+    await delay(1000);
+
+    const maxRetries = 3;
+    for (let attempt = 0; ; attempt++) {
+        try {
+            return await axios(url);
+        } catch (e: any) {
+            const status = e.response?.status;
+            // 404 (not found) is a definite answer - never retry it.
+            if (status === 404) {
+                throw e;
+            }
+            // Only retry on GitHub rate limit responses; give up once retries are exhausted.
+            if (!status || !isRateLimit(status) || attempt >= maxRetries) {
+                throw e;
+            }
+            const hintedDelay = getRetryDelayFromResponse(e.response);
+            const waitMs = hintedDelay ?? RETRY_FALLBACK_DELAYS[attempt];
+            console.warn(
+                `Rate limited (HTTP ${status}) for ${url}. ` +
+                    `Waiting ${Math.round(waitMs / 1000)}s before retry ${attempt + 1}/${maxRetries}` +
+                    `${hintedDelay !== undefined ? ' (from response headers)' : ' (fallback)'}.`,
+            );
+            await delay(waitMs);
+        }
+    }
 }
 
 const reservedAdapterNames = ['config', 'system', 'alias', 'design', 'all', 'self'];

--- a/src/test/testRepo.mts
+++ b/src/test/testRepo.mts
@@ -77,10 +77,13 @@ async function request(url: string) {
             }
             const hintedDelay = getRetryDelayFromResponse(e.response);
             const waitMs = hintedDelay ?? RETRY_FALLBACK_DELAYS[attempt];
+            const nextTry = new Date(Date.now() + waitMs).toISOString();
+            // Make the stall explicit: processing is paused (not hung) while we wait out the rate limit.
             console.warn(
-                `Rate limited (HTTP ${status}) for ${url}. ` +
-                    `Waiting ${Math.round(waitMs / 1000)}s before retry ${attempt + 1}/${maxRetries}` +
-                    `${hintedDelay !== undefined ? ' (from response headers)' : ' (fallback)'}.`,
+                `Rate limited (HTTP ${status}) for ${url}. Processing is PAUSED - not stuck: ` +
+                    `waiting ${Math.round(waitMs / 1000)}s ` +
+                    `${hintedDelay !== undefined ? '(from response headers)' : '(fallback)'} ` +
+                    `before retry ${attempt + 1}/${maxRetries}, next attempt at ${nextTry}.`,
             );
             await delay(waitMs);
         }


### PR DESCRIPTION
## What

Add retry logic to `request()` in `src/test/testRepo.mts` for GitHub rate-limit responses.

## Why

Even with the automatic `github.token` (#6619), the `compare types` test still failed with `HTTP 429` when GitHub rate limited the `io-package.json` meta requests — e.g. [run 34323186468](https://github.com/ioBroker/ioBroker.repositories/actions/runs/34323186468/job/102374296331). A single 429 anywhere in the ~800-adapter loop fails the whole job. Retrying with a back-off rides out transient limits.

## Behaviour

On a failed request:
- **404 (not found)** → thrown immediately, never retried.
- **429 / 403 (rate limit)** → wait and retry, up to **3 times**:
  - honour the wait time from the response when present — `Retry-After` (seconds or HTTP date) or `x-ratelimit-reset` (epoch seconds);
  - otherwise fall back to **5 min**, then **10 min**.
- **Any other error** → re-thrown as before (still wrapped with the adapter id/URL by the caller).

Each wait logs the reason, the delay, and the attempt number.

## Notes for reviewer

- 403 is included alongside 429 because GitHub returns 403 once the primary rate limit is exhausted.
- The pre-existing 1 s pacing delay before each request is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)