### PR TITLE
Add per-ref concurrency to Check Repository workflow

### DIFF
--- a/.github/workflows/checkRepository.yml
+++ b/.github/workflows/checkRepository.yml
@@ -27,6 +27,13 @@ on:
 permissions:
   contents: read
 
+# Group per ref so runs of different PRs never cancel each other.
+# refs/pull/<n>/merge is unique per PR, refs/heads/master is shared by all master runs,
+# so only a new master push (after a commit) cancels the older master run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CHECK_REPOSITORY_DEBUG: ${{ (github.event.inputs.debug == 'true' || github.event.inputs.log == 'true') && 'true' || 'false' }}
   CHECK_REPOSITORY_LOG: ${{ github.event.inputs.log == 'true' && 'true' || 'false' }}


### PR DESCRIPTION
## Summary

Adds a `concurrency` block to the **Check Repository** workflow so that in-progress runs are only cancelled when appropriate.

- Groups runs by `github.ref` (`${{ github.workflow }}-${{ github.ref }}`).
- Runs of **different PRs** use distinct refs (`refs/pull/<n>/merge`) → **never cancel each other**.
- All master runs share `refs/heads/master` → only a **new push to master** (after a commit) cancels the older master run.

## Behavior

| Trigger | Group | Effect |
|---|---|---|
| PR #1 vs PR #2 | different | independent, no cancellation |
| New commit on master | `refs/heads/master` | cancels older master run |
| New commit on same PR | that PR's ref | cancels its own stale run |

🤖 Generated with [Claude Code](https://claude.com/claude-code)