### PR TITLE
Add webuntis2 to latest

### DIFF
--- a/sources-dist.json
+++ b/sources-dist.json
@@ -3785,6 +3785,11 @@
     "icon": "https://raw.githubusercontent.com/Newan/ioBroker.webuntis/main/admin/webuntis.png",
     "type": "date-and-time"
   },
+  "webuntis2": {
+    "meta": "https://raw.githubusercontent.com/Voodoo2man/ioBroker.webuntis2/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/Voodoo2man/ioBroker.webuntis2/main/admin/webuntis2.png",
+    "type": "date-and-time"
+  },
   "weishaupt-wem": {
     "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.weishaupt-wem/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.weishaupt-wem/master/admin/weishaupt-wem.png",


### PR DESCRIPTION
Adds ioBroker.webuntis2 to the latest adapter repository. The adapter is published on npm and the metadata/icon URLs point to the public main branch.