### PR TITLE
Update tesla-wallconnector3 to 1.3.2

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -3205,7 +3205,7 @@
     "meta": "https://raw.githubusercontent.com/nobl/ioBroker.tesla-wallconnector3/main/io-package.json",
     "icon": "https://raw.githubusercontent.com/nobl/ioBroker.tesla-wallconnector3/main/admin/tesla-wallconnector3.png",
     "type": "vehicle",
-    "version": "1.3.1"
+    "version": "1.3.2"
   },
   "teslafi": {
     "meta": "https://raw.githubusercontent.com/hombach/ioBroker.teslafi/master/io-package.json",


### PR DESCRIPTION
Please update my adapter ioBroker.tesla-wallconnector3 to version 1.3.2.

*This pull request was created by https://www.iobroker.dev ae24fc9.*