### PR TITLE
Update pi-hole2 to 1.5.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -2383,7 +2383,7 @@
     "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.pi-hole2/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.pi-hole2/main/admin/pi-hole2.png",
     "type": "network",
-    "version": "1.2.0"
+    "version": "1.5.0"
   },
   "pid": {
     "meta": "https://raw.githubusercontent.com/mcm4iob/ioBroker.pid/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.pi-hole2 to version 1.5.0.

*This pull request was created by https://www.iobroker.dev ae24fc9.*