### PR TITLE
Update lovelace version to 6.1.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -1717,7 +1717,7 @@
     "meta": "https://raw.githubusercontent.com/ioBroker/ioBroker.lovelace/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/ioBroker/ioBroker.lovelace/master/admin/lovelace.png",
     "type": "visualization",
-    "version": "5.0.5"
+    "version": "6.1.3"
   },
   "lowpass-filter": {
     "meta": "https://raw.githubusercontent.com/BenAhrdt/ioBroker.lowpass-filter/main/io-package.json",


### PR DESCRIPTION
It is "only" one week old, but 6.1.2 -> 6.1.3 were only small bug fixes and 6.1.2 was out for quite a long time. Also, 5.0.5 is pretty old... so let's update.