### PR TITLE
Fix 'Check repository files' concurrency to not cancel across PRs

### DIFF
--- a/.github/workflows/checkRepositoryFiles.yml
+++ b/.github/workflows/checkRepositoryFiles.yml
@@ -14,8 +14,11 @@ on:
   
   pull_request: {}
 
+# Group per ref so runs of different PRs never cancel each other.
+# refs/pull/<n>/merge is unique per PR, refs/heads/master is shared by all master runs,
+# so only a new master push (after a commit) cancels the older master run.
 concurrency:
-    group: stable-${{ github.head_ref }}
+    group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

The **Check repository files** workflow (`checkRepositoryFiles.yml`) used:

```yaml
concurrency:
    group: stable-${{ github.head_ref }}
    cancel-in-progress: true
```

`github.head_ref` is only set on `pull_request` events and is **empty on `push`** — so all master pushes shared the single group `stable-`, and the value is not reliably unique across PRs.

## Change

Group by `github.ref` instead:

```yaml
concurrency:
    group: ${{ github.workflow }}-${{ github.ref }}
    cancel-in-progress: true
```

- **Different PRs** → distinct `refs/pull/<n>/merge` → **never cancel each other**.
- **Master pushes** → all share `refs/heads/master` → only a new master push (after a commit) cancels the older master run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)