### PR TITLE
Update vis-mapwidgets to 0.3.3

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3573,6 +3573,12 @@
     "type": "visualization-widgets",
     "version": "1.1.2"
   },
+  "vis-mapwidgets": {
+    "meta": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-mapwidgets/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/oweitman/ioBroker.vis-mapwidgets/main/admin/mapwidgets.svg",
+    "type": "visualization-widgets",
+    "version": "0.3.3"
+  },
   "vis-material": {
     "meta": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-material/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/iobroker-community-adapters/ioBroker.vis-material/master/admin/material.png",


### PR DESCRIPTION
Please update my adapter ioBroker.vis-mapwidgets to version 0.3.3.

*This pull request was created by https://www.iobroker.dev ae24fc9.*