### PR TITLE
Add alias-workbench to LATEST

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -135,6 +135,11 @@
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.alias-manager/master/admin/alias-manager.png",
     "type": "general"
   },
+  "alias-workbench": {
+    "meta": "https://raw.githubusercontent.com/RicardoHipp/ioBroker.alias-workbench/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/RicardoHipp/ioBroker.alias-workbench/main/admin/alias-workbench.png",
+    "type": "general"
+  },
   "alpha-ess": {
     "meta": "https://raw.githubusercontent.com/Gaspode69/ioBroker.alpha-ess/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/Gaspode69/ioBroker.alpha-ess/main/admin/alpha-ess.png",


### PR DESCRIPTION
Add alias-workbench to latest.

- Adapter: https://github.com/RicardoHipp/ioBroker.alias-workbench
- npm: https://www.npmjs.com/package/iobroker.alias-workbench (0.9.8, published with provenance)
- Type: general
- License: MIT
- Adapter checker: 0 errors

The adapter provides an editor for ioBroker aliases: bulk creation from
templates, a device tree browser, MQTT/Tasmota device knowledge and
round-trip checking of read/write formulas.

Note: "Add to latest" on iobroker.dev failed repeatedly with
[E0000] cannot access repository / AxiosError 403 — that is the
unauthenticated GitHub rate limit (60/h per IP) hitting the portal
server, not a problem with the repository. Hence this manual PR.