### PR TITLE
Update electrolux-aeg to 1.0.0

### DIFF
--- a/sources-dist-stable.json
+++ b/sources-dist-stable.json
@@ -681,6 +681,12 @@
     "type": "hardware",
     "version": "1.2.3"
   },
+  "electrolux-aeg": {
+    "meta": "https://raw.githubusercontent.com/TA2k/ioBroker.electrolux-aeg/main/io-package.json",
+    "icon": "https://raw.githubusercontent.com/TA2k/ioBroker.electrolux-aeg/main/admin/electrolux-aeg.png",
+    "type": "household",
+    "version": "1.0.0"
+  },
   "elero-usb-transmitter": {
     "meta": "https://raw.githubusercontent.com/marc2016/ioBroker.elero-usb-transmitter/master/io-package.json",
     "icon": "https://raw.githubusercontent.com/marc2016/ioBroker.elero-usb-transmitter/master/admin/elero-usb-transmitter.png",


### PR DESCRIPTION
Please update my adapter ioBroker.electrolux-aeg to version 1.0.0.

*This pull request was created by https://www.iobroker.dev ae24fc9.*