### PR TITLE
Fix stale 'auto-checked ❌' label after a passing RE-CHECK!

### DIFF
--- a/src/check.mts
+++ b/src/check.mts
@@ -850,11 +850,16 @@ async function doIt() {
     if (!someChecked) {
         comments.push({ text: 'No changed adapters found', noDecorate: true });
     } else {
-        try {
-            await deleteLabel(prID, 'auto-checked ✔');
-            await deleteLabel(prID, 'auto-checked ❌');
-        } catch {
-            // the labels may not be present on the PR - nothing to clean up then
+        // Remove both result labels independently: deleting a label that is not
+        // present returns 404, so a shared try/catch would abort the second delete
+        // and leave a stale label behind (e.g. a failing check followed by a
+        // passing RE-CHECK! left both 'auto-checked ✔' and 'auto-checked ❌' set).
+        for (const label of ['auto-checked ✔', 'auto-checked ❌']) {
+            try {
+                await deleteLabel(prID, label);
+            } catch {
+                // the label may not be present on the PR - nothing to clean up then
+            }
         }
         try {
             if (errorsFound) {

--- a/src/common.mts
+++ b/src/common.mts
@@ -33,9 +33,12 @@ export function addLabel(prID: IssueId, labels: string[]): Promise<any> {
 }
 
 export function deleteLabel(prID: IssueId, label: string): Promise<any> {
-    let url = `labels/${label}`;
+    // Label names may contain spaces and non-ASCII characters (e.g. 'auto-checked ❌'),
+    // so they must be percent-encoded to form a valid request path.
+    const encodedLabel = encodeURIComponent(label);
+    let url = `labels/${encodedLabel}`;
     if (prID) {
-        url = `issues/${prID}/labels/${label}`;
+        url = `issues/${prID}/labels/${encodedLabel}`;
     }
     return axios
         .delete(`https://api.github.com/repos/ioBroker/ioBroker.repositories/${url}`, {


### PR DESCRIPTION
## What

Fixes the case (seen in #6634) where a PR ends up with **both** `auto-checked ✔` and `auto-checked ❌` set.

## Why

The "check changed Adapters" workflow (`src/check.mts`) removes both old result labels before adding the new one. The two `deleteLabel` calls sat in a **single `try` block**:

```js
try {
    await deleteLabel(prID, 'auto-checked ✔');   // not present → GitHub 404 → throws
    await deleteLabel(prID, 'auto-checked ❌');   // never reached
} catch { /* swallowed */ }
```

GitHub's REST API returns **404 when deleting a label that isn't on the issue**, and axios throws on it. In #6634 the PR carried only `auto-checked ❌` from the first (failing) run. On the passing `RE-CHECK!`, deleting the absent `auto-checked ✔` threw, the shared `catch` swallowed the error, and the delete of `auto-checked ❌` never ran. The `✔` label was then added, leaving both.

## Changes

- **`src/check.mts`** — delete each result label in its own `try/catch` loop, so a missing label can no longer abort removal of the other.
- **`src/common.mts`** — `deleteLabel` now `encodeURIComponent`s the label name. Names like `auto-checked ❌` contain a space and an emoji and were being placed into the request path unencoded (invalid path / mismatch even when the label is present).

## Notes for reviewer

Behaviour-only change to label cleanup; no change to the JSON repo files or to how pass/fail is determined. `npm run typecheck` was not run locally (dependencies not installed in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)