### PR TITLE
Update vis-2-widgets-tibberlink to 0.4.11

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3469,7 +3469,7 @@
     "meta": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-tibberlink/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/ssbingo/ioBroker.vis-2-widgets-tibberlink/main/admin/vis-2-widgets-tibberlink.png",
     "type": "visualization-widgets",
-    "version": "0.4.10"
+    "version": "0.4.11"
   },
   "vis-2-widgets-weather-and-heating": {
     "meta": "https://raw.githubusercontent.com/rg-engineering/ioBroker.vis-2-widgets-weather-and-heating/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-2-widgets-tibberlink to version 0.4.11.

*This pull request was created by https://www.iobroker.dev ae24fc9.*