### PR TITLE
Refine error messages for E1004 in checkObjectStructure

### DIFF
--- a/lib/checkObjectStructure.js
+++ b/lib/checkObjectStructure.js
@@ -100,10 +100,12 @@ const ERROR_EXPLANATIONS = {
 
     E1004: {
         en: 'A key in the `common` block has a value of the wrong JavaScript type.'
-          + ' For example, `common.read` must be a boolean, not a string `"true"`.\n\n'
+          + ' For example, `common.read` must be a boolean, not a string `"true"`.'
+          + ' If the error relates to common.states note that using an array is deprecated and an object is required now.\n\n'
           + '**Fix:** Check the type requirement listed in the error message and adjust the value accordingly.',
         de: 'Ein Schlüssel im `common`-Block hat einen Wert des falschen JavaScript-Typs.'
-          + ' Zum Beispiel muss `common.read` ein Boolean sein, nicht die Zeichenkette `"true"`.\n\n'
+          + ' Zum Beispiel muss `common.read` ein Boolean sein, nicht die Zeichenkette `"true"`.'
+          + ' Falls sich der Fehler auf common.states bezieht bitte beachten dass die Verwendung eines Arrays hier deprecated ist und nunmehr an Object verwendet werden muss.\n\n'
           + '**Lösung:** Prüfe die im Fehlertext genannte Typanforderung und passe den Wert entsprechend an.',
     },
 


### PR DESCRIPTION
Updated error messages for E1004 to clarify type requirements and deprecation notice.